### PR TITLE
chore: version packages to v0.7.2 [skip-coderabbit]

### DIFF
--- a/.changeset/fast-oranges-appear.md
+++ b/.changeset/fast-oranges-appear.md
@@ -1,7 +1,0 @@
----
-"@branchforge/backend": patch
-"@branchforge/frontend": patch
-"@branchforge/shared": patch
----
-
-Fixed release workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to BranchForge will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.7.2 - 2026-04-12
+
+- Fixed release workflow
+
 ## v0.7.1 - 2026-04-10
 
 - Updated write mode design and features, now tabs

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/backend",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/frontend",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branchforge",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "Visual Novel IDE for Ren'Py",
   "scripts": {

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,0 @@
-# @branchforge/shared
-
-## 0.7.1
-
-## 0.7.0

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/shared",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
<!-- release-automation:version-workflow -->
## Summary
- Consume pending changesets and bump package versions to v0.7.2.
- Run build, typecheck, and tests before opening this release PR.
- Merge this PR to trigger version tagging and release workflows.

## Notes
- Generated by .github/workflows/version.yml.
- Title includes [skip-coderabbit] to skip CodeRabbit on this automation PR.