### PR TITLE
Fixeing release workflow again [skip-coderabbit]

### DIFF
--- a/.changeset/quiet-buses-carry.md
+++ b/.changeset/quiet-buses-carry.md
@@ -1,0 +1,7 @@
+---
+"@branchforge/backend": patch
+"@branchforge/frontend": patch
+"@branchforge/shared": patch
+---
+
+Fixed release workflow again

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_TOKEN }}
 
       - name: Validate REPO_TOKEN
         env:


### PR DESCRIPTION
[fix: update token reference in tag version workflow to use REPO_TOKEN](https://github.com/mikkisguy/branchforge/commit/37a95ef6585a539a631a8289bc6f8a8aeb24ddcc)