### PR TITLE
Centralize localStorage persistence with useLocalStorage hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,10 +69,11 @@ pnpm db:studio
 
 ### Imports
 
-- All imports must use `.js` extensions (ES modules)
+- Backend: All imports must use `.js` extensions (ES modules)
 - Backend: Import from local files with relative paths: `import { thing } from "../service.js"`
 - Frontend: Use `@/` alias for src: `import { thing } from "@/lib/thing"`
-- Type-only imports: `import type { Thing } from "./file.js"`
+- Type-only imports: Backend: `import type { Thing } from "./file.js"`
+- Type-only imports: Frontend: `import type { Thing } from "./file"`
 
 ### TypeScript
 

--- a/apps/frontend/src/components/FontSizeSwitcher.tsx
+++ b/apps/frontend/src/components/FontSizeSwitcher.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useLocalStorageNumber } from "@/hooks/useLocalStorage";
 
 export const EDITOR_FONT_SIZE_CHANGED = "editor-font-size-changed";
 
@@ -18,7 +19,7 @@ interface FontSizeSwitcherProps {
 
 const MODE_CONFIGS = {
   script: {
-    storageKey: "branchforge-font-size",
+    storageKey: "script:font-size",
     cssVariable: "--editor-font-size",
     defaultSize: 14,
     sizeOptions: [
@@ -33,7 +34,7 @@ const MODE_CONFIGS = {
       "px-3 py-1.5 bg-muted/50 hover:bg-muted border border-border",
   },
   write: {
-    storageKey: "writemode-font-size",
+    storageKey: "write:font-size",
     cssVariable: "--prose-editor-font-size",
     defaultSize: 16,
     sizeOptions: [
@@ -48,46 +49,6 @@ const MODE_CONFIGS = {
       "px-2 py-1 border border-[hsl(var(--border)/0.6)] hover:bg-[hsl(var(--muted)/0.4)]",
   },
 } as const;
-
-/**
- * Get the saved font size from local storage or return default
- */
-function getSavedFontSize(
-  storageKey: string,
-  defaultSize: number,
-  sizeOptions: Readonly<FontSizeOption[]>
-): number {
-  try {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return defaultSize;
-    }
-    const saved = window.localStorage.getItem(storageKey);
-    if (saved === null) {
-      return defaultSize;
-    }
-    const parsed = parseInt(saved, 10);
-    // Validate it's one of our options
-    if (!sizeOptions.some((opt) => opt.value === parsed)) {
-      return defaultSize;
-    }
-    return parsed;
-  } catch {
-    return defaultSize;
-  }
-}
-
-/**
- * Save the font size to local storage
- */
-function saveFontSize(storageKey: string, size: number): void {
-  try {
-    localStorage.setItem(storageKey, size.toString());
-  } catch {
-    console.warn(
-      "Failed to save font size preference - Local storage may be unavailable"
-    );
-  }
-}
 
 /**
  * Font size switcher for editors
@@ -127,8 +88,17 @@ export function FontSizeSwitcher({
   const baseClassName = customClassName ?? config.className;
   const buttonClassName = config.buttonClassName;
 
-  const [fontSize, setFontSize] = useState(() =>
-    getSavedFontSize(storageKey, defaultSize, sizeOptions)
+  const validateFontSize = useCallback(
+    (value: number) => sizeOptions.some((option) => option.value === value),
+    [sizeOptions]
+  );
+
+  const [fontSize, setFontSize] = useLocalStorageNumber(
+    storageKey,
+    defaultSize,
+    {
+      validate: validateFontSize,
+    }
   );
   const [isOpen, setIsOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
@@ -177,7 +147,6 @@ export function FontSizeSwitcher({
 
   const handleSelect = (size: number) => {
     setFontSize(size);
-    saveFontSize(storageKey, size);
     setIsOpen(false);
   };
 

--- a/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
+++ b/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
@@ -20,8 +20,6 @@ import { StateVariablesModal } from "./StateVariablesModal";
 import { CharactersModal } from "./CharactersModal";
 import { Logo } from "@/components/ui/logo";
 
-const SIDEBAR_COLLAPSED_KEY = "branchforge-sidebar-collapsed";
-
 export interface ThemePaletteOption {
   name: string;
   key: ThemePalette;
@@ -66,27 +64,9 @@ export function LeftSidebar({
   const themeDropdownRef = useRef<HTMLDivElement>(null);
   const projectPopoverRef = useRef<HTMLDivElement>(null);
 
-  // Load collapsed state from localStorage on mount (default: expanded/false)
-  useEffect(() => {
-    try {
-      const stored = localStorage.getItem(SIDEBAR_COLLAPSED_KEY);
-      if (stored !== null) {
-        onCollapsedChange(stored === "true");
-      }
-    } catch {
-      // Ignore storage errors
-    }
-  }, [onCollapsedChange]);
-
-  // Persist collapsed state to localStorage
   const handleToggleCollapse = () => {
     const newState = !isCollapsed;
     onCollapsedChange(newState);
-    try {
-      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(newState));
-    } catch {
-      // Ignore storage errors
-    }
   };
 
   // Close theme dropdown when clicking outside

--- a/apps/frontend/src/components/script-mode/LineWrapSwitcher.tsx
+++ b/apps/frontend/src/components/script-mode/LineWrapSwitcher.tsx
@@ -1,41 +1,11 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { EditorView } from "@codemirror/view";
 import type { Extension } from "@codemirror/state";
 import { AlignJustify, WrapText } from "lucide-react";
+import { useLocalStorageBoolean } from "@/hooks/useLocalStorage";
 
-const LINE_WRAP_KEY = "branchforge-line-wrap";
+const LINE_WRAP_KEY = "script:line-wrap";
 const DEFAULT_LINE_WRAP = false;
-
-/**
- * Get the saved line wrap preference from local storage or return default
- */
-function getSavedLineWrap(): boolean {
-  try {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return DEFAULT_LINE_WRAP;
-    }
-    const saved = window.localStorage.getItem(LINE_WRAP_KEY);
-    if (saved === null) {
-      return DEFAULT_LINE_WRAP;
-    }
-    return saved === "true";
-  } catch {
-    return DEFAULT_LINE_WRAP;
-  }
-}
-
-/**
- * Save the line wrap preference to local storage
- */
-function saveLineWrap(enabled: boolean): void {
-  try {
-    localStorage.setItem(LINE_WRAP_KEY, enabled.toString());
-  } catch {
-    console.warn(
-      "Failed to save line wrap preference - Local storage may be unavailable"
-    );
-  }
-}
 
 /**
  * Creates a CodeMirror extension for line wrapping
@@ -71,7 +41,10 @@ interface LineWrapSwitcherProps {
 }
 
 export function LineWrapSwitcher({ onChange }: LineWrapSwitcherProps) {
-  const [lineWrap, setLineWrap] = useState(getSavedLineWrap);
+  const [lineWrap, setLineWrap] = useLocalStorageBoolean(
+    LINE_WRAP_KEY,
+    DEFAULT_LINE_WRAP
+  );
 
   useEffect(() => {
     // Notify parent of extension change
@@ -79,9 +52,7 @@ export function LineWrapSwitcher({ onChange }: LineWrapSwitcherProps) {
   }, [lineWrap, onChange]);
 
   const toggle = () => {
-    const newValue = !lineWrap;
-    setLineWrap(newValue);
-    saveLineWrap(newValue);
+    setLineWrap((previousValue) => !previousValue);
   };
 
   return (

--- a/apps/frontend/src/components/script-mode/PaletteSwitcher.tsx
+++ b/apps/frontend/src/components/script-mode/PaletteSwitcher.tsx
@@ -2,16 +2,21 @@ import { useEffect, useState, useMemo } from "react";
 import {
   PALETTES,
   applyPalette,
-  getSavedPalette,
-  savePalette,
   type PaletteGroup,
 } from "../../lib/codemirror/palettes";
+import { useLocalStorageNumber } from "@/hooks/useLocalStorage";
 
 /**
  * Palette switcher for syntax highlighting colors
  */
 export function PaletteSwitcher() {
-  const [selectedIndex, setSelectedIndex] = useState(getSavedPalette());
+  const [selectedIndex, setSelectedIndex] = useLocalStorageNumber(
+    "editor:syntax-palette",
+    0,
+    {
+      validate: (value) => value >= 0 && value < PALETTES.length,
+    }
+  );
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
@@ -20,7 +25,6 @@ export function PaletteSwitcher() {
 
   const handleSelect = (index: number) => {
     setSelectedIndex(index);
-    savePalette(index);
     setIsOpen(false);
   };
 

--- a/apps/frontend/src/components/write-mode/FontFamilySwitcher.tsx
+++ b/apps/frontend/src/components/write-mode/FontFamilySwitcher.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 
 export type FontFamilyOption = {
   label: string;
@@ -19,43 +20,8 @@ const FONT_FAMILY_OPTIONS: Readonly<FontFamilyOption[]> = [
   { label: "Noto Serif", value: "noto-serif", family: "'Noto Serif', serif" },
 ] as const;
 
-const STORAGE_KEY = "writemode-font-family";
+const STORAGE_KEY = "write:font-family";
 const CSS_VARIABLE = "--prose-editor-font-family";
-
-/**
- * Get the saved font family from local storage or return default
- */
-function getSavedFontFamily(): string {
-  try {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return FONT_FAMILY_OPTIONS[0].value;
-    }
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved === null) {
-      return FONT_FAMILY_OPTIONS[0].value;
-    }
-    // Validate it's one of our options
-    if (!FONT_FAMILY_OPTIONS.some((opt) => opt.value === saved)) {
-      return FONT_FAMILY_OPTIONS[0].value;
-    }
-    return saved;
-  } catch {
-    return FONT_FAMILY_OPTIONS[0].value;
-  }
-}
-
-/**
- * Save the font family to local storage
- */
-function saveFontFamily(value: string): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, value);
-  } catch {
-    console.warn(
-      "Failed to save font family preference - Local storage may be unavailable"
-    );
-  }
-}
 
 interface FontFamilySwitcherProps {
   className?: string;
@@ -69,7 +35,14 @@ interface FontFamilySwitcherProps {
 export function FontFamilySwitcher({
   className = "",
 }: FontFamilySwitcherProps = {}) {
-  const [fontFamily, setFontFamily] = useState(getSavedFontFamily);
+  const [fontFamily, setFontFamily] = useLocalStorage<string>(
+    STORAGE_KEY,
+    FONT_FAMILY_OPTIONS[0].value,
+    {
+      validate: (value) =>
+        FONT_FAMILY_OPTIONS.some((option) => option.value === value),
+    }
+  );
 
   // Consolidated dropdown state for better clarity
   const [dropdownState, setDropdownState] = useState({
@@ -141,7 +114,6 @@ export function FontFamilySwitcher({
 
   const handleSelect = (value: string) => {
     setFontFamily(value);
-    saveFontFamily(value);
     updateDropdownState({ isOpen: false });
   };
 

--- a/apps/frontend/src/components/write-mode/ProseEditor.tsx
+++ b/apps/frontend/src/components/write-mode/ProseEditor.tsx
@@ -25,6 +25,7 @@ import { useWritingGoals } from "@/hooks/useWritingGoals";
 import { useInMemoryUndo } from "./useInMemoryUndo";
 import { UndoRedoControls } from "./UndoRedoControls";
 import { BookOpen, PenLine } from "lucide-react";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 import type { DialogueEntry } from "@/lib/prose-types";
 import type { Character, LabelDetail } from "@branchforge/shared";
 import type { SaveStatus } from "@/hooks/useAutosave";
@@ -45,7 +46,7 @@ export interface ProseEditorRef {
 }
 
 type LineLayoutMode = "inline" | "stacked";
-const LINE_LAYOUT_STORAGE_KEY = "writemode-line-layout";
+const LINE_LAYOUT_STORAGE_KEY = "write:line-layout";
 const NEW_LINE_BOTTOM_SAFE_OFFSET = 96;
 const TEXT_HISTORY_DEBOUNCE_MS = 450;
 
@@ -181,10 +182,15 @@ export const ProseEditor = forwardRef<ProseEditorRef, ProseEditorProps>(
     const [entries, setEntries] = useState<DialogueEntry[]>(() =>
       convertLabelLinesToEntries(activeLabel)
     );
-    const [layoutMode, setLayoutMode] = useState<LineLayoutMode>(() => {
-      const saved = localStorage.getItem(LINE_LAYOUT_STORAGE_KEY);
-      return saved === "stacked" ? "stacked" : "inline";
-    });
+    const [layoutMode, setLayoutMode] = useLocalStorage<LineLayoutMode>(
+      LINE_LAYOUT_STORAGE_KEY,
+      "inline",
+      {
+        serializer: (value) => value,
+        deserializer: (value) => value as LineLayoutMode,
+        validate: (value) => value === "inline" || value === "stacked",
+      }
+    );
 
     // Writing stats dialog state
     const [statsDialogOpen, setStatsDialogOpen] = useState(false);
@@ -429,10 +435,6 @@ export const ProseEditor = forwardRef<ProseEditorRef, ProseEditorProps>(
         }
       };
     }, []);
-
-    useEffect(() => {
-      localStorage.setItem(LINE_LAYOUT_STORAGE_KEY, layoutMode);
-    }, [layoutMode]);
 
     // Notify parent of changes (but not from external updates)
     useEffect(() => {

--- a/apps/frontend/src/contexts/ThemeContext.tsx
+++ b/apps/frontend/src/contexts/ThemeContext.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { ThemeContext, type ThemePalette, type ThemeColors } from "./useTheme";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 
 export const themeConfigs: Record<ThemePalette, ThemeColors> = {
   forest: { primary: "#40bb82", hover: "#52c992" },
@@ -20,10 +21,15 @@ function isValidTheme(value: string): value is ThemePalette {
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState<ThemePalette>(() => {
-    const saved = localStorage.getItem("branchforge-theme");
-    return saved && isValidTheme(saved) ? saved : "periwinkle";
-  });
+  const [theme, setThemeState] = useLocalStorage<ThemePalette>(
+    "theme",
+    "periwinkle",
+    {
+      serializer: (value) => value,
+      deserializer: (value) => value as ThemePalette,
+      validate: isValidTheme,
+    }
+  );
 
   const colors = themeConfigs[theme];
 
@@ -59,7 +65,6 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const setTheme = (newTheme: ThemePalette) => {
     setThemeState(newTheme);
-    localStorage.setItem("branchforge-theme", newTheme);
   };
 
   return (

--- a/apps/frontend/src/contexts/ThemeContext.tsx
+++ b/apps/frontend/src/contexts/ThemeContext.tsx
@@ -63,12 +63,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     root.style.setProperty("--theme-draft-color", STATUS_COLORS.draft);
   }, [theme, colors]);
 
-  const setTheme = (newTheme: ThemePalette) => {
-    setThemeState(newTheme);
-  };
-
   return (
-    <ThemeContext.Provider value={{ theme, setTheme, colors }}>
+    <ThemeContext.Provider value={{ theme, setTheme: setThemeState, colors }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/apps/frontend/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/ThemeContext.test.tsx
@@ -116,7 +116,7 @@ describe("ThemeContext", () => {
 
   describe("Saved Theme", () => {
     it("should load saved theme from localStorage", () => {
-      localStorage.setItem("branchforge-theme", "forest");
+      localStorage.setItem("branchforge:theme", "forest");
 
       render(
         <ThemeProvider>
@@ -129,7 +129,7 @@ describe("ThemeContext", () => {
     });
 
     it("should set correct colors for forest theme", () => {
-      localStorage.setItem("branchforge-theme", "forest");
+      localStorage.setItem("branchforge:theme", "forest");
 
       render(
         <ThemeProvider>
@@ -146,7 +146,7 @@ describe("ThemeContext", () => {
     });
 
     it("should fall back to default for invalid saved theme", () => {
-      localStorage.setItem("branchforge-theme", "invalid-theme");
+      localStorage.setItem("branchforge:theme", "invalid-theme");
 
       render(
         <ThemeProvider>
@@ -187,7 +187,7 @@ describe("ThemeContext", () => {
       fireEvent.click(screen.getByRole("button", { name: "Set Forest" }));
 
       await waitFor(() => {
-        expect(localStorage.getItem("branchforge-theme")).toBe("forest");
+        expect(localStorage.getItem("branchforge:theme")).toBe("forest");
       });
     });
 
@@ -236,7 +236,7 @@ describe("ThemeContext", () => {
     ];
 
     it.each(themes)("should provide correct colors for %s", (theme) => {
-      localStorage.setItem("branchforge-theme", theme);
+      localStorage.setItem("branchforge:theme", theme);
 
       const { container } = render(
         <ThemeProvider>
@@ -269,7 +269,7 @@ describe("ThemeContext", () => {
     };
 
     it.each(themes)("should have correct hardcoded colors for %s", (theme) => {
-      localStorage.setItem("branchforge-theme", theme);
+      localStorage.setItem("branchforge:theme", theme);
 
       const { container } = render(
         <ThemeProvider>

--- a/apps/frontend/src/hooks/__tests__/useLabels.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useLabels.test.tsx
@@ -66,6 +66,7 @@ describe("useLabels", () => {
   beforeEach(() => {
     queryClient = createTestQueryClient();
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   afterEach(() => {
@@ -160,6 +161,25 @@ describe("useLabels", () => {
     it("should load active label ID from cache on mount", async () => {
       // Pre-populate cache
       queryClient.setQueryData(labelKeys.activeLabelId("project-1"), "label-1");
+      vi.mocked(labelsApi.listLabels).mockResolvedValue(mockLabels);
+      vi.mocked(labelsApi.getLabel).mockResolvedValue(mockLabelDetail);
+
+      const { result } = renderHook(() => useLabels(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.activeLabelId).toBe("label-1");
+      });
+
+      await waitFor(() => {
+        expect(result.current.activeLabel).toEqual(mockLabelDetail);
+      });
+    });
+
+    it("hydrates active label ID from localStorage on mount", async () => {
+      localStorage.setItem(
+        "branchforge:write:active-label:project-1",
+        "label-1"
+      );
       vi.mocked(labelsApi.listLabels).mockResolvedValue(mockLabels);
       vi.mocked(labelsApi.getLabel).mockResolvedValue(mockLabelDetail);
 

--- a/apps/frontend/src/hooks/__tests__/useLocalStorage.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useLocalStorage.test.tsx
@@ -1,0 +1,125 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getPrefixedStorageKey,
+  readLocalStorageItem,
+  removeLocalStorageItem,
+  useLocalStorage,
+  useLocalStorageBoolean,
+  useLocalStorageNumber,
+  writeLocalStorageItem,
+} from "../useLocalStorage";
+
+describe("useLocalStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it("prefixes keys consistently", () => {
+    expect(getPrefixedStorageKey("theme")).toBe("branchforge:theme");
+    expect(getPrefixedStorageKey("branchforge:theme")).toBe(
+      "branchforge:theme"
+    );
+  });
+
+  it("reads and writes values with default JSON serialization", () => {
+    localStorage.setItem(
+      "branchforge:editor:settings",
+      JSON.stringify({ x: 1 })
+    );
+
+    const { result } = renderHook(() =>
+      useLocalStorage("editor:settings", { x: 0 })
+    );
+
+    expect(result.current[0]).toEqual({ x: 1 });
+
+    act(() => {
+      result.current[1]({ x: 2 });
+    });
+
+    expect(localStorage.getItem("branchforge:editor:settings")).toBe(
+      JSON.stringify({ x: 2 })
+    );
+  });
+
+  it("supports updater function setters", () => {
+    const { result } = renderHook(() => useLocalStorageNumber("count", 1));
+
+    act(() => {
+      result.current[1]((prev) => prev + 4);
+    });
+
+    expect(result.current[0]).toBe(5);
+    expect(localStorage.getItem("branchforge:count")).toBe("5");
+  });
+
+  it("falls back to default when validation fails", () => {
+    localStorage.setItem("branchforge:port", "0");
+
+    const { result } = renderHook(() =>
+      useLocalStorageNumber("port", 8080, {
+        validate: (value) => value >= 1,
+      })
+    );
+
+    expect(result.current[0]).toBe(8080);
+  });
+
+  it("warns and falls back when read throws", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("read-failure");
+    });
+
+    const { result } = renderHook(() => useLocalStorage("theme", "forest"));
+
+    expect(result.current[0]).toBe("forest");
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("warns and keeps state when write throws", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("write-failure");
+    });
+
+    const { result } = renderHook(() => useLocalStorageNumber("size", 12));
+
+    act(() => {
+      result.current[1](16);
+    });
+
+    expect(result.current[0]).toBe(16);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("supports boolean convenience hook", () => {
+    localStorage.setItem("branchforge:write:focus-mode", "true");
+
+    const { result } = renderHook(() =>
+      useLocalStorageBoolean("write:focus-mode", false)
+    );
+
+    expect(result.current[0]).toBe(true);
+
+    act(() => {
+      result.current[1](false);
+    });
+
+    expect(localStorage.getItem("branchforge:write:focus-mode")).toBe("false");
+  });
+
+  it("supports localStorage helper functions", () => {
+    writeLocalStorageItem("branchforge:test:key", "value");
+    expect(readLocalStorageItem("branchforge:test:key")).toBe("value");
+
+    removeLocalStorageItem("branchforge:test:key");
+    expect(readLocalStorageItem("branchforge:test:key")).toBeNull();
+  });
+});

--- a/apps/frontend/src/hooks/useFocusModeState.ts
+++ b/apps/frontend/src/hooks/useFocusModeState.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from "react";
+import { useRef, useState } from "react";
+import { useLocalStorageBoolean } from "@/hooks/useLocalStorage";
 
 export interface FocusModeSidebarStates {
   leftCollapsed: boolean;
@@ -15,28 +16,16 @@ export interface FocusModeState {
 }
 
 export function useFocusModeState(storageKey: string): FocusModeState {
-  const [isFocusMode, setIsFocusMode] = useState(() => {
-    try {
-      const saved = localStorage.getItem(storageKey);
-      return saved === "true";
-    } catch {
-      return false;
-    }
-  });
+  const [isFocusMode, setIsFocusMode] = useLocalStorageBoolean(
+    storageKey,
+    false
+  );
 
   const [preFocusSidebarStates, setPreFocusSidebarStates] =
     useState<FocusModeSidebarStates | null>(null);
 
   const preFocusElementRef = useRef<HTMLElement | null>(null);
   const focusToggleRef = useRef<HTMLButtonElement | null>(null);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, String(isFocusMode));
-    } catch {
-      console.warn(`Could not save focus mode preference to localStorage`);
-    }
-  }, [storageKey, isFocusMode]);
 
   return {
     isFocusMode,

--- a/apps/frontend/src/hooks/useLabels.ts
+++ b/apps/frontend/src/hooks/useLabels.ts
@@ -5,22 +5,30 @@
  * Simplified with stable query keys and proper refetch behavior.
  */
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import { labelKeys, projectFilesKeys } from "@/lib/query-keys";
 import { labelsApi, type UpdateDialogueResponse } from "@/lib/api/labels";
 import { useProject } from "@/hooks/useProject";
+import {
+  getPrefixedStorageKey,
+  readLocalStorageItem,
+  removeLocalStorageItem,
+  writeLocalStorageItem,
+} from "@/hooks/useLocalStorage";
 import type { PublicLabel, LabelDetail } from "@branchforge/shared";
 
 function clearHistoryCursor(labelId: string): void {
-  try {
-    localStorage.removeItem(`label-history-cursor:${labelId}`);
-  } catch {
-    // Ignore storage failures.
-  }
+  removeLocalStorageItem(
+    getPrefixedStorageKey(`write:label-history-cursor:${labelId}`)
+  );
 }
 
 const EMPTY_PROJECT_KEY = "__no_project__";
+
+function getActiveLabelStorageKey(projectKey: string): string {
+  return getPrefixedStorageKey(`write:active-label:${projectKey}`);
+}
 
 // ============================================================================
 // Constants
@@ -78,16 +86,26 @@ export function useLabels(): UseLabelsReturn {
   const { data: activeLabelId = null } = useQuery<string | null>({
     queryKey: labelKeys.activeLabelId(projectKey),
     queryFn: () => {
-      try {
-        const saved = localStorage.getItem(
-          `branchforge:activeLabel:${projectKey}`
-        );
-        return saved;
-      } catch {
+      if (projectKey === EMPTY_PROJECT_KEY) {
         return null;
       }
+
+      return readLocalStorageItem(getActiveLabelStorageKey(projectKey));
     },
-    initialData: null,
+    initialData: () => {
+      const cachedActiveLabelId = queryClient.getQueryData<string | null>(
+        labelKeys.activeLabelId(projectKey)
+      );
+      if (cachedActiveLabelId !== undefined) {
+        return cachedActiveLabelId;
+      }
+
+      if (projectKey === EMPTY_PROJECT_KEY) {
+        return null;
+      }
+
+      return readLocalStorageItem(getActiveLabelStorageKey(projectKey));
+    },
     staleTime: Infinity,
     gcTime: Infinity,
     enabled: true,
@@ -157,6 +175,20 @@ export function useLabels(): UseLabelsReturn {
     },
     [projectKey, queryClient]
   );
+
+  useEffect(() => {
+    if (projectKey === EMPTY_PROJECT_KEY) {
+      return;
+    }
+
+    const storageKey = getActiveLabelStorageKey(projectKey);
+    if (activeLabelId) {
+      writeLocalStorageItem(storageKey, activeLabelId);
+      return;
+    }
+
+    removeLocalStorageItem(storageKey);
+  }, [activeLabelId, projectKey]);
 
   // Invalidate labels method
   const invalidateLabels = useCallback(async () => {

--- a/apps/frontend/src/hooks/useLocalStorage.ts
+++ b/apps/frontend/src/hooks/useLocalStorage.ts
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const STORAGE_PREFIX = "branchforge:";
+
+type SetStateAction<T> = T | ((prev: T) => T);
+
+export interface UseLocalStorageOptions<T> {
+  serializer?: (value: T) => string;
+  deserializer?: (value: string) => T;
+  validate?: (value: T) => boolean;
+  ssrSafe?: boolean;
+}
+
+function defaultSerializer<T>(value: T): string {
+  return JSON.stringify(value);
+}
+
+function defaultDeserializer<T>(value: string): T {
+  return JSON.parse(value) as T;
+}
+
+function defaultValidator<T>(_value: T): boolean {
+  return true;
+}
+
+function isStorageAvailable(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    return typeof window.localStorage !== "undefined";
+  } catch {
+    return false;
+  }
+}
+
+function logStorageWarning(
+  action: "load" | "save" | "remove",
+  key: string,
+  error: unknown
+) {
+  console.warn(`Failed to ${action} localStorage value (key: ${key})`, error);
+}
+
+export function getPrefixedStorageKey(key: string): string {
+  if (key.startsWith(STORAGE_PREFIX)) {
+    return key;
+  }
+
+  return `${STORAGE_PREFIX}${key}`;
+}
+
+export function readLocalStorageItem(rawKey: string): string | null {
+  if (!isStorageAvailable()) {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(rawKey);
+  } catch (error) {
+    logStorageWarning("load", rawKey, error);
+    return null;
+  }
+}
+
+export function writeLocalStorageItem(rawKey: string, value: string): void {
+  if (!isStorageAvailable()) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(rawKey, value);
+  } catch (error) {
+    logStorageWarning("save", rawKey, error);
+  }
+}
+
+export function removeLocalStorageItem(rawKey: string): void {
+  if (!isStorageAvailable()) {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(rawKey);
+  } catch (error) {
+    logStorageWarning("remove", rawKey, error);
+  }
+}
+
+function readStorageValue<T>(
+  key: string,
+  defaultValue: T,
+  deserializer: (value: string) => T,
+  validate: (value: T) => boolean,
+  ssrSafe: boolean
+): T {
+  if (ssrSafe && !isStorageAvailable()) {
+    return defaultValue;
+  }
+
+  if (!isStorageAvailable()) {
+    return defaultValue;
+  }
+
+  try {
+    const item = window.localStorage.getItem(key);
+    if (item === null) {
+      return defaultValue;
+    }
+
+    const parsed = deserializer(item);
+    if (!validate(parsed)) {
+      return defaultValue;
+    }
+
+    return parsed;
+  } catch (error) {
+    logStorageWarning("load", key, error);
+    return defaultValue;
+  }
+}
+
+export function useLocalStorage<T>(
+  key: string,
+  defaultValue: T,
+  options?: UseLocalStorageOptions<T>
+) {
+  const prefixedKey = getPrefixedStorageKey(key);
+
+  const serializer = options?.serializer ?? defaultSerializer<T>;
+  const deserializer = options?.deserializer ?? defaultDeserializer<T>;
+  const validate = options?.validate ?? defaultValidator<T>;
+  const ssrSafe = options?.ssrSafe ?? true;
+
+  const defaultValueRef = useRef(defaultValue);
+  const serializerRef = useRef(serializer);
+  const deserializerRef = useRef(deserializer);
+  const validateRef = useRef(validate);
+  const ssrSafeRef = useRef(ssrSafe);
+
+  useEffect(() => {
+    defaultValueRef.current = defaultValue;
+    serializerRef.current = serializer;
+    deserializerRef.current = deserializer;
+    validateRef.current = validate;
+    ssrSafeRef.current = ssrSafe;
+  }, [defaultValue, serializer, deserializer, validate, ssrSafe]);
+
+  const [state, setState] = useState<T>(() =>
+    readStorageValue(prefixedKey, defaultValue, deserializer, validate, ssrSafe)
+  );
+
+  useEffect(() => {
+    setState(
+      readStorageValue(
+        prefixedKey,
+        defaultValueRef.current,
+        deserializerRef.current,
+        validateRef.current,
+        ssrSafeRef.current
+      )
+    );
+  }, [prefixedKey]);
+
+  const setItem = useCallback(
+    (value: SetStateAction<T>) => {
+      setState((previousValue) => {
+        const nextValue =
+          typeof value === "function"
+            ? (value as (prev: T) => T)(previousValue)
+            : value;
+
+        if (ssrSafe && !isStorageAvailable()) {
+          return nextValue;
+        }
+
+        if (!isStorageAvailable()) {
+          return nextValue;
+        }
+
+        try {
+          if (nextValue === undefined) {
+            window.localStorage.removeItem(prefixedKey);
+          } else {
+            window.localStorage.setItem(
+              prefixedKey,
+              serializerRef.current(nextValue)
+            );
+          }
+        } catch (error) {
+          logStorageWarning("save", prefixedKey, error);
+        }
+
+        return nextValue;
+      });
+    },
+    [prefixedKey, ssrSafe]
+  );
+
+  const removeItem = useCallback(() => {
+    if (ssrSafe && !isStorageAvailable()) {
+      setState(defaultValueRef.current);
+      return;
+    }
+
+    if (!isStorageAvailable()) {
+      setState(defaultValueRef.current);
+      return;
+    }
+
+    try {
+      window.localStorage.removeItem(prefixedKey);
+      setState(defaultValueRef.current);
+    } catch (error) {
+      logStorageWarning("remove", prefixedKey, error);
+    }
+  }, [prefixedKey, ssrSafe]);
+
+  return [state, setItem, removeItem] as const;
+}
+
+export function useLocalStorageBoolean(
+  key: string,
+  defaultValue: boolean,
+  options?: Pick<UseLocalStorageOptions<boolean>, "ssrSafe">
+) {
+  return useLocalStorage<boolean>(key, defaultValue, {
+    serializer: (value) => String(value),
+    deserializer: (value) => value === "true",
+    ssrSafe: options?.ssrSafe,
+  });
+}
+
+export function useLocalStorageNumber(
+  key: string,
+  defaultValue: number,
+  options?: Omit<UseLocalStorageOptions<number>, "serializer" | "deserializer">
+) {
+  return useLocalStorage<number>(key, defaultValue, {
+    serializer: (value) => String(value),
+    deserializer: (value) => Number(value),
+    validate: (value) => {
+      const isValidNumber = Number.isFinite(value);
+      if (!isValidNumber) {
+        return false;
+      }
+
+      if (!options?.validate) {
+        return true;
+      }
+
+      return options.validate(value);
+    },
+    ssrSafe: options?.ssrSafe,
+  });
+}

--- a/apps/frontend/src/hooks/useLocalStorage.ts
+++ b/apps/frontend/src/hooks/useLocalStorage.ts
@@ -99,10 +99,6 @@ function readStorageValue<T>(
     return defaultValue;
   }
 
-  if (!isStorageAvailable()) {
-    return defaultValue;
-  }
-
   try {
     const item = window.localStorage.getItem(key);
     if (item === null) {
@@ -175,10 +171,6 @@ export function useLocalStorage<T>(
           return nextValue;
         }
 
-        if (!isStorageAvailable()) {
-          return nextValue;
-        }
-
         try {
           if (nextValue === undefined) {
             window.localStorage.removeItem(prefixedKey);
@@ -204,17 +196,13 @@ export function useLocalStorage<T>(
       return;
     }
 
-    if (!isStorageAvailable()) {
-      setState(defaultValueRef.current);
-      return;
-    }
-
     try {
       window.localStorage.removeItem(prefixedKey);
-      setState(defaultValueRef.current);
     } catch (error) {
       logStorageWarning("remove", prefixedKey, error);
     }
+
+    setState(defaultValueRef.current);
   }, [prefixedKey, ssrSafe]);
 
   return [state, setItem, removeItem] as const;

--- a/apps/frontend/src/hooks/useLocalStorage.ts
+++ b/apps/frontend/src/hooks/useLocalStorage.ts
@@ -215,7 +215,11 @@ export function useLocalStorageBoolean(
 ) {
   return useLocalStorage<boolean>(key, defaultValue, {
     serializer: (value) => String(value),
-    deserializer: (value) => value === "true",
+    deserializer: (value) => {
+      if (value === "true") return true;
+      if (value === "false") return false;
+      return defaultValue;
+    },
     ssrSafe: options?.ssrSafe,
   });
 }

--- a/apps/frontend/src/hooks/useProject.test.tsx
+++ b/apps/frontend/src/hooks/useProject.test.tsx
@@ -49,16 +49,13 @@ describe("useProject", () => {
       expect(result.current.currentProject?.id).toBe("project-1");
     });
 
-    expect(localStorage.getItem("branchforge_current_project_id")).toBe(
-      JSON.stringify("project-1")
+    expect(localStorage.getItem("branchforge:project:current")).toBe(
+      "project-1"
     );
   });
 
   it("falls back to the first available project when storage points to a missing project", async () => {
-    localStorage.setItem(
-      "branchforge_current_project_id",
-      JSON.stringify("missing-project")
-    );
+    localStorage.setItem("branchforge:project:current", "missing-project");
 
     const queryClient = createTestQueryClient();
 
@@ -70,8 +67,8 @@ describe("useProject", () => {
       expect(result.current.currentProject?.id).toBe("project-1");
     });
 
-    expect(localStorage.getItem("branchforge_current_project_id")).toBe(
-      JSON.stringify("project-1")
+    expect(localStorage.getItem("branchforge:project:current")).toBe(
+      "project-1"
     );
   });
 });

--- a/apps/frontend/src/hooks/useProject.ts
+++ b/apps/frontend/src/hooks/useProject.ts
@@ -13,41 +13,48 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { projectsApi, type Project } from "@/lib/api/projects";
 import { projectKeys } from "@/lib/query-keys";
+import {
+  getPrefixedStorageKey,
+  readLocalStorageItem,
+  removeLocalStorageItem,
+  writeLocalStorageItem,
+} from "@/hooks/useLocalStorage";
 
 // ============================================================================
 // Constants
 // ============================================================================
 
-const CURRENT_PROJECT_STORAGE_KEY = "branchforge_current_project_id";
+const CURRENT_PROJECT_STORAGE_KEY = getPrefixedStorageKey("project:current");
 
-function readStoredCurrentProjectId(): string | null {
+function parseStoredProjectId(value: string): string | null {
+  if (value.length === 0) {
+    return null;
+  }
+
   try {
-    const stored = localStorage.getItem(CURRENT_PROJECT_STORAGE_KEY);
-    if (!stored) {
-      return null;
-    }
-
-    const parsed = JSON.parse(stored);
+    const parsed = JSON.parse(value) as unknown;
     return typeof parsed === "string" ? parsed : null;
   } catch {
-    return null;
+    return value;
   }
 }
 
-function persistCurrentProjectId(projectId: string | null): void {
-  try {
-    if (projectId) {
-      localStorage.setItem(
-        CURRENT_PROJECT_STORAGE_KEY,
-        JSON.stringify(projectId)
-      );
-      return;
-    }
-
-    localStorage.removeItem(CURRENT_PROJECT_STORAGE_KEY);
-  } catch {
-    // Ignore storage errors (for example in restrictive browser contexts).
+function readStoredCurrentProjectId(): string | null {
+  const stored = readLocalStorageItem(CURRENT_PROJECT_STORAGE_KEY);
+  if (!stored) {
+    return null;
   }
+
+  return parseStoredProjectId(stored);
+}
+
+function persistCurrentProjectId(projectId: string | null): void {
+  if (projectId) {
+    writeLocalStorageItem(CURRENT_PROJECT_STORAGE_KEY, projectId);
+    return;
+  }
+
+  removeLocalStorageItem(CURRENT_PROJECT_STORAGE_KEY);
 }
 
 // ============================================================================

--- a/apps/frontend/src/lib/codemirror/palettes.ts
+++ b/apps/frontend/src/lib/codemirror/palettes.ts
@@ -277,29 +277,3 @@ export function applyPalette(palette: SyntaxPalette): void {
     root.style.setProperty(`--${cssKey}-light`, deriveLightColor(value));
   });
 }
-
-/**
- * Get the current palette from local storage or return the first one
- */
-export function getSavedPalette(): number {
-  try {
-    if (typeof window === "undefined" || !window.localStorage) {
-      return 0;
-    }
-    const saved = window.localStorage.getItem("branchforge-syntax-palette");
-    if (saved === null) {
-      return 0;
-    }
-    const parsed = parseInt(saved, 10);
-    return Number.isFinite(parsed) ? parsed : 0;
-  } catch {
-    return 0;
-  }
-}
-
-/**
- * Save the selected palette index to local storage
- */
-export function savePalette(index: number): void {
-  localStorage.setItem("branchforge-syntax-palette", index.toString());
-}

--- a/apps/frontend/src/pages/ide/ScriptMode.tsx
+++ b/apps/frontend/src/pages/ide/ScriptMode.tsx
@@ -100,6 +100,9 @@ export function ScriptMode({
   } = useFocusModeState("script:focus-mode");
 
   const editorRef = useRef<ScriptEditorRef>(null);
+  const isResettingRef = useRef(false);
+  const skipSaveRef = useRef(false);
+  const currentResetIdRef = useRef(0);
 
   const handleFocusModeToggle = useCallback(() => {
     if (!isFocusMode) {
@@ -183,6 +186,7 @@ export function ScriptMode({
     data: editedFileContent,
     hashFn: hashFileContent,
     debounceMs: 1000, // Reduced from 2000ms for faster feedback
+    skipSaveRef,
     onSave: useCallback(
       async (content: string) => {
         if (currentEditFileId) {
@@ -444,32 +448,49 @@ export function ScriptMode({
   }, [showErrorToast]);
 
   useEffect(() => {
-    const resetProjectState = async () => {
-      if (
-        currentEditFileIdRef.current &&
-        (isFileDirtyRef.current || fileSaveStatusRef.current === "error")
-      ) {
-        const flushed = await triggerFileSaveRef.current();
-        if (!flushed) {
-          showErrorToastRef.current(
-            "Could not save pending edits. The save failed when switching projects.",
-            "Project switch warning"
-          );
+    const resetId = ++currentResetIdRef.current;
+
+    (async () => {
+      isResettingRef.current = true;
+      skipSaveRef.current = true;
+
+      try {
+        if (
+          currentEditFileIdRef.current &&
+          (isFileDirtyRef.current || fileSaveStatusRef.current === "error")
+        ) {
+          if (resetId !== currentResetIdRef.current) {
+            return;
+          }
+          const flushed = await triggerFileSaveRef.current();
+          if (!flushed) {
+            showErrorToastRef.current(
+              "Could not save pending edits. The save failed when switching projects.",
+              "Project switch warning"
+            );
+          }
+        }
+
+        if (resetId !== currentResetIdRef.current) {
+          return;
+        }
+
+        hasRefreshed.current = false;
+        setHydratedTabsProjectId(undefined);
+        setOpenTabs([]);
+        setActiveFileId(null);
+        setCurrentEditFileId(null);
+        setCurrentEditFileHash(null);
+        setEditedFileContent("");
+        setScrollToLine(null);
+        setHasSaveConflict(false);
+      } finally {
+        if (resetId === currentResetIdRef.current) {
+          isResettingRef.current = false;
+          skipSaveRef.current = false;
         }
       }
-
-      hasRefreshed.current = false;
-      setHydratedTabsProjectId(undefined);
-      setOpenTabs([]);
-      setActiveFileId(null);
-      setCurrentEditFileId(null);
-      setCurrentEditFileHash(null);
-      setEditedFileContent("");
-      setScrollToLine(null);
-      setHasSaveConflict(false);
-    };
-
-    void resetProjectState();
+    })();
   }, [projectId]);
 
   // Handle Ctrl+S for immediate save
@@ -637,7 +658,12 @@ export function ScriptMode({
 
   // Load persisted tabs and active file once per project after files load
   useEffect(() => {
-    if (!projectId || isLoadingFiles || hydratedTabsProjectId === projectId) {
+    if (
+      !projectId ||
+      isLoadingFiles ||
+      hydratedTabsProjectId === projectId ||
+      isResettingRef.current
+    ) {
       return;
     }
 

--- a/apps/frontend/src/pages/ide/ScriptMode.tsx
+++ b/apps/frontend/src/pages/ide/ScriptMode.tsx
@@ -487,7 +487,11 @@ export function ScriptMode({
       } finally {
         if (resetId === currentResetIdRef.current) {
           isResettingRef.current = false;
-          skipSaveRef.current = false;
+          Promise.resolve().then(() => {
+            if (resetId === currentResetIdRef.current) {
+              skipSaveRef.current = false;
+            }
+          });
         }
       }
     })();

--- a/apps/frontend/src/pages/ide/ScriptMode.tsx
+++ b/apps/frontend/src/pages/ide/ScriptMode.tsx
@@ -34,6 +34,13 @@ import { registerModeFlushHandler } from "@/lib/editor-sync-coordinator";
 import type { FileSourceType } from "@branchforge/shared";
 import type { ScriptEditorRef } from "@/components/script-mode/ScriptEditor";
 import { cva } from "class-variance-authority";
+import {
+  getPrefixedStorageKey,
+  readLocalStorageItem,
+  removeLocalStorageItem,
+  useLocalStorageBoolean,
+  writeLocalStorageItem,
+} from "@/hooks/useLocalStorage";
 
 const sidebarVariants = cva(
   "min-h-0 shrink-0 rounded-lg border border-border bg-card/50 overflow-hidden mt-3 transition-all duration-300 ease-out",
@@ -78,18 +85,10 @@ export function ScriptMode({
   const [showZipImportDialog, setShowZipImportDialog] = useState(false);
 
   // Sidebar collapse states
-  const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] = useState(() => {
-    const leftCollapsed = localStorage.getItem(
-      "scriptmode-left-sidebar-collapsed"
-    );
-    return leftCollapsed === "true";
-  });
-  const [isRightSidebarCollapsed, setIsRightSidebarCollapsed] = useState(() => {
-    const rightCollapsed = localStorage.getItem(
-      "scriptmode-right-sidebar-collapsed"
-    );
-    return rightCollapsed === "true";
-  });
+  const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] =
+    useLocalStorageBoolean("script:left-sidebar-collapsed", false);
+  const [isRightSidebarCollapsed, setIsRightSidebarCollapsed] =
+    useLocalStorageBoolean("script:right-sidebar-collapsed", false);
 
   const {
     isFocusMode,
@@ -98,7 +97,7 @@ export function ScriptMode({
     setPreFocusSidebarStates,
     preFocusElementRef,
     focusToggleRef,
-  } = useFocusModeState("scriptmode-focus-mode");
+  } = useFocusModeState("script:focus-mode");
 
   const editorRef = useRef<ScriptEditorRef>(null);
 
@@ -142,13 +141,15 @@ export function ScriptMode({
 
   // Track open tabs with project-scoped persistence
   const [openTabs, setOpenTabs] = useState<string[]>([]);
-  const tabsLoadedRef = useRef<string | undefined>(undefined);
+  const [hydratedTabsProjectId, setHydratedTabsProjectId] = useState<
+    string | undefined
+  >(undefined);
 
   const tabsStorageKey = projectId
-    ? `branchforge:scriptTabs:${projectId}`
+    ? getPrefixedStorageKey(`script:open-tabs:${projectId}`)
     : null;
   const activeFileStorageKey = projectId
-    ? `branchforge:activeScriptFile:${projectId}`
+    ? getPrefixedStorageKey(`script:active-file:${projectId}`)
     : null;
 
   // Track edited file content for autosave
@@ -402,38 +403,23 @@ export function ScriptMode({
 
   // Persist open tabs after project state has been hydrated from storage
   useEffect(() => {
-    if (tabsStorageKey && tabsLoadedRef.current === projectId) {
-      localStorage.setItem(tabsStorageKey, JSON.stringify(openTabs));
+    if (tabsStorageKey && hydratedTabsProjectId === projectId) {
+      writeLocalStorageItem(tabsStorageKey, JSON.stringify(openTabs));
     }
-  }, [openTabs, projectId, tabsStorageKey]);
+  }, [openTabs, projectId, tabsStorageKey, hydratedTabsProjectId]);
 
   // Persist active file to localStorage
   useEffect(() => {
-    if (!activeFileStorageKey) {
+    if (!activeFileStorageKey || hydratedTabsProjectId !== projectId) {
       return;
     }
 
     if (activeFileId) {
-      localStorage.setItem(activeFileStorageKey, activeFileId);
+      writeLocalStorageItem(activeFileStorageKey, activeFileId);
     } else {
-      localStorage.removeItem(activeFileStorageKey);
+      removeLocalStorageItem(activeFileStorageKey);
     }
-  }, [activeFileId, activeFileStorageKey]);
-
-  // Persist sidebar collapse states to localStorage
-  useEffect(() => {
-    localStorage.setItem(
-      "scriptmode-left-sidebar-collapsed",
-      String(isLeftSidebarCollapsed)
-    );
-  }, [isLeftSidebarCollapsed]);
-
-  useEffect(() => {
-    localStorage.setItem(
-      "scriptmode-right-sidebar-collapsed",
-      String(isRightSidebarCollapsed)
-    );
-  }, [isRightSidebarCollapsed]);
+  }, [activeFileId, activeFileStorageKey, projectId, hydratedTabsProjectId]);
 
   // Refs for project reset effect to avoid unwanted reruns
   const currentEditFileIdRef = useRef(currentEditFileId);
@@ -473,7 +459,7 @@ export function ScriptMode({
       }
 
       hasRefreshed.current = false;
-      tabsLoadedRef.current = undefined;
+      setHydratedTabsProjectId(undefined);
       setOpenTabs([]);
       setActiveFileId(null);
       setCurrentEditFileId(null);
@@ -651,15 +637,13 @@ export function ScriptMode({
 
   // Load persisted tabs and active file once per project after files load
   useEffect(() => {
-    if (!projectId || isLoadingFiles || tabsLoadedRef.current === projectId) {
+    if (!projectId || isLoadingFiles || hydratedTabsProjectId === projectId) {
       return;
     }
 
-    let isMounted = true;
-
     const fileIds = new Set(projectFiles.map((file) => file.id));
     const savedTabsRaw = tabsStorageKey
-      ? localStorage.getItem(tabsStorageKey)
+      ? readLocalStorageItem(tabsStorageKey)
       : null;
 
     let nextOpenTabs: string[] = [];
@@ -677,7 +661,7 @@ export function ScriptMode({
     }
 
     const savedActiveFileId = activeFileStorageKey
-      ? localStorage.getItem(activeFileStorageKey)
+      ? readLocalStorageItem(activeFileStorageKey)
       : null;
     const resolvedActiveFileId =
       savedActiveFileId && fileIds.has(savedActiveFileId)
@@ -693,20 +677,16 @@ export function ScriptMode({
     setOpenTabs(nextOpenTabs);
 
     const loadActiveFile = async () => {
-      if (resolvedActiveFileId && resolvedActiveFileId !== activeFileId) {
-        await handleSelectFileTab(resolvedActiveFileId);
-      }
-
-      if (isMounted) {
-        tabsLoadedRef.current = projectId;
+      try {
+        if (resolvedActiveFileId && resolvedActiveFileId !== activeFileId) {
+          await handleSelectFileTab(resolvedActiveFileId);
+        }
+      } finally {
+        setHydratedTabsProjectId(projectId);
       }
     };
 
     void loadActiveFile();
-
-    return () => {
-      isMounted = false;
-    };
   }, [
     projectId,
     isLoadingFiles,
@@ -715,6 +695,7 @@ export function ScriptMode({
     activeFileStorageKey,
     activeFileId,
     handleSelectFileTab,
+    hydratedTabsProjectId,
   ]);
 
   // Keep tab bar aligned with externally changed active file

--- a/apps/frontend/src/pages/ide/WriteMode.tsx
+++ b/apps/frontend/src/pages/ide/WriteMode.tsx
@@ -27,6 +27,13 @@ import type { LabelDetail } from "@branchforge/shared";
 import { useToast } from "@/contexts/ToastContext";
 import { registerModeFlushHandler } from "@/lib/editor-sync-coordinator";
 import { cva } from "class-variance-authority";
+import {
+  getPrefixedStorageKey,
+  readLocalStorageItem,
+  removeLocalStorageItem,
+  useLocalStorageBoolean,
+  writeLocalStorageItem,
+} from "@/hooks/useLocalStorage";
 
 const sidebarVariants = cva(
   "min-h-0 shrink-0 rounded-lg border border-border bg-card/50 overflow-hidden mt-3 transition-all duration-300 ease-out",
@@ -95,20 +102,12 @@ export function WriteMode({ projectName }: WriteModeProps) {
     setPreFocusSidebarStates,
     preFocusElementRef,
     focusToggleRef,
-  } = useFocusModeState("writemode-focus-mode");
+  } = useFocusModeState("write:focus-mode");
 
-  const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] = useState(() => {
-    const leftCollapsed = localStorage.getItem(
-      "writemode-left-sidebar-collapsed"
-    );
-    return leftCollapsed === "true";
-  });
-  const [isRightSidebarCollapsed, setIsRightSidebarCollapsed] = useState(() => {
-    const rightCollapsed = localStorage.getItem(
-      "writemode-right-sidebar-collapsed"
-    );
-    return rightCollapsed === "true";
-  });
+  const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] =
+    useLocalStorageBoolean("write:left-sidebar-collapsed", false);
+  const [isRightSidebarCollapsed, setIsRightSidebarCollapsed] =
+    useLocalStorageBoolean("write:right-sidebar-collapsed", false);
 
   const editorRef = useRef<{ focus: () => void } | null>(null);
   const [lastKnownVersionByLabel, setLastKnownVersionByLabel] = useState<
@@ -150,45 +149,64 @@ export function WriteMode({ projectName }: WriteModeProps) {
     if (activeLabelId) return [activeLabelId];
     return [];
   });
-  const tabsLoadedRef = useRef<string | undefined>(undefined);
+  const [hydratedTabsProjectId, setHydratedTabsProjectId] = useState<
+    string | undefined
+  >(undefined);
+  const tabsStorageKey = useMemo(
+    () =>
+      currentProject?.id
+        ? getPrefixedStorageKey(`write:open-tabs:${currentProject.id}`)
+        : null,
+    [currentProject?.id]
+  );
+  const activeTabStorageKey = useMemo(
+    () =>
+      currentProject?.id
+        ? getPrefixedStorageKey(`write:active-tab:${currentProject.id}`)
+        : null,
+    [currentProject?.id]
+  );
 
   // Persist open tabs after project state has been hydrated from storage
   useEffect(() => {
-    if (currentProject?.id && tabsLoadedRef.current === currentProject.id) {
-      localStorage.setItem(
-        `branchforge:tabs:${currentProject.id}`,
-        JSON.stringify(openTabs)
-      );
-    }
-  }, [openTabs, currentProject?.id]);
-
-  // Persist active label to localStorage
-  useEffect(() => {
-    if (currentProject?.id) {
-      if (activeLabelId) {
-        localStorage.setItem(
-          `branchforge:activeLabel:${currentProject.id}`,
-          activeLabelId
-        );
-      } else {
-        localStorage.removeItem(`branchforge:activeLabel:${currentProject.id}`);
+    if (tabsStorageKey && currentProject?.id) {
+      if (hydratedTabsProjectId !== currentProject.id) {
+        return;
       }
+
+      writeLocalStorageItem(tabsStorageKey, JSON.stringify(openTabs));
     }
-  }, [activeLabelId, currentProject?.id]);
+  }, [tabsStorageKey, openTabs, currentProject?.id, hydratedTabsProjectId]);
 
+  // Persist active tab after project state has been hydrated from storage
   useEffect(() => {
-    localStorage.setItem(
-      "writemode-left-sidebar-collapsed",
-      String(isLeftSidebarCollapsed)
-    );
-  }, [isLeftSidebarCollapsed]);
+    if (!activeTabStorageKey || !currentProject?.id) {
+      return;
+    }
 
-  useEffect(() => {
-    localStorage.setItem(
-      "writemode-right-sidebar-collapsed",
-      String(isRightSidebarCollapsed)
+    if (hydratedTabsProjectId !== currentProject.id) {
+      return;
+    }
+
+    const fallbackActiveTabId = openTabs.find((tabId) =>
+      labels.some((label) => label.id === tabId)
     );
-  }, [isRightSidebarCollapsed]);
+    const nextActiveTabId = activeLabelId ?? fallbackActiveTabId ?? null;
+
+    if (nextActiveTabId) {
+      writeLocalStorageItem(activeTabStorageKey, nextActiveTabId);
+      return;
+    }
+
+    removeLocalStorageItem(activeTabStorageKey);
+  }, [
+    activeTabStorageKey,
+    activeLabelId,
+    currentProject?.id,
+    hydratedTabsProjectId,
+    labels,
+    openTabs,
+  ]);
 
   const handleFocusModeToggle = useCallback(() => {
     if (!isFocusMode) {
@@ -280,7 +298,7 @@ export function WriteMode({ projectName }: WriteModeProps) {
       savedHashesRef.current.clear();
       serverContentHashesRef.current.clear();
       setOpenTabs([]);
-      tabsLoadedRef.current = undefined;
+      setHydratedTabsProjectId(undefined);
     }
     prevProjectIdRef.current = currentProject?.id;
   }, [currentProject?.id]);
@@ -290,16 +308,18 @@ export function WriteMode({ projectName }: WriteModeProps) {
     if (
       isLoadingLabels ||
       !currentProject?.id ||
-      labels.length === 0 ||
-      tabsLoadedRef.current === currentProject.id
+      hydratedTabsProjectId === currentProject.id
     ) {
       return;
     }
 
     const labelIds = new Set(labels.map((l) => l.id));
-    const savedTabsRaw = localStorage.getItem(
-      `branchforge:tabs:${currentProject.id}`
-    );
+    const savedTabsRaw = tabsStorageKey
+      ? readLocalStorageItem(tabsStorageKey)
+      : null;
+    const savedActiveTabId = activeTabStorageKey
+      ? readLocalStorageItem(activeTabStorageKey)
+      : null;
 
     let nextOpenTabs: string[] = [];
     if (savedTabsRaw) {
@@ -315,36 +335,36 @@ export function WriteMode({ projectName }: WriteModeProps) {
       }
     }
 
-    const savedActiveLabel = localStorage.getItem(
-      `branchforge:activeLabel:${currentProject.id}`
-    );
-    const resolvedActiveLabelId =
-      savedActiveLabel && labelIds.has(savedActiveLabel)
-        ? savedActiveLabel
-        : activeLabelId && labelIds.has(activeLabelId)
-          ? activeLabelId
-          : null;
+    let nextActiveLabelId: string | null;
 
-    if (
-      resolvedActiveLabelId &&
-      !nextOpenTabs.includes(resolvedActiveLabelId)
-    ) {
-      nextOpenTabs = [...nextOpenTabs, resolvedActiveLabelId];
+    if (activeLabelId && labelIds.has(activeLabelId)) {
+      nextActiveLabelId = activeLabelId;
+    } else if (savedActiveTabId && labelIds.has(savedActiveTabId)) {
+      nextActiveLabelId = savedActiveTabId;
+    } else {
+      nextActiveLabelId = nextOpenTabs[0] ?? labels[0]?.id ?? null;
+    }
+
+    if (nextActiveLabelId && !nextOpenTabs.includes(nextActiveLabelId)) {
+      nextOpenTabs = [...nextOpenTabs, nextActiveLabelId];
     }
 
     setOpenTabs(nextOpenTabs);
 
-    if (resolvedActiveLabelId && resolvedActiveLabelId !== activeLabelId) {
-      setActiveLabelId(resolvedActiveLabelId);
+    if (nextActiveLabelId && nextActiveLabelId !== activeLabelId) {
+      setActiveLabelId(nextActiveLabelId);
     }
 
-    tabsLoadedRef.current = currentProject.id;
+    setHydratedTabsProjectId(currentProject.id);
   }, [
     isLoadingLabels,
     currentProject?.id,
+    tabsStorageKey,
+    activeTabStorageKey,
     labels,
     activeLabelId,
     setActiveLabelId,
+    hydratedTabsProjectId,
   ]);
 
   // Keep tab bar aligned with externally changed active label

--- a/apps/frontend/src/pages/ide/index.tsx
+++ b/apps/frontend/src/pages/ide/index.tsx
@@ -11,38 +11,35 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { WriteMode } from "./WriteMode";
 import { flushModeBeforeTransition } from "@/lib/editor-sync-coordinator";
 import { useToast } from "@/contexts/ToastContext";
+import {
+  useLocalStorage,
+  useLocalStorageBoolean,
+} from "@/hooks/useLocalStorage";
 
 const ScriptMode = lazy(() =>
   import("./ScriptMode").then((m) => ({ default: m.ScriptMode }))
 );
 
-const MODE_STORAGE_KEY = "branchforge_ide_mode";
-
-function getStoredMode(): "write" | "script" {
-  try {
-    const stored = localStorage.getItem(MODE_STORAGE_KEY);
-    return stored === "write" || stored === "script" ? stored : "write";
-  } catch {
-    return "write";
-  }
-}
-
-function setStoredMode(mode: "write" | "script") {
-  try {
-    localStorage.setItem(MODE_STORAGE_KEY, mode);
-  } catch {
-    // Ignore storage errors (e.g., private browsing)
-  }
-}
-
 export function HomePageIDE() {
   const { theme, setTheme } = useTheme();
   const { logout } = useAuth();
   const navigate = useNavigate();
-  const [mode, setMode] = useState<"write" | "script">(getStoredMode);
-  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [mode, setMode] = useLocalStorage<"write" | "script">(
+    "ide:mode",
+    "write",
+    {
+      serializer: (value) => value,
+      deserializer: (value) => value as "write" | "script",
+      validate: (value) => value === "write" || value === "script",
+    }
+  );
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useLocalStorageBoolean(
+    "ide:sidebar-collapsed",
+    false
+  );
   const [scriptModeKey, setScriptModeKey] = useState(0);
   const isFlushing = useRef(false);
+  const previousProjectIdRef = useRef<string | undefined>(undefined);
 
   // Project context
   const { currentProject, projects, setCurrentProject, isLoadingProjects } =
@@ -57,7 +54,17 @@ export function HomePageIDE() {
 
   // Clear active label when project changes
   useEffect(() => {
-    setActiveLabelId(null);
+    const previousProjectId = previousProjectIdRef.current;
+    const nextProjectId = currentProject?.id;
+
+    if (
+      previousProjectId !== undefined &&
+      previousProjectId !== nextProjectId
+    ) {
+      setActiveLabelId(null);
+    }
+
+    previousProjectIdRef.current = nextProjectId;
   }, [currentProject?.id, setActiveLabelId]);
 
   const handleLogout = async () => {
@@ -65,7 +72,6 @@ export function HomePageIDE() {
     navigate(`${BASE_URL}login`);
   };
 
-  // Wrap setMode to persist to localStorage
   const handleSetMode = (newMode: "write" | "script") => {
     void (async () => {
       if (newMode === mode) {
@@ -89,7 +95,6 @@ export function HomePageIDE() {
         }
 
         setMode(newMode);
-        setStoredMode(newMode);
       } catch (error) {
         showErrorToast(
           "An error occurred while switching modes. Please try again.",


### PR DESCRIPTION
Consolidated scattered localStorage implementations to a hook. No need for any kind of migrating of the old values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified and renamed persisted storage keys and centralized SSR-safe persistence for UI preferences (theme, fonts, palettes, line layout, focus mode, sidebars, open tabs, active files/tabs).
  * Per-project hydration gating and autosave coordination to avoid stale restores during resets.

* **Bug Fixes**
  * Improved validation and safer fallbacks when storage is missing or corrupted; more predictable preference restoration.

* **Tests**
  * Added and updated tests for storage hooks and preference hydration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->