### PR TITLE
chore: version packages to v0.7.1 [skip-coderabbit]

### DIFF
--- a/.changeset/free-pants-wear.md
+++ b/.changeset/free-pants-wear.md
@@ -1,5 +1,0 @@
----
-"@branchforge/frontend": patch
----
-
-Updated write mode design and features, now tabs

--- a/.changeset/neat-rockets-stop.md
+++ b/.changeset/neat-rockets-stop.md
@@ -1,5 +1,0 @@
----
-"@branchforge/frontend": patch
----
-
-Improved GitLab sync user flow

--- a/.changeset/slow-zoos-turn.md
+++ b/.changeset/slow-zoos-turn.md
@@ -1,5 +1,0 @@
----
-"@branchforge/frontend": patch
----
-
-Added focus mode toggle for both write and script mode.

--- a/.changeset/twenty-jeans-fold.md
+++ b/.changeset/twenty-jeans-fold.md
@@ -1,5 +1,0 @@
----
-"@branchforge/frontend": patch
----
-
-Added collapsible sidebars to modes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to BranchForge will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.7.1 - 2026-04-10
+
+- 9b5b4fe: Updated write mode design and features, now tabs
+- 6c0f03f: Improved GitLab sync user flow
+- 7e4a16a: Added focus mode toggle for both write and script mode.
+- 18a6d9d: Added collapsible sidebars to modes
+  - @branchforge/shared@0.7.1
+- @branchforge/shared@0.7.1
+
 ## v0.7.0 - 2026-04-03
 
 - b5285de: Added write mode components and functionality

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/backend",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/frontend",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branchforge",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Visual Novel IDE for Ren'Py",
   "scripts": {

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,3 +1,5 @@
 # @branchforge/shared
 
+## 0.7.1
+
 ## 0.7.0

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/shared",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
<!-- release-automation:version-workflow -->
## Summary
- Consume pending changesets and bump package versions to v0.7.1.
- Run build, typecheck, and tests before opening this release PR.
- Merge this PR to trigger version tagging and release workflows.

## Notes
- Generated by .github/workflows/version.yml.
- Title includes [skip-coderabbit] to skip CodeRabbit on this automation PR.