### PR TITLE
Extract ScriptMode editor logic into hooks and components

### DIFF
--- a/apps/frontend/src/hooks/__tests__/useFileEditor.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useFileEditor.test.tsx
@@ -1,0 +1,198 @@
+import { act, renderHook } from "@testing-library/react";
+import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { useFileEditor } from "../useFileEditor";
+import { createTestQueryClient } from "@/test/query-client";
+import type { ProjectFileNode } from "../useProjectFiles";
+
+function createProjectFile(
+  id: string,
+  filePath: string,
+  content: string,
+  contentHash: string
+): ProjectFileNode {
+  return {
+    id,
+    projectId: "project-1",
+    filePath,
+    fileType: "STORY",
+    content,
+    sourceType: "GITLAB",
+    contentHash,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    labels: [],
+  };
+}
+
+const FILE_A = createProjectFile(
+  "file-1",
+  "labels/act_1.rpy",
+  'label act_1:\n    e "Hi"',
+  "hash-file-1"
+);
+const FILE_B = createProjectFile(
+  "file-2",
+  "labels/act_2.rpy",
+  'label act_2:\n    e "Bye"',
+  "hash-file-2"
+);
+
+describe("useFileEditor", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("switches files and saves edited content", async () => {
+    const updateFileContent = vi.fn().mockResolvedValue({
+      success: true,
+      contentHash: "hash-new",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    });
+    const showErrorToast = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useFileEditor({
+          projectId: "project-1",
+          projectFiles: [FILE_A, FILE_B],
+          activeLabelId: null,
+          updateFileContent,
+          showErrorToast,
+        }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      const switched = await result.current.switchToFile(FILE_A);
+      expect(switched).toBe(true);
+    });
+
+    expect(result.current.currentEditFileId).toBe("file-1");
+    expect(result.current.editedFileContent).toBe(FILE_A.content);
+
+    act(() => {
+      result.current.setEditedFileContent("updated content");
+    });
+
+    await act(async () => {
+      const saved = await result.current.triggerFileSave();
+      expect(saved).toBe(true);
+    });
+
+    expect(updateFileContent).toHaveBeenCalledWith(
+      "file-1",
+      "updated content",
+      {
+        expectedContentHash: "hash-file-1",
+      }
+    );
+    expect(result.current.hasSaveConflict).toBe(false);
+    expect(showErrorToast).not.toHaveBeenCalled();
+  });
+
+  it("marks save conflict when backend reports stale hash", async () => {
+    const updateFileContent = vi.fn().mockResolvedValue({
+      success: false,
+      conflict: {
+        reason: "STALE_CONTENT_HASH",
+        currentContentHash: "hash-server",
+      },
+    });
+    const showErrorToast = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useFileEditor({
+          projectId: "project-1",
+          projectFiles: [FILE_A],
+          activeLabelId: null,
+          updateFileContent,
+          showErrorToast,
+        }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      await result.current.switchToFile(FILE_A);
+    });
+
+    act(() => {
+      result.current.setEditedFileContent("changed");
+    });
+
+    await act(async () => {
+      const saved = await result.current.triggerFileSave();
+      expect(saved).toBe(false);
+    });
+
+    expect(result.current.hasSaveConflict).toBe(true);
+    expect(showErrorToast).toHaveBeenCalledWith(
+      "This file changed elsewhere. Reload project files before editing again.",
+      "Script conflict detected"
+    );
+  });
+
+  it("blocks switching files when pending save cannot flush", async () => {
+    const updateFileContent = vi.fn().mockResolvedValue({
+      success: false,
+      conflict: {
+        reason: "STALE_CONTENT_HASH",
+        currentContentHash: "hash-server",
+      },
+    });
+    const showErrorToast = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useFileEditor({
+          projectId: "project-1",
+          projectFiles: [FILE_A, FILE_B],
+          activeLabelId: null,
+          updateFileContent,
+          showErrorToast,
+        }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      await result.current.switchToFile(FILE_A);
+    });
+
+    act(() => {
+      result.current.setEditedFileContent("changed");
+    });
+
+    await act(async () => {
+      await result.current.triggerFileSave();
+    });
+
+    await act(async () => {
+      const switched = await result.current.switchToFile(FILE_B);
+      expect(switched).toBe(false);
+    });
+
+    expect(result.current.currentEditFileId).toBe("file-1");
+    expect(showErrorToast).toHaveBeenCalledTimes(3);
+    expect(showErrorToast).toHaveBeenCalledWith(
+      "This file changed elsewhere. Reload project files before editing again.",
+      "Script conflict detected"
+    );
+    expect(showErrorToast).toHaveBeenCalledWith(
+      "Could not save pending edits. Resolve the save error before switching files.",
+      "File switch blocked"
+    );
+  });
+});

--- a/apps/frontend/src/hooks/__tests__/useFileTabs.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useFileTabs.test.tsx
@@ -1,0 +1,126 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useFileTabs } from "../useFileTabs";
+import type { ProjectFileNode } from "../useProjectFiles";
+
+function createProjectFile(
+  id: string,
+  filePath: string,
+  fileType: "STORY" | "SETTINGS"
+): ProjectFileNode {
+  return {
+    id,
+    projectId: "project-1",
+    filePath,
+    fileType,
+    content: "content",
+    sourceType: "GITLAB",
+    contentHash: `hash-${id}`,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    labels: [],
+  };
+}
+
+describe("useFileTabs", () => {
+  const projectFiles: ProjectFileNode[] = [
+    createProjectFile("file-1", "labels/act_1.rpy", "STORY"),
+    createProjectFile("file-2", "gui/screens.rpy", "SETTINGS"),
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("selects files and tracks active/open tabs", async () => {
+    const onFileSelect = vi.fn().mockResolvedValue(true);
+    const onFileActivated = vi.fn();
+
+    const { result } = renderHook(() =>
+      useFileTabs({
+        projectId: "project-1",
+        projectFiles,
+        isLoadingFiles: false,
+        onFileSelect,
+        onFileActivated,
+      })
+    );
+
+    await act(async () => {
+      await result.current.selectFileTab("file-1");
+    });
+
+    expect(onFileSelect).toHaveBeenCalledWith("file-1");
+    expect(onFileActivated).toHaveBeenCalledWith("file-1");
+    expect(result.current.activeFileId).toBe("file-1");
+    expect(result.current.openTabs).toEqual(["file-1"]);
+    expect(result.current.tabItems).toEqual([
+      {
+        id: "file-1",
+        title: "act_1.rpy",
+        meta: "Story",
+        closeLabel: "Close act_1.rpy",
+      },
+    ]);
+  });
+
+  it("closes the final active tab and invokes empty callback", async () => {
+    const onFileSelect = vi.fn().mockResolvedValue(true);
+    const onNoTabsRemaining = vi.fn();
+
+    const { result } = renderHook(() =>
+      useFileTabs({
+        projectId: "project-1",
+        projectFiles,
+        isLoadingFiles: false,
+        onFileSelect,
+        onNoTabsRemaining,
+      })
+    );
+
+    await act(async () => {
+      await result.current.selectFileTab("file-1");
+    });
+
+    const event = {
+      stopPropagation: vi.fn(),
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleCloseFileTab(event, "file-1");
+    });
+
+    expect(onNoTabsRemaining).toHaveBeenCalledTimes(1);
+    expect(result.current.activeFileId).toBeNull();
+    expect(result.current.openTabs).toEqual([]);
+  });
+
+  it("hydrates persisted tabs and active file from localStorage", async () => {
+    localStorage.setItem(
+      "branchforge:script:open-tabs:project-1",
+      JSON.stringify(["file-1", "missing-file"])
+    );
+    localStorage.setItem("branchforge:script:active-file:project-1", "file-1");
+
+    const onFileSelect = vi.fn().mockResolvedValue(true);
+
+    const { result } = renderHook(() =>
+      useFileTabs({
+        projectId: "project-1",
+        projectFiles,
+        isLoadingFiles: false,
+        onFileSelect,
+      })
+    );
+
+    await waitFor(() => {
+      expect(onFileSelect).toHaveBeenCalledWith("file-1");
+    });
+
+    await waitFor(() => {
+      expect(result.current.openTabs).toEqual(["file-1"]);
+      expect(result.current.activeFileId).toBe("file-1");
+    });
+  });
+});

--- a/apps/frontend/src/hooks/__tests__/useLabelFileSync.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useLabelFileSync.test.tsx
@@ -99,4 +99,13 @@ describe("useLabelFileSync", () => {
 
     expect(onSetScrollToLine).not.toHaveBeenCalled();
   });
+
+  it("finds label line numbers for parameterized labels", () => {
+    const line = findLabelLineNumber(
+      ["# intro", "label my_label(arg1, arg2):", '    e "hi"'].join("\n"),
+      "my_label"
+    );
+
+    expect(line).toBe(2);
+  });
 });

--- a/apps/frontend/src/hooks/__tests__/useLabelFileSync.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useLabelFileSync.test.tsx
@@ -1,0 +1,102 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { findLabelLineNumber, useLabelFileSync } from "../useLabelFileSync";
+import type { ProjectFileNode } from "../useProjectFiles";
+
+function createProjectFile(
+  id: string,
+  filePath: string,
+  content: string,
+  labels: ProjectFileNode["labels"]
+): ProjectFileNode {
+  return {
+    id,
+    projectId: "project-1",
+    filePath,
+    fileType: "STORY",
+    content,
+    sourceType: "GITLAB",
+    contentHash: `hash-${id}`,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    labels,
+  };
+}
+
+describe("useLabelFileSync", () => {
+  it("finds label line numbers from label titles", () => {
+    const line = findLabelLineNumber(
+      ["# intro", "label chapter_one_intro:", '    e "hi"'].join("\n"),
+      "Chapter One Intro"
+    );
+
+    expect(line).toBe(2);
+  });
+
+  it("switches to label file and sets target line", async () => {
+    const onFileSelect = vi.fn().mockResolvedValue(true);
+    const onSetScrollToLine = vi.fn();
+    const files: ProjectFileNode[] = [
+      createProjectFile(
+        "file-1",
+        "story/chapter-one.rpy",
+        ["label chapter_one_intro:", '    e "Hello"'].join("\n"),
+        [
+          {
+            id: "label-1",
+            labelName: "chapter_one_intro",
+            title: "Chapter One Intro",
+          },
+        ]
+      ),
+    ];
+
+    renderHook(() =>
+      useLabelFileSync({
+        projectFiles: files,
+        activeLabelId: "label-1",
+        onFileSelect,
+        onSetScrollToLine,
+      })
+    );
+
+    await waitFor(() => {
+      expect(onFileSelect).toHaveBeenCalledWith("file-1");
+      expect(onSetScrollToLine).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it("does not set scroll line when file switch is blocked", async () => {
+    const onFileSelect = vi.fn().mockResolvedValue(false);
+    const onSetScrollToLine = vi.fn();
+    const files: ProjectFileNode[] = [
+      createProjectFile(
+        "file-1",
+        "story/chapter-one.rpy",
+        ["label chapter_one_intro:", '    e "Hello"'].join("\n"),
+        [
+          {
+            id: "label-1",
+            labelName: "chapter_one_intro",
+            title: "Chapter One Intro",
+          },
+        ]
+      ),
+    ];
+
+    renderHook(() =>
+      useLabelFileSync({
+        projectFiles: files,
+        activeLabelId: "label-1",
+        onFileSelect,
+        onSetScrollToLine,
+      })
+    );
+
+    await waitFor(() => {
+      expect(onFileSelect).toHaveBeenCalledWith("file-1");
+    });
+
+    expect(onSetScrollToLine).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/__tests__/useProjectReset.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useProjectReset.test.tsx
@@ -1,0 +1,77 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useRef, useState } from "react";
+import { useProjectReset } from "../useProjectReset";
+
+describe("useProjectReset", () => {
+  it("flushes pending save and resets state on project switch", async () => {
+    const triggerSave = vi.fn().mockResolvedValue(true);
+    const onReset = vi.fn();
+    const showErrorToast = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ projectId }) => {
+        const isResettingRef = useRef(false);
+        const [_skipSave, setSkipSaveState] = useState(false);
+
+        useProjectReset({
+          projectId,
+          isResettingRef,
+          hasPendingSave: true,
+          triggerSave,
+          showErrorToast,
+          setSkipSave: setSkipSaveState,
+          onReset,
+        });
+      },
+      {
+        initialProps: {
+          projectId: "project-1" as string | undefined,
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(triggerSave).toHaveBeenCalledTimes(1);
+      expect(onReset).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ projectId: "project-2" });
+
+    await waitFor(() => {
+      expect(triggerSave).toHaveBeenCalledTimes(2);
+      expect(onReset).toHaveBeenCalledTimes(2);
+    });
+
+    expect(showErrorToast).not.toHaveBeenCalled();
+  });
+
+  it("shows warning toast when save flush fails", async () => {
+    const triggerSave = vi.fn().mockResolvedValue(false);
+    const onReset = vi.fn();
+    const showErrorToast = vi.fn();
+
+    renderHook(() => {
+      const isResettingRef = useRef(false);
+      const [_skipSave, setSkipSaveState] = useState(false);
+
+      useProjectReset({
+        projectId: "project-1",
+        isResettingRef,
+        hasPendingSave: true,
+        triggerSave,
+        showErrorToast,
+        setSkipSave: setSkipSaveState,
+        onReset,
+      });
+    });
+
+    await waitFor(() => {
+      expect(showErrorToast).toHaveBeenCalledWith(
+        "Could not save pending edits. The save failed when switching projects.",
+        "Project switch warning"
+      );
+      expect(onReset).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/frontend/src/hooks/__tests__/useScriptModeRefresh.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useScriptModeRefresh.test.tsx
@@ -1,0 +1,55 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useScriptModeRefresh } from "../useScriptModeRefresh";
+
+describe("useScriptModeRefresh", () => {
+  it("refreshes files only once until reset", async () => {
+    const refreshFiles = vi.fn().mockResolvedValue(undefined);
+
+    const { result, rerender } = renderHook(
+      ({ projectId, isLoadingFiles }) =>
+        useScriptModeRefresh({ projectId, isLoadingFiles, refreshFiles }),
+      {
+        initialProps: {
+          projectId: "project-1" as string | undefined,
+          isLoadingFiles: true,
+        },
+      }
+    );
+
+    expect(refreshFiles).not.toHaveBeenCalled();
+
+    rerender({ projectId: "project-1", isLoadingFiles: false });
+    await waitFor(() => {
+      expect(refreshFiles).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ projectId: "project-1", isLoadingFiles: false });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(refreshFiles).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.resetRefreshState();
+    });
+
+    rerender({ projectId: "project-2", isLoadingFiles: false });
+    await waitFor(() => {
+      expect(refreshFiles).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does not refresh when project id is missing", async () => {
+    const refreshFiles = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useScriptModeRefresh({
+        projectId: undefined,
+        isLoadingFiles: false,
+        refreshFiles,
+      })
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(refreshFiles).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/useFileEditor.ts
+++ b/apps/frontend/src/hooks/useFileEditor.ts
@@ -1,0 +1,268 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAutosave, type SaveStatus } from "@/hooks/useAutosave";
+import { labelKeys, projectFilesKeys } from "@/lib/query-keys";
+import { registerModeFlushHandler } from "@/lib/editor-sync-coordinator";
+import { ApiRequestError } from "@/lib/api/client";
+import type { ProjectFileNode, UseProjectFilesReturn } from "./useProjectFiles";
+
+interface UseFileEditorProps {
+  projectId: string | undefined;
+  projectFiles: ProjectFileNode[];
+  activeLabelId: string | null;
+  updateFileContent: UseProjectFilesReturn["updateFileContent"];
+  showErrorToast: (message: string, title: string) => void;
+  skipSaveRef?: RefObject<boolean>;
+}
+
+export interface SwitchFileTarget {
+  id: string;
+  content: string;
+  contentHash?: string | null;
+}
+
+interface UseFileEditorReturn {
+  fileSaveStatus: SaveStatus;
+  isFileDirty: boolean;
+  editedFileContent: string;
+  currentEditFileId: string | null;
+  hasSaveConflict: boolean;
+  setEditedFileContent: (content: string) => void;
+  triggerFileSave: () => Promise<boolean>;
+  retryFileSave: () => Promise<boolean>;
+  switchToFile: (file: SwitchFileTarget) => Promise<boolean>;
+  clearEditorState: (flush?: boolean) => Promise<boolean>;
+}
+
+class SaveConflictError extends Error {
+  constructor() {
+    super("Save conflict detected");
+    this.name = "SaveConflictError";
+  }
+}
+
+function hashFileContent(content: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < content.length; i++) {
+    hash ^= content.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function useFileEditor({
+  projectId,
+  projectFiles,
+  activeLabelId,
+  updateFileContent,
+  showErrorToast,
+  skipSaveRef,
+}: UseFileEditorProps): UseFileEditorReturn {
+  const queryClient = useQueryClient();
+
+  const [editedFileContent, setEditedFileContent] = useState("");
+  const [currentEditFileId, setCurrentEditFileId] = useState<string | null>(
+    null
+  );
+  const [currentEditFileHash, setCurrentEditFileHash] = useState<string | null>(
+    null
+  );
+  const [hasSaveConflict, setHasSaveConflict] = useState(false);
+
+  const {
+    saveStatus: fileSaveStatus,
+    isDirty: isFileDirty,
+    retrySave: retryFileSave,
+    triggerSave: triggerFileSave,
+    resetSavedHash,
+  } = useAutosave({
+    data: editedFileContent,
+    hashFn: hashFileContent,
+    debounceMs: 1000,
+    skipSaveRef,
+    onSave: useCallback(
+      async (content: string) => {
+        if (!currentEditFileId) {
+          return;
+        }
+
+        const result = await updateFileContent(currentEditFileId, content, {
+          expectedContentHash: currentEditFileHash ?? undefined,
+        });
+
+        if (!result.success) {
+          throw new SaveConflictError();
+        }
+
+        setCurrentEditFileHash(result.contentHash);
+        setHasSaveConflict(false);
+
+        if (!projectId) {
+          return;
+        }
+
+        queryClient.invalidateQueries({
+          queryKey: projectFilesKeys.lists(projectId),
+        });
+        void queryClient.refetchQueries({
+          queryKey: labelKeys.lists(projectId),
+        });
+
+        if (!activeLabelId) {
+          return;
+        }
+
+        void queryClient.refetchQueries({
+          queryKey: labelKeys.detail(projectId, activeLabelId),
+        });
+      },
+      [
+        activeLabelId,
+        currentEditFileHash,
+        currentEditFileId,
+        projectId,
+        queryClient,
+        updateFileContent,
+      ]
+    ),
+    onError: useCallback(
+      (error: Error) => {
+        if (
+          error instanceof SaveConflictError ||
+          (error instanceof ApiRequestError && error.status === 409)
+        ) {
+          setHasSaveConflict(true);
+          showErrorToast(
+            "This file changed elsewhere. Reload project files before editing again.",
+            "Script conflict detected"
+          );
+          return;
+        }
+
+        console.error("Failed to save file content:", error);
+      },
+      [showErrorToast]
+    ),
+  });
+
+  const triggerFileSaveRef = useRef(triggerFileSave);
+
+  useEffect(() => {
+    triggerFileSaveRef.current = triggerFileSave;
+  }, [triggerFileSave]);
+
+  useEffect(() => {
+    const unregister = registerModeFlushHandler("script", async () => {
+      return await triggerFileSaveRef.current();
+    });
+
+    return unregister;
+  }, []);
+
+  // Best-effort save on unmount - may not complete if page closes quickly
+  useEffect(() => {
+    return () => {
+      void triggerFileSaveRef.current().catch((error) => {
+        console.error("Best-effort save on unmount failed:", error);
+      });
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.code === "KeyS") {
+        event.preventDefault();
+        void triggerFileSave();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [triggerFileSave]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!isFileDirty) {
+        return;
+      }
+
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [isFileDirty]);
+
+  const switchToFile = useCallback(
+    async (file: SwitchFileTarget) => {
+      if (currentEditFileId === file.id) {
+        return true;
+      }
+
+      if (currentEditFileId && (isFileDirty || fileSaveStatus === "error")) {
+        const flushed = await triggerFileSave();
+        if (!flushed) {
+          showErrorToast(
+            "Could not save pending edits. Resolve the save error before switching files.",
+            "File switch blocked"
+          );
+          return false;
+        }
+      }
+
+      setEditedFileContent(file.content);
+      setCurrentEditFileId(file.id);
+
+      const projectFile = projectFiles.find((f) => f.id === file.id);
+      setCurrentEditFileHash(
+        projectFile?.contentHash ?? file.contentHash ?? null
+      );
+      setHasSaveConflict(false);
+      resetSavedHash(file.content);
+      return true;
+    },
+    [
+      currentEditFileId,
+      fileSaveStatus,
+      isFileDirty,
+      projectFiles,
+      resetSavedHash,
+      showErrorToast,
+      triggerFileSave,
+    ]
+  );
+
+  const clearEditorState = useCallback(
+    async (flush = false) => {
+      if (flush && isFileDirty) {
+        const flushed = await triggerFileSave();
+        if (!flushed) {
+          return false;
+        }
+      }
+
+      setCurrentEditFileId(null);
+      setCurrentEditFileHash(null);
+      setEditedFileContent("");
+      setHasSaveConflict(false);
+      resetSavedHash("");
+      return true;
+    },
+    [isFileDirty, resetSavedHash, triggerFileSave]
+  );
+
+  return {
+    fileSaveStatus,
+    isFileDirty,
+    editedFileContent,
+    currentEditFileId,
+    hasSaveConflict,
+    setEditedFileContent,
+    triggerFileSave,
+    retryFileSave,
+    switchToFile,
+    clearEditorState,
+  };
+}

--- a/apps/frontend/src/hooks/useFileTabs.ts
+++ b/apps/frontend/src/hooks/useFileTabs.ts
@@ -1,0 +1,319 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  KeyboardEvent,
+  MouseEvent,
+  MutableRefObject,
+  Dispatch,
+  SetStateAction,
+} from "react";
+import type { EditorTabBarItem } from "@/components/ide-shared";
+import {
+  getPrefixedStorageKey,
+  readLocalStorageItem,
+  removeLocalStorageItem,
+  writeLocalStorageItem,
+} from "@/hooks/useLocalStorage";
+import type { ProjectFileNode } from "./useProjectFiles";
+
+interface SelectFileOptions {
+  notify?: boolean;
+}
+
+interface UseFileTabsProps {
+  projectId: string | undefined;
+  projectFiles: ProjectFileNode[];
+  isLoadingFiles: boolean;
+  isResettingRef?: MutableRefObject<boolean>;
+  onFileSelect: (fileId: string) => Promise<boolean> | boolean;
+  onFileActivated?: (fileId: string) => void;
+  onNoTabsRemaining?: () => void;
+}
+
+interface UseFileTabsReturn {
+  openTabs: string[];
+  activeFileId: string | null;
+  setActiveFileId: Dispatch<SetStateAction<string | null>>;
+  tabItems: EditorTabBarItem[];
+  selectFileTab: (
+    fileId: string,
+    options?: SelectFileOptions
+  ) => Promise<boolean>;
+  handleCloseFileTab: (
+    event: MouseEvent | KeyboardEvent,
+    fileId: string
+  ) => void;
+  clearTabsState: () => void;
+}
+
+export function useFileTabs({
+  projectId,
+  projectFiles,
+  isLoadingFiles,
+  isResettingRef,
+  onFileSelect,
+  onFileActivated,
+  onNoTabsRemaining,
+}: UseFileTabsProps): UseFileTabsReturn {
+  const [openTabs, setOpenTabs] = useState<string[]>([]);
+
+  /**
+   * Low-level state setter for the active file ID.
+   *
+   * WARNING: This bypasses validation and callbacks that {@link selectFileTab} performs.
+   * Specifically, it does NOT check:
+   * - File existence in projectFiles
+   * - onFileSelect gating (may allow selecting files that should be blocked)
+   * - onFileActivated callback (activation side effects are skipped)
+   *
+   * PREFER: Use {@link selectFileTab} for normal file activation to ensure validation
+   * and proper callback execution.
+   *
+   * USE CASE: Only use {@link setActiveFileId} directly for special cases like:
+   * - Resetting state during project switching
+   * - Direct state updates where validation is intentionally skipped
+   */
+  const [activeFileId, setActiveFileId] = useState<string | null>(null);
+  const activeFileIdRef = useRef(activeFileId);
+
+  useEffect(() => {
+    activeFileIdRef.current = activeFileId;
+  }, [activeFileId]);
+
+  const [hydratedTabsProjectId, setHydratedTabsProjectId] = useState<
+    string | undefined
+  >(undefined);
+
+  const tabsStorageKey = projectId
+    ? getPrefixedStorageKey(`script:open-tabs:${projectId}`)
+    : null;
+  const activeFileStorageKey = projectId
+    ? getPrefixedStorageKey(`script:active-file:${projectId}`)
+    : null;
+
+  const selectFileTab = useCallback(
+    async (fileId: string, options: SelectFileOptions = {}) => {
+      const file = projectFiles.find(
+        (projectFile) => projectFile.id === fileId
+      );
+      if (!file) {
+        return false;
+      }
+
+      const switched = await onFileSelect(fileId);
+      if (!switched) {
+        return false;
+      }
+
+      setActiveFileId(fileId);
+      setOpenTabs((prev) => {
+        if (prev.includes(fileId)) {
+          return prev;
+        }
+        return [...prev, fileId];
+      });
+
+      if (options.notify !== false) {
+        onFileActivated?.(fileId);
+      }
+
+      return true;
+    },
+    [onFileActivated, onFileSelect, projectFiles]
+  );
+
+  const handleCloseFileTab = useCallback(
+    (event: MouseEvent | KeyboardEvent, fileId: string) => {
+      event.stopPropagation();
+
+      const isActive = fileId === activeFileId;
+      const nextTabs = openTabs.filter((id) => id !== fileId);
+      setOpenTabs(nextTabs);
+
+      if (!isActive) {
+        return;
+      }
+
+      if (nextTabs.length === 0) {
+        setActiveFileId(null);
+        onNoTabsRemaining?.();
+        return;
+      }
+
+      const index = openTabs.indexOf(fileId);
+      const fallbackFileId = openTabs[index - 1] ?? nextTabs[0];
+      void selectFileTab(fallbackFileId);
+    },
+    [activeFileId, onNoTabsRemaining, openTabs, selectFileTab]
+  );
+
+  const tabItems = useMemo<EditorTabBarItem[]>(
+    () =>
+      openTabs
+        .map((tabId) =>
+          projectFiles.find((projectFile) => projectFile.id === tabId)
+        )
+        .filter((file): file is NonNullable<typeof file> => file !== undefined)
+        .map((file) => {
+          const fileName = file.filePath.split("/").pop() || file.filePath;
+          const fileKind = file.fileType === "SETTINGS" ? "Settings" : "Story";
+
+          return {
+            id: file.id,
+            title: fileName,
+            meta: fileKind,
+            closeLabel: `Close ${fileName}`,
+          };
+        }),
+    [openTabs, projectFiles]
+  );
+
+  useEffect(() => {
+    if (tabsStorageKey && hydratedTabsProjectId === projectId) {
+      writeLocalStorageItem(tabsStorageKey, JSON.stringify(openTabs));
+    }
+  }, [openTabs, projectId, tabsStorageKey, hydratedTabsProjectId]);
+
+  useEffect(() => {
+    if (!activeFileStorageKey || hydratedTabsProjectId !== projectId) {
+      return;
+    }
+
+    if (activeFileId) {
+      writeLocalStorageItem(activeFileStorageKey, activeFileId);
+    } else {
+      removeLocalStorageItem(activeFileStorageKey);
+    }
+  }, [activeFileId, activeFileStorageKey, hydratedTabsProjectId, projectId]);
+
+  useEffect(() => {
+    if (
+      !projectId ||
+      isLoadingFiles ||
+      hydratedTabsProjectId === projectId ||
+      isResettingRef?.current
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const hydrateTabs = async () => {
+      // Intentionally yield to next microtask to allow state to settle
+      await Promise.resolve();
+
+      if (cancelled || isResettingRef?.current) {
+        return;
+      }
+
+      const fileIds = new Set(projectFiles.map((file) => file.id));
+      const savedTabsRaw = tabsStorageKey
+        ? readLocalStorageItem(tabsStorageKey)
+        : null;
+
+      let nextOpenTabs: string[] = [];
+      if (savedTabsRaw) {
+        try {
+          const parsedTabs = JSON.parse(savedTabsRaw) as unknown;
+          if (Array.isArray(parsedTabs)) {
+            nextOpenTabs = parsedTabs.filter(
+              (id): id is string => typeof id === "string" && fileIds.has(id)
+            );
+          }
+        } catch {
+          // Invalid JSON; ignore and continue.
+        }
+      }
+
+      const savedActiveFileId = activeFileStorageKey
+        ? readLocalStorageItem(activeFileStorageKey)
+        : null;
+      const resolvedActiveFileId =
+        savedActiveFileId && fileIds.has(savedActiveFileId)
+          ? savedActiveFileId
+          : activeFileIdRef.current && fileIds.has(activeFileIdRef.current)
+            ? activeFileIdRef.current
+            : null;
+
+      if (
+        resolvedActiveFileId &&
+        !nextOpenTabs.includes(resolvedActiveFileId)
+      ) {
+        nextOpenTabs = [...nextOpenTabs, resolvedActiveFileId];
+      }
+
+      if (cancelled) {
+        return;
+      }
+
+      setOpenTabs(nextOpenTabs);
+
+      try {
+        if (
+          resolvedActiveFileId &&
+          resolvedActiveFileId !== activeFileIdRef.current
+        ) {
+          await selectFileTab(resolvedActiveFileId);
+        }
+      } finally {
+        if (!cancelled) {
+          setHydratedTabsProjectId(projectId);
+        }
+      }
+    };
+
+    void hydrateTabs();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeFileStorageKey,
+    hydratedTabsProjectId,
+    isLoadingFiles,
+    isResettingRef,
+    projectFiles,
+    projectId,
+    selectFileTab,
+    tabsStorageKey,
+  ]);
+
+  useEffect(() => {
+    if (
+      !activeFileId ||
+      !projectFiles.some((file) => file.id === activeFileId)
+    ) {
+      return;
+    }
+
+    setOpenTabs((prev) => {
+      if (prev.includes(activeFileId)) {
+        return prev;
+      }
+      return [...prev, activeFileId];
+    });
+  }, [activeFileId, projectFiles]);
+
+  useEffect(() => {
+    const fileIds = new Set(projectFiles.map((file) => file.id));
+    setOpenTabs((prev) => {
+      const nextTabs = prev.filter((tabId) => fileIds.has(tabId));
+      return nextTabs.length === prev.length ? prev : nextTabs;
+    });
+  }, [projectFiles]);
+
+  const clearTabsState = useCallback(() => {
+    setHydratedTabsProjectId(undefined);
+    setOpenTabs([]);
+    setActiveFileId(null);
+  }, []);
+
+  return {
+    openTabs,
+    activeFileId,
+    setActiveFileId,
+    tabItems,
+    selectFileTab,
+    handleCloseFileTab,
+    clearTabsState,
+  };
+}

--- a/apps/frontend/src/hooks/useLabelFileSync.ts
+++ b/apps/frontend/src/hooks/useLabelFileSync.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from "react";
+import { sanitizeLabelName } from "@/lib/label-utils";
+import type { ProjectFileNode } from "./useProjectFiles";
+
+interface UseLabelFileSyncProps {
+  /**
+   * Project files array. Should be memoized (useMemo) to prevent unnecessary re-runs.
+   */
+  projectFiles: ProjectFileNode[];
+  activeLabelId: string | null;
+  /**
+   * Callback to select a file. Should be memoized (useCallback) to prevent unnecessary re-runs.
+   */
+  onFileSelect: (fileId: string) => Promise<boolean> | boolean;
+  /**
+   * Callback to set scroll to line. Should be memoized (useCallback) to prevent unnecessary re-runs.
+   */
+  onSetScrollToLine: (line: number | null) => void;
+}
+
+export function findLabelLineNumber(
+  fileContent: string,
+  labelTitle: string
+): number | null {
+  const labelName = sanitizeLabelName(labelTitle);
+  const lines = fileContent.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.startsWith("label ") && line.endsWith(":")) {
+      const extractedLabel = line.slice(6, -1).trim();
+      if (extractedLabel === labelName) {
+        return i + 1;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function useLabelFileSync({
+  projectFiles,
+  activeLabelId,
+  onFileSelect,
+  onSetScrollToLine,
+}: UseLabelFileSyncProps): void {
+  const onFileSelectRef = useRef(onFileSelect);
+  const onSetScrollToLineRef = useRef(onSetScrollToLine);
+
+  useEffect(() => {
+    onFileSelectRef.current = onFileSelect;
+    onSetScrollToLineRef.current = onSetScrollToLine;
+  }, [onFileSelect, onSetScrollToLine]);
+
+  useEffect(() => {
+    if (!activeLabelId) {
+      return;
+    }
+
+    const fileWithLabel = projectFiles.find((file) =>
+      file.labels.some((label) => label.id === activeLabelId)
+    );
+    if (!fileWithLabel) {
+      return;
+    }
+
+    const labelMetadata = fileWithLabel.labels.find(
+      (label) => label.id === activeLabelId
+    );
+    if (!labelMetadata) {
+      onSetScrollToLineRef.current(null);
+      return;
+    }
+
+    const lineNumber = findLabelLineNumber(
+      fileWithLabel.content,
+      labelMetadata.title
+    );
+    let cancelled = false;
+
+    void (async () => {
+      const switched = await onFileSelectRef.current(fileWithLabel.id);
+      if (!switched || cancelled) {
+        return;
+      }
+      onSetScrollToLineRef.current(lineNumber);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeLabelId, projectFiles]);
+}

--- a/apps/frontend/src/hooks/useLabelFileSync.ts
+++ b/apps/frontend/src/hooks/useLabelFileSync.ts
@@ -26,9 +26,10 @@ export function findLabelLineNumber(
   const lines = fileContent.split("\n");
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim();
-    if (line.startsWith("label ") && line.endsWith(":")) {
-      const extractedLabel = line.slice(6, -1).trim();
+    const line = lines[i];
+    const labelMatch = line.match(/^\s*label\s+([a-zA-Z_][a-zA-Z0-9_]*)/);
+    if (labelMatch) {
+      const extractedLabel = labelMatch[1];
       if (extractedLabel === labelName) {
         return i + 1;
       }

--- a/apps/frontend/src/hooks/useLabelFileSync.ts
+++ b/apps/frontend/src/hooks/useLabelFileSync.ts
@@ -55,6 +55,7 @@ export function useLabelFileSync({
 
   useEffect(() => {
     if (!activeLabelId) {
+      onSetScrollToLineRef.current(null);
       return;
     }
 
@@ -62,6 +63,7 @@ export function useLabelFileSync({
       file.labels.some((label) => label.id === activeLabelId)
     );
     if (!fileWithLabel) {
+      onSetScrollToLineRef.current(null);
       return;
     }
 
@@ -80,11 +82,15 @@ export function useLabelFileSync({
     let cancelled = false;
 
     void (async () => {
-      const switched = await onFileSelectRef.current(fileWithLabel.id);
-      if (!switched || cancelled) {
-        return;
+      try {
+        const switched = await onFileSelectRef.current(fileWithLabel.id);
+        if (!switched || cancelled) {
+          return;
+        }
+        onSetScrollToLineRef.current(lineNumber);
+      } catch (error) {
+        console.error("Failed to select file:", error);
       }
-      onSetScrollToLineRef.current(lineNumber);
     })();
 
     return () => {

--- a/apps/frontend/src/hooks/useProjectReset.ts
+++ b/apps/frontend/src/hooks/useProjectReset.ts
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from "react";
+import type { MutableRefObject } from "react";
+
+interface UseProjectResetProps {
+  projectId: string | undefined;
+  isResettingRef: MutableRefObject<boolean>;
+  hasPendingSave: boolean;
+  triggerSave: () => Promise<boolean>;
+  showErrorToast: (message: string, title: string) => void;
+  setSkipSave: (value: boolean) => void;
+  onReset: () => void;
+}
+
+export function useProjectReset({
+  projectId,
+  isResettingRef,
+  hasPendingSave,
+  triggerSave,
+  showErrorToast,
+  setSkipSave,
+  onReset,
+}: UseProjectResetProps): void {
+  const currentResetIdRef = useRef(0);
+
+  const triggerSaveRef = useRef(triggerSave);
+  const hasPendingSaveRef = useRef(hasPendingSave);
+  const showErrorToastRef = useRef(showErrorToast);
+  const setSkipSaveRef = useRef(setSkipSave);
+  const onResetRef = useRef(onReset);
+
+  triggerSaveRef.current = triggerSave;
+  hasPendingSaveRef.current = hasPendingSave;
+  showErrorToastRef.current = showErrorToast;
+  setSkipSaveRef.current = setSkipSave;
+  onResetRef.current = onReset;
+
+  useEffect(() => {
+    const resetId = ++currentResetIdRef.current;
+    let cancelled = false;
+
+    void (async () => {
+      await Promise.resolve();
+      if (cancelled) {
+        return;
+      }
+
+      isResettingRef.current = true;
+      setSkipSaveRef.current(true);
+
+      try {
+        if (cancelled) {
+          return;
+        }
+
+        if (hasPendingSaveRef.current) {
+          if (resetId !== currentResetIdRef.current) {
+            return;
+          }
+
+          let flushed = false;
+          try {
+            flushed = await triggerSaveRef.current();
+          } catch (error) {
+            console.error("Error saving pending edits:", error);
+          }
+          if (!flushed) {
+            showErrorToastRef.current(
+              "Could not save pending edits. The save failed when switching projects.",
+              "Project switch warning"
+            );
+          }
+        }
+
+        if (resetId !== currentResetIdRef.current) {
+          return;
+        }
+
+        onResetRef.current();
+      } finally {
+        if (resetId === currentResetIdRef.current) {
+          isResettingRef.current = false;
+          // Defer setSkipSave(false) to a microtask to ensure it runs after the current reset cycle
+          // finishes and after currentResetIdRef is updated by a potential new reset. This prevents
+          // race conditions where setSkipSave(false) could be called by a stale resetId after a new
+          // reset has already started.
+          Promise.resolve().then(() => {
+            if (resetId === currentResetIdRef.current) {
+              setSkipSaveRef.current(false);
+            }
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isResettingRef, projectId]);
+}

--- a/apps/frontend/src/hooks/useScriptModeRefresh.ts
+++ b/apps/frontend/src/hooks/useScriptModeRefresh.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef } from "react";
+
+interface UseScriptModeRefreshProps {
+  projectId: string | undefined;
+  isLoadingFiles: boolean;
+  refreshFiles: () => Promise<unknown>;
+}
+
+interface UseScriptModeRefreshReturn {
+  resetRefreshState: () => void;
+}
+
+export function useScriptModeRefresh({
+  projectId,
+  isLoadingFiles,
+  refreshFiles,
+}: UseScriptModeRefreshProps): UseScriptModeRefreshReturn {
+  const hasRefreshedRef = useRef(false);
+
+  useEffect(() => {
+    if (!projectId || isLoadingFiles || hasRefreshedRef.current) {
+      return;
+    }
+
+    (async () => {
+      try {
+        await refreshFiles();
+        hasRefreshedRef.current = true;
+      } catch (error) {
+        console.error("Failed to refresh files:", error);
+      }
+    })();
+  }, [isLoadingFiles, projectId, refreshFiles]);
+
+  const resetRefreshState = useCallback(() => {
+    hasRefreshedRef.current = false;
+  }, []);
+
+  return { resetRefreshState };
+}

--- a/apps/frontend/src/hooks/useScriptModeRefresh.ts
+++ b/apps/frontend/src/hooks/useScriptModeRefresh.ts
@@ -24,9 +24,10 @@ export function useScriptModeRefresh({
 
     (async () => {
       try {
-        await refreshFiles();
         hasRefreshedRef.current = true;
+        await refreshFiles();
       } catch (error) {
+        hasRefreshedRef.current = false;
         console.error("Failed to refresh files:", error);
       }
     })();

--- a/apps/frontend/src/hooks/useScriptModeRefresh.ts
+++ b/apps/frontend/src/hooks/useScriptModeRefresh.ts
@@ -15,26 +15,30 @@ export function useScriptModeRefresh({
   isLoadingFiles,
   refreshFiles,
 }: UseScriptModeRefreshProps): UseScriptModeRefreshReturn {
-  const hasRefreshedRef = useRef(false);
+  const hasRefreshedRef = useRef<Map<string, boolean>>(new Map());
 
   useEffect(() => {
-    if (!projectId || isLoadingFiles || hasRefreshedRef.current) {
+    if (!projectId || isLoadingFiles) {
+      return;
+    }
+
+    if (hasRefreshedRef.current.get(projectId)) {
       return;
     }
 
     (async () => {
       try {
-        hasRefreshedRef.current = true;
+        hasRefreshedRef.current.set(projectId, true);
         await refreshFiles();
       } catch (error) {
-        hasRefreshedRef.current = false;
+        hasRefreshedRef.current.delete(projectId);
         console.error("Failed to refresh files:", error);
       }
     })();
   }, [isLoadingFiles, projectId, refreshFiles]);
 
   const resetRefreshState = useCallback(() => {
-    hasRefreshedRef.current = false;
+    hasRefreshedRef.current.clear();
   }, []);
 
   return { resetRefreshState };

--- a/apps/frontend/src/pages/ide/ScriptMode.tsx
+++ b/apps/frontend/src/pages/ide/ScriptMode.tsx
@@ -1,61 +1,24 @@
-import { useState, useMemo, useEffect, useCallback, useRef } from "react";
-import {
-  Download,
-  Package,
-  Sparkles,
-  X,
-  ChevronRight,
-  ChevronLeft,
-} from "lucide-react";
-import {
-  StatusBar,
-  ScriptEditor,
-  CharacterReferencePanel,
-} from "@/components/script-mode";
-import { ProjectFileTree } from "@/components/script-mode/ProjectFileTree";
-import { EditorTabBar, type EditorTabBarItem } from "@/components/ide-shared";
-import { FocusModeToggle } from "@/components/write-mode/FocusModeToggle";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { StatusBar } from "@/components/script-mode";
+import { GitLabSyncDialog } from "@/components/script-mode/GitLabSyncDialog";
+import { ZipImportDialog } from "@/components/zip-import";
 import { useLabels } from "@/hooks/useLabels";
 import { useFocusModeKeyboardHandler } from "@/hooks/useFocusModeKeyboardHandler";
 import { useFocusModeState } from "@/hooks/useFocusModeState";
 import { useGitLab } from "@/hooks/useGitLab";
 import { useCharacters } from "@/hooks/useCharacters";
 import { useProjectFiles } from "@/hooks/useProjectFiles";
-import { useAutosave } from "@/hooks/useAutosave";
-import { sanitizeLabelName } from "@/lib/label-utils";
-import { GitLabSyncDialog } from "@/components/script-mode/GitLabSyncDialog";
-import { ZipImportDialog } from "@/components/zip-import";
-import { Button } from "@/components/ui/button";
-import { queryClient } from "@/lib/query-client";
-import { labelKeys, projectFilesKeys } from "@/lib/query-keys";
+import { useFileEditor } from "@/hooks/useFileEditor";
+import { useFileTabs } from "@/hooks/useFileTabs";
+import { useLabelFileSync } from "@/hooks/useLabelFileSync";
+import { useProjectReset } from "@/hooks/useProjectReset";
+import { useScriptModeRefresh } from "@/hooks/useScriptModeRefresh";
 import { useToast } from "@/contexts/ToastContext";
-import { ApiRequestError } from "@/lib/api/client";
-import { registerModeFlushHandler } from "@/lib/editor-sync-coordinator";
 import type { FileSourceType } from "@branchforge/shared";
 import type { ScriptEditorRef } from "@/components/script-mode/ScriptEditor";
-import { cva } from "class-variance-authority";
-import {
-  getPrefixedStorageKey,
-  readLocalStorageItem,
-  removeLocalStorageItem,
-  useLocalStorageBoolean,
-  writeLocalStorageItem,
-} from "@/hooks/useLocalStorage";
-
-const sidebarVariants = cva(
-  "min-h-0 shrink-0 rounded-lg border border-border bg-card/50 overflow-hidden mt-3 transition-all duration-300 ease-out",
-  {
-    variants: {
-      variant: {
-        collapsed: "w-0 opacity-0 -translate-x-full pointer-events-none",
-        expanded: "w-56 opacity-100 translate-x-0",
-      },
-    },
-    defaultVariants: {
-      variant: "expanded",
-    },
-  }
-);
+import { useLocalStorageBoolean } from "@/hooks/useLocalStorage";
+import { ScriptModeEditorLayout } from "./components/ScriptModeEditorLayout";
+import { ScriptModeEmptyState } from "./components/ScriptModeEmptyState";
 
 interface ScriptModeProps {
   projectId?: string;
@@ -80,16 +43,15 @@ export function ScriptMode({
     refreshFiles,
   } = useProjectFiles(projectId);
 
-  // Sync dialog state
   const [showSyncDialog, setShowSyncDialog] = useState(false);
   const [showZipImportDialog, setShowZipImportDialog] = useState(false);
 
-  // Sidebar collapse states
   const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] =
     useLocalStorageBoolean("script:left-sidebar-collapsed", false);
   const [isRightSidebarCollapsed, setIsRightSidebarCollapsed] =
     useLocalStorageBoolean("script:right-sidebar-collapsed", false);
 
+  const focusModeState = useFocusModeState("script:focus-mode");
   const {
     isFocusMode,
     setIsFocusMode,
@@ -97,12 +59,13 @@ export function ScriptMode({
     setPreFocusSidebarStates,
     preFocusElementRef,
     focusToggleRef,
-  } = useFocusModeState("script:focus-mode");
+  } = focusModeState;
 
   const editorRef = useRef<ScriptEditorRef>(null);
   const isResettingRef = useRef(false);
   const skipSaveRef = useRef(false);
-  const currentResetIdRef = useRef(0);
+
+  const [scrollToLine, setScrollToLine] = useState<number | null>(null);
 
   const handleFocusModeToggle = useCallback(() => {
     if (!isFocusMode) {
@@ -116,160 +79,141 @@ export function ScriptMode({
       });
       setIsFocusMode(true);
       editorRef.current?.focus();
+      return;
+    }
+
+    setIsFocusMode(false);
+    if (preFocusSidebarStates) {
+      setIsLeftSidebarCollapsed(preFocusSidebarStates.leftCollapsed);
+      setIsRightSidebarCollapsed(preFocusSidebarStates.rightCollapsed);
+    }
+    if (preFocusElementRef.current) {
+      preFocusElementRef.current.focus();
     } else {
-      setIsFocusMode(false);
-      if (preFocusSidebarStates) {
-        setIsLeftSidebarCollapsed(preFocusSidebarStates.leftCollapsed);
-        setIsRightSidebarCollapsed(preFocusSidebarStates.rightCollapsed);
-      }
-      if (preFocusElementRef.current) {
-        preFocusElementRef.current.focus();
-      } else if (focusToggleRef.current) {
-        focusToggleRef.current.focus();
-      }
+      focusToggleRef.current?.focus();
     }
   }, [
-    isFocusMode,
-    setIsFocusMode,
-    isLeftSidebarCollapsed,
-    setIsLeftSidebarCollapsed,
-    isRightSidebarCollapsed,
-    setIsRightSidebarCollapsed,
-    preFocusSidebarStates,
-    setPreFocusSidebarStates,
-    preFocusElementRef,
     focusToggleRef,
-    editorRef,
+    isFocusMode,
+    isLeftSidebarCollapsed,
+    isRightSidebarCollapsed,
+    preFocusElementRef,
+    preFocusSidebarStates,
+    setIsFocusMode,
+    setIsLeftSidebarCollapsed,
+    setIsRightSidebarCollapsed,
+    setPreFocusSidebarStates,
   ]);
 
-  // Track open tabs with project-scoped persistence
-  const [openTabs, setOpenTabs] = useState<string[]>([]);
-  const [hydratedTabsProjectId, setHydratedTabsProjectId] = useState<
-    string | undefined
-  >(undefined);
-
-  const tabsStorageKey = projectId
-    ? getPrefixedStorageKey(`script:open-tabs:${projectId}`)
-    : null;
-  const activeFileStorageKey = projectId
-    ? getPrefixedStorageKey(`script:active-file:${projectId}`)
-    : null;
-
-  // Track edited file content for autosave
-  const [editedFileContent, setEditedFileContent] = useState<string>("");
-  const [currentEditFileId, setCurrentEditFileId] = useState<string | null>(
-    null
-  );
-  const [currentEditFileHash, setCurrentEditFileHash] = useState<string | null>(
-    null
-  );
-  const [hasSaveConflict, setHasSaveConflict] = useState(false);
-
-  // Simple hash function for file content
-  const hashFileContent = useCallback((content: string) => {
-    let hash = 0x811c9dc5;
-    for (let i = 0; i < content.length; i++) {
-      hash ^= content.charCodeAt(i);
-      hash = Math.imul(hash, 0x01000193);
-    }
-    return (hash >>> 0).toString(36);
-  }, []);
-
-  // Autosave hook for file content
   const {
-    saveStatus: fileSaveStatus,
-    isDirty: isFileDirty,
-    retrySave: retryFileSave,
-    triggerSave: triggerFileSave,
-    resetSavedHash,
-  } = useAutosave({
-    data: editedFileContent,
-    hashFn: hashFileContent,
-    debounceMs: 1000, // Reduced from 2000ms for faster feedback
+    fileSaveStatus,
+    isFileDirty,
+    editedFileContent,
+    currentEditFileId,
+    hasSaveConflict,
+    setEditedFileContent,
+    triggerFileSave,
+    retryFileSave,
+    switchToFile,
+    clearEditorState,
+  } = useFileEditor({
+    projectId,
+    projectFiles,
+    activeLabelId,
+    updateFileContent,
+    showErrorToast,
     skipSaveRef,
-    onSave: useCallback(
-      async (content: string) => {
-        if (currentEditFileId) {
-          const result = await updateFileContent(currentEditFileId, content, {
-            expectedContentHash: currentEditFileHash ?? undefined,
-          });
-
-          if (result.success) {
-            setCurrentEditFileHash(result.contentHash);
-            setHasSaveConflict(false);
-
-            // Invalidate both files and labels queries after save
-            if (projectId) {
-              queryClient.invalidateQueries({
-                queryKey: projectFilesKeys.lists(projectId),
-              });
-              void queryClient.refetchQueries({
-                queryKey: labelKeys.lists(projectId),
-              });
-
-              // Also invalidate the specific label detail if we're viewing a label
-              if (activeLabelId) {
-                void queryClient.refetchQueries({
-                  queryKey: labelKeys.detail(projectId, activeLabelId),
-                });
-              }
-            }
-          }
-        }
-      },
-      [
-        currentEditFileId,
-        updateFileContent,
-        projectId,
-        activeLabelId,
-        currentEditFileHash,
-      ]
-    ),
-    onError: useCallback(
-      (error: Error) => {
-        if (error instanceof ApiRequestError && error.status === 409) {
-          setHasSaveConflict(true);
-          showErrorToast(
-            "This file changed elsewhere. Reload project files before editing again.",
-            "Script conflict detected"
-          );
-          return;
-        }
-        console.error("Failed to save file content:", error);
-      },
-      [showErrorToast]
-    ),
   });
 
-  // Keep latest autosave state for unmount cleanup without re-running cleanup
-  const triggerFileSaveRef = useRef(triggerFileSave);
+  const handleScriptFileSelect = useCallback(
+    async (fileId: string) => {
+      const file = projectFiles.find(
+        (projectFile) => projectFile.id === fileId
+      );
+      if (!file) {
+        return false;
+      }
+      return await switchToFile(file);
+    },
+    [projectFiles, switchToFile]
+  );
 
-  useEffect(() => {
-    triggerFileSaveRef.current = triggerFileSave;
-  }, [triggerFileSave]);
+  const handleNoTabsRemaining = useCallback(() => {
+    void clearEditorState();
+    setActiveLabelId(null);
+    setScrollToLine(null);
+  }, [clearEditorState, setActiveLabelId]);
 
-  useEffect(() => {
-    const unregister = registerModeFlushHandler("script", async () => {
-      return await triggerFileSaveRef.current();
-    });
+  const handleFileActivated = useCallback(() => {
+    setScrollToLine(null);
+    setActiveLabelId(null);
+  }, [setActiveLabelId]);
 
-    return unregister;
+  const {
+    activeFileId,
+    tabItems,
+    selectFileTab,
+    handleCloseFileTab,
+    clearTabsState,
+  } = useFileTabs({
+    projectId,
+    projectFiles,
+    isLoadingFiles,
+    isResettingRef,
+    onFileSelect: handleScriptFileSelect,
+    onFileActivated: handleFileActivated,
+    onNoTabsRemaining: handleNoTabsRemaining,
+  });
+
+  const { resetRefreshState } = useScriptModeRefresh({
+    projectId,
+    isLoadingFiles,
+    refreshFiles,
+  });
+
+  const hasPendingSave =
+    !!currentEditFileId && (isFileDirty || fileSaveStatus === "error");
+
+  const handleResetState = useCallback(() => {
+    resetRefreshState();
+    clearTabsState();
+    void clearEditorState();
+    setScrollToLine(null);
+  }, [clearEditorState, clearTabsState, resetRefreshState]);
+
+  const setSkipSave = useCallback((value: boolean) => {
+    skipSaveRef.current = value;
   }, []);
 
-  // Flush pending file save on unmount (e.g., mode switch Script -> Write)
-  useEffect(() => {
-    return () => {
-      // Always trigger on unmount so we don't miss very recent edits during
-      // rapid mode switches; useAutosave will no-op if nothing changed.
-      void triggerFileSaveRef.current();
-    };
-  }, []);
+  useProjectReset({
+    projectId,
+    isResettingRef,
+    hasPendingSave,
+    triggerSave: triggerFileSave,
+    showErrorToast,
+    setSkipSave,
+    onReset: handleResetState,
+  });
 
-  // Track active file for Script Mode
-  const [activeFileId, setActiveFileId] = useState<string | null>(null);
+  const handleLabelDrivenFileSelect = useCallback(
+    async (fileId: string) => {
+      return await selectFileTab(fileId, { notify: false });
+    },
+    [selectFileTab]
+  );
+
+  useLabelFileSync({
+    projectFiles,
+    activeLabelId,
+    onFileSelect: handleLabelDrivenFileSelect,
+    onSetScrollToLine: setScrollToLine,
+  });
+
+  useFocusModeKeyboardHandler(handleFocusModeToggle);
+
   const activeProjectFile = useMemo(
-    () => projectFiles.find((f) => f.id === activeFileId) || null,
-    [projectFiles, activeFileId]
+    () => projectFiles.find((file) => file.id === activeFileId) || null,
+    [activeFileId, projectFiles]
   );
 
   const { characters: projectCharacters } = useCharacters(projectId ?? "");
@@ -285,349 +229,32 @@ export function ScriptMode({
         ? "var(--theme-review-color)"
         : "var(--theme-draft-color)";
 
-  // Track the line number to scroll to when switching modes
-  const [scrollToLine, setScrollToLine] = useState<number | null>(null);
-
-  // Helper: Find the line number where a label starts in the file content
-  const findLabelLineNumber = useCallback(
-    (fileContent: string, labelTitle: string): number | null => {
-      const labelName = sanitizeLabelName(labelTitle);
-      const lines = fileContent.split("\n");
-
-      // Find the line with "label {name}:" pattern
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i].trim();
-        if (line.startsWith("label ") && line.endsWith(":")) {
-          const extractedLabel = line.slice(6, -1).trim();
-          if (extractedLabel === labelName) {
-            return i + 1; // Line numbers are 1-indexed
-          }
-        }
-      }
-
-      return null;
-    },
-    []
-  );
-
-  // Helper: Switch to a file with dirty state checking
-  // Auto-saves unsaved changes before switching to prevent data loss
-  const switchToFile = useCallback(
-    async (file: { id: string; content: string }) => {
-      // Skip if already on this file
-      if (currentEditFileId === file.id) {
-        return true;
-      }
-
-      // Save unsaved changes before switching
-      if (currentEditFileId && (isFileDirty || fileSaveStatus === "error")) {
-        const flushed = await triggerFileSave();
-        if (!flushed) {
-          showErrorToast(
-            "Could not save pending edits. Resolve the save error before switching files.",
-            "File switch blocked"
-          );
-          return false;
-        }
-      }
-
-      // Switch to the new file
-      setActiveFileId(file.id);
-      setOpenTabs((prev) => {
-        if (prev.includes(file.id)) {
-          return prev;
-        }
-        return [...prev, file.id];
-      });
-      setEditedFileContent(file.content);
-      setCurrentEditFileId(file.id);
-      const nextFile = projectFiles.find((f) => f.id === file.id);
-      setCurrentEditFileHash(nextFile?.contentHash ?? null);
-      setHasSaveConflict(false);
-      resetSavedHash(file.content);
-      return true;
-    },
-    [
-      currentEditFileId,
-      isFileDirty,
-      fileSaveStatus,
-      triggerFileSave,
-      resetSavedHash,
-      projectFiles,
-      showErrorToast,
-    ]
-  );
-
-  // When script mode has an active label, select its file and scroll to the label line
-  useEffect(() => {
-    if (!activeLabelId) {
-      return;
-    }
-
-    const fileWithLabel = projectFiles.find((f) =>
-      f.labels.some((l) => l.id === activeLabelId)
-    );
-
-    if (!fileWithLabel) {
-      return;
-    }
-
-    const labelMetadata = fileWithLabel.labels.find(
-      (l) => l.id === activeLabelId
-    );
-    if (!labelMetadata) {
-      setScrollToLine(null);
-      return;
-    }
-
-    const lineNumber = findLabelLineNumber(
-      fileWithLabel.content,
-      labelMetadata.title
-    );
-
-    // Switch to the file with dirty state checking, then scroll to label
-    void (async () => {
-      const switched = await switchToFile(fileWithLabel);
-      if (!switched) {
-        return;
-      }
-      setScrollToLine(lineNumber);
-    })();
-  }, [activeLabelId, projectFiles, findLabelLineNumber, switchToFile]);
-
-  // Refresh files on mount to ensure fresh data when switching from write mode
-  // This ensures that any changes made in write mode are reflected immediately
-  const hasRefreshed = useRef(false);
-  useEffect(() => {
-    if (projectId && !isLoadingFiles && !hasRefreshed.current) {
-      refreshFiles();
-      hasRefreshed.current = true;
-    }
-  }, [projectId, isLoadingFiles, refreshFiles]);
-
-  // Persist open tabs after project state has been hydrated from storage
-  useEffect(() => {
-    if (tabsStorageKey && hydratedTabsProjectId === projectId) {
-      writeLocalStorageItem(tabsStorageKey, JSON.stringify(openTabs));
-    }
-  }, [openTabs, projectId, tabsStorageKey, hydratedTabsProjectId]);
-
-  // Persist active file to localStorage
-  useEffect(() => {
-    if (!activeFileStorageKey || hydratedTabsProjectId !== projectId) {
-      return;
-    }
-
-    if (activeFileId) {
-      writeLocalStorageItem(activeFileStorageKey, activeFileId);
-    } else {
-      removeLocalStorageItem(activeFileStorageKey);
-    }
-  }, [activeFileId, activeFileStorageKey, projectId, hydratedTabsProjectId]);
-
-  // Refs for project reset effect to avoid unwanted reruns
-  const currentEditFileIdRef = useRef(currentEditFileId);
-  const isFileDirtyRef = useRef(isFileDirty);
-  const fileSaveStatusRef = useRef(fileSaveStatus);
-  const showErrorToastRef = useRef(showErrorToast);
-
-  useEffect(() => {
-    currentEditFileIdRef.current = currentEditFileId;
-  }, [currentEditFileId]);
-
-  useEffect(() => {
-    isFileDirtyRef.current = isFileDirty;
-  }, [isFileDirty]);
-
-  useEffect(() => {
-    fileSaveStatusRef.current = fileSaveStatus;
-  }, [fileSaveStatus]);
-
-  useEffect(() => {
-    showErrorToastRef.current = showErrorToast;
-  }, [showErrorToast]);
-
-  useEffect(() => {
-    const resetId = ++currentResetIdRef.current;
-
-    (async () => {
-      isResettingRef.current = true;
-      skipSaveRef.current = true;
-
-      try {
-        if (
-          currentEditFileIdRef.current &&
-          (isFileDirtyRef.current || fileSaveStatusRef.current === "error")
-        ) {
-          if (resetId !== currentResetIdRef.current) {
-            return;
-          }
-          const flushed = await triggerFileSaveRef.current();
-          if (!flushed) {
-            showErrorToastRef.current(
-              "Could not save pending edits. The save failed when switching projects.",
-              "Project switch warning"
-            );
-          }
-        }
-
-        if (resetId !== currentResetIdRef.current) {
-          return;
-        }
-
-        hasRefreshed.current = false;
-        setHydratedTabsProjectId(undefined);
-        setOpenTabs([]);
-        setActiveFileId(null);
-        setCurrentEditFileId(null);
-        setCurrentEditFileHash(null);
-        setEditedFileContent("");
-        setScrollToLine(null);
-        setHasSaveConflict(false);
-      } finally {
-        if (resetId === currentResetIdRef.current) {
-          isResettingRef.current = false;
-          Promise.resolve().then(() => {
-            if (resetId === currentResetIdRef.current) {
-              skipSaveRef.current = false;
-            }
-          });
-        }
-      }
-    })();
-  }, [projectId]);
-
-  // Handle Ctrl+S for immediate save
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.code === "KeyS") {
-        e.preventDefault();
-        triggerFileSave();
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [triggerFileSave]);
-
-  useFocusModeKeyboardHandler(handleFocusModeToggle);
-
-  // Get active file content directly for Script Mode editing
-  // Use edited content if available, otherwise use original content
   const activeFileContent =
     activeProjectFile && currentEditFileId === activeProjectFile.id
       ? editedFileContent
       : activeProjectFile?.content || "";
 
-  // Handle GitLab file selection
-  const handleGitLabFileSelect = (fileId: string) => {
-    const file = projectFiles.find((f) => f.id === fileId);
-    if (!file) {
-      return;
-    }
-
-    void (async () => {
-      const switched = await switchToFile(file);
-      if (!switched) {
-        return;
-      }
-      setScrollToLine(null);
-      // Also clear the active scene since we're now in file mode
-      setActiveLabelId(null);
-    })();
-  };
+  const handleGitLabFileSelect = useCallback(
+    (fileId: string) => {
+      void selectFileTab(fileId);
+    },
+    [selectFileTab]
+  );
 
   const handleSelectFileTab = useCallback(
     async (fileId: string) => {
-      const file = projectFiles.find(
-        (projectFile) => projectFile.id === fileId
-      );
-      if (!file) {
-        return;
-      }
-
-      const switched = await switchToFile(file);
-      if (!switched) {
-        return;
-      }
-
-      setScrollToLine(null);
-      setActiveLabelId(null);
+      await selectFileTab(fileId);
     },
-    [projectFiles, switchToFile, setActiveLabelId]
+    [selectFileTab]
   );
 
-  const handleCloseFileTab = useCallback(
-    (e: React.MouseEvent | React.KeyboardEvent, fileId: string) => {
-      e.stopPropagation();
-
-      const isActive = fileId === activeFileId;
-      setOpenTabs((prev) => {
-        const index = prev.indexOf(fileId);
-        if (index === -1) {
-          return prev;
-        }
-
-        return prev.filter((id) => id !== fileId);
-      });
-
-      if (isActive) {
-        const nextTabs = openTabs.filter((id) => id !== fileId);
-
-        if (nextTabs.length === 0) {
-          setActiveFileId(null);
-          setCurrentEditFileId(null);
-          setCurrentEditFileHash(null);
-          setEditedFileContent("");
-          setActiveLabelId(null);
-          setScrollToLine(null);
-        } else {
-          const index = openTabs.indexOf(fileId);
-          const fallbackFileId = openTabs[index - 1] ?? nextTabs[0];
-
-          void handleSelectFileTab(fallbackFileId);
-        }
-      }
+  const handleGitLabSceneSelect = useCallback(
+    (sceneId: string) => {
+      setActiveLabelId(sceneId);
     },
-    [
-      activeFileId,
-      openTabs,
-      handleSelectFileTab,
-      setActiveLabelId,
-      setActiveFileId,
-      setCurrentEditFileId,
-      setCurrentEditFileHash,
-      setEditedFileContent,
-      setScrollToLine,
-    ]
+    [setActiveLabelId]
   );
 
-  // Update edited content when active file changes (manual selection)
-  useEffect(() => {
-    if (activeProjectFile && activeProjectFile.id !== currentEditFileId) {
-      void switchToFile(activeProjectFile);
-    }
-  }, [activeProjectFile, switchToFile, currentEditFileId]);
-
-  useEffect(() => {
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (!isFileDirty) {
-        return;
-      }
-      event.preventDefault();
-      event.returnValue = "";
-    };
-
-    window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [isFileDirty]);
-
-  // Handle GitLab scene selection (label within a file)
-  const handleGitLabSceneSelect = (sceneId: string) => {
-    setActiveLabelId(sceneId);
-  };
-
-  // Determine which folders should be expanded by default
   const initialExpandedFolders = useMemo(() => {
     const folders = new Set<string>();
     for (const file of projectFiles) {
@@ -639,380 +266,97 @@ export function ScriptMode({
     return Array.from(folders);
   }, [projectFiles]);
 
-  const tabItems = useMemo<EditorTabBarItem[]>(
-    () =>
-      openTabs
-        .map((tabId) =>
-          projectFiles.find((projectFile) => projectFile.id === tabId)
-        )
-        .filter((file): file is NonNullable<typeof file> => file !== undefined)
-        .map((file) => {
-          const fileName = file.filePath.split("/").pop() || file.filePath;
-          const fileKind = file.fileType === "SETTINGS" ? "Settings" : "Story";
-
-          return {
-            id: file.id,
-            title: fileName,
-            meta: fileKind,
-            closeLabel: `Close ${fileName}`,
-          };
-        }),
-    [openTabs, projectFiles]
-  );
-
-  // Load persisted tabs and active file once per project after files load
-  useEffect(() => {
-    if (
-      !projectId ||
-      isLoadingFiles ||
-      hydratedTabsProjectId === projectId ||
-      isResettingRef.current
-    ) {
-      return;
-    }
-
-    const fileIds = new Set(projectFiles.map((file) => file.id));
-    const savedTabsRaw = tabsStorageKey
-      ? readLocalStorageItem(tabsStorageKey)
-      : null;
-
-    let nextOpenTabs: string[] = [];
-    if (savedTabsRaw) {
-      try {
-        const parsedTabs = JSON.parse(savedTabsRaw) as unknown;
-        if (Array.isArray(parsedTabs)) {
-          nextOpenTabs = parsedTabs.filter(
-            (id): id is string => typeof id === "string" && fileIds.has(id)
-          );
-        }
-      } catch {
-        // Invalid JSON, ignore
-      }
-    }
-
-    const savedActiveFileId = activeFileStorageKey
-      ? readLocalStorageItem(activeFileStorageKey)
-      : null;
-    const resolvedActiveFileId =
-      savedActiveFileId && fileIds.has(savedActiveFileId)
-        ? savedActiveFileId
-        : activeFileId && fileIds.has(activeFileId)
-          ? activeFileId
-          : null;
-
-    if (resolvedActiveFileId && !nextOpenTabs.includes(resolvedActiveFileId)) {
-      nextOpenTabs = [...nextOpenTabs, resolvedActiveFileId];
-    }
-
-    setOpenTabs(nextOpenTabs);
-
-    const loadActiveFile = async () => {
-      try {
-        if (resolvedActiveFileId && resolvedActiveFileId !== activeFileId) {
-          await handleSelectFileTab(resolvedActiveFileId);
-        }
-      } finally {
-        setHydratedTabsProjectId(projectId);
-      }
-    };
-
-    void loadActiveFile();
-  }, [
-    projectId,
-    isLoadingFiles,
-    projectFiles,
-    tabsStorageKey,
-    activeFileStorageKey,
-    activeFileId,
-    handleSelectFileTab,
-    hydratedTabsProjectId,
-  ]);
-
-  // Keep tab bar aligned with externally changed active file
-  useEffect(() => {
-    if (
-      !activeFileId ||
-      !projectFiles.some((file) => file.id === activeFileId)
-    ) {
-      return;
-    }
-
-    setOpenTabs((prev) => {
-      if (prev.includes(activeFileId)) {
-        return prev;
-      }
-      return [...prev, activeFileId];
-    });
-  }, [activeFileId, projectFiles]);
-
-  // Prune tabs if files disappear from the project
-  useEffect(() => {
-    const fileIds = new Set(projectFiles.map((file) => file.id));
-    setOpenTabs((prev) => {
-      const nextTabs = prev.filter((tabId) => fileIds.has(tabId));
-      return nextTabs.length === prev.length ? prev : nextTabs;
-    });
-  }, [projectFiles]);
-
   const isLinked = projectId ? isProjectLinked(projectId) : false;
   const linkedRepo = projectId ? getLinkedRepository(projectId) : null;
 
-  // Determine the primary file source type from project files
-  // If no files exist but project is GitLab-linked, assume GITLAB type
   const primaryFileSourceType: FileSourceType | undefined = useMemo(() => {
     if (projectFiles.length === 0) {
-      // No files yet - check if project is GitLab-linked
       if (isLinked) {
         return "GITLAB";
       }
       return undefined;
     }
-    // Use the first file's source type as the primary type
-    // (projects typically use a single source type)
+
     return projectFiles[0].sourceType;
   }, [projectFiles, isLinked]);
 
-  // Loading state
+  const statusBar = (
+    <StatusBar
+      language="Ren'Py"
+      projectId={projectId}
+      projectName={projectName}
+      gitlabBranch={gitlabBranch}
+      fileSourceType={primaryFileSourceType}
+      saveStatus={activeProjectFile ? fileSaveStatus : undefined}
+      saveConflict={activeProjectFile ? hasSaveConflict : undefined}
+      onSaveRequest={activeProjectFile ? retryFileSave : undefined}
+    />
+  );
+
   if (isLoadingLabels || isLoadingFiles) {
     return (
-      <div className="flex-1 flex flex-col pt-16">
-        <div className="flex-1 flex items-center justify-center">
-          <p className="text-muted-foreground">Loading labels...</p>
+      <div className="h-screen flex flex-col overflow-hidden">
+        <div className="flex-1 flex flex-col pt-16">
+          <div className="flex-1 flex items-center justify-center">
+            <p className="text-muted-foreground">Loading project...</p>
+          </div>
         </div>
+        {statusBar}
       </div>
     );
   }
 
-  // No files state
   if (!projectFiles.length) {
     return (
-      <div className="flex-1 flex flex-col pt-16">
-        <div className="flex-1 flex flex-col items-center justify-center gap-4">
-          <p className="text-muted-foreground">No files imported yet</p>
-          <p className="text-sm text-muted-foreground">
-            Import from GitLab or import from a zip file to get started
-          </p>
-          <div className="flex gap-2">
-            {isLinked && (
-              <Button
-                variant="outline"
-                onClick={() => setShowSyncDialog(true)}
-                className="mt-2"
-              >
-                <Download className="w-4 h-4 mr-2" />
-                Import from GitLab
-              </Button>
-            )}
-            <Button
-              variant="outline"
-              onClick={() => setShowZipImportDialog(true)}
-              className="mt-2"
-            >
-              <Package className="w-4 h-4 mr-2" />
-              Import from Zip
-            </Button>
-          </div>
-        </div>
-
-        {/* Sync Dialog */}
-        {projectId && isLinked && linkedRepo && (
-          <GitLabSyncDialog
-            open={showSyncDialog}
-            onOpenChange={setShowSyncDialog}
-            operationType="import"
-            projectId={projectId}
-            projectName={projectName}
-            defaultBranch={linkedRepo.defaultBranch}
-          />
-        )}
-
-        {/* Zip Import Dialog */}
-        {projectId && (
-          <ZipImportDialog
-            open={showZipImportDialog}
-            onOpenChange={setShowZipImportDialog}
-            projectId={projectId}
-            projectName={projectName}
-          />
-        )}
+      <div className="h-screen flex flex-col overflow-hidden">
+        <ScriptModeEmptyState
+          projectId={projectId}
+          projectName={projectName}
+          isLinked={isLinked}
+          linkedRepoDefaultBranch={linkedRepo?.defaultBranch ?? undefined}
+          showSyncDialog={showSyncDialog}
+          onShowSyncDialogChange={setShowSyncDialog}
+          showZipImportDialog={showZipImportDialog}
+          onShowZipImportDialogChange={setShowZipImportDialog}
+        />
+        {statusBar}
       </div>
     );
   }
 
   return (
     <div className="h-screen flex flex-col overflow-hidden">
-      {/* Floating Focus Mode Toggle (shown when focus mode is ON) */}
-      {isFocusMode && (
-        <div className="fixed top-2 right-2 z-[100] pointer-events-auto">
-          <FocusModeToggle
-            ref={focusToggleRef}
-            isFocusMode={isFocusMode}
-            onToggle={handleFocusModeToggle}
-          />
-        </div>
-      )}
-
-      {/* Main Editor Layout */}
-      <div className="flex-1 flex gap-4 px-4 pb-4 overflow-hidden min-h-0 min-w-0">
-        {/* Left Sidebar */}
-        <div
-          aria-hidden={isFocusMode}
-          inert={isFocusMode}
-          className={sidebarVariants({
-            variant:
-              isFocusMode || isLeftSidebarCollapsed ? "collapsed" : "expanded",
-          })}
-        >
-          <div className="h-full overflow-y-auto relative">
-            <div className="sticky top-0 z-20 bg-card border-b border-border pl-10 pr-4 py-3">
-              <button
-                onClick={() => setIsLeftSidebarCollapsed(true)}
-                className="absolute top-2 left-2 z-30 p-1 rounded-md hover:bg-muted/80 transition-colors"
-                aria-label="Collapse project files sidebar"
-                title="Collapse project files sidebar"
-              >
-                <ChevronLeft className="w-4 h-4 text-muted-foreground" />
-              </button>
-              <div className="flex items-center gap-3">
-                <div className="w-7 h-7 rounded bg-[var(--theme-color)] flex items-center justify-center shadow-sm shrink-0">
-                  <Sparkles className="w-4 h-4 text-white" />
-                </div>
-                <div className="min-w-0">
-                  <span className="text-sm font-medium block truncate">
-                    {projectName || "Script Mode"}
-                  </span>
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    {projectFiles.length} file
-                    {projectFiles.length !== 1 ? "s" : ""}
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <div className="p-3 space-y-3">
-              <button
-                type="button"
-                className="w-full py-2 px-3 rounded-lg text-sm font-medium transition-colors bg-[var(--theme-color)] text-white hover:opacity-90"
-              >
-                + New Chapter
-              </button>
-
-              <ProjectFileTree
-                files={projectFiles}
-                activeFileId={activeFileId ?? undefined}
-                activeSceneId={activeLabelId ?? undefined}
-                onFileSelect={handleGitLabFileSelect}
-                onSceneSelect={handleGitLabSceneSelect}
-                initialExpandedFolders={initialExpandedFolders}
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* Left Sidebar Expand Button (shown when collapsed and not in focus mode) */}
-        {isLeftSidebarCollapsed && !isFocusMode && (
-          <div className="min-h-0 shrink-0 mt-3 flex items-center -ml-4">
-            <button
-              onClick={() => setIsLeftSidebarCollapsed(false)}
-              className="p-2 rounded-lg border border-border bg-card/50 hover:bg-muted/80 transition-colors"
-              aria-label="Expand project files sidebar"
-              title="Expand project files sidebar"
-            >
-              <ChevronRight className="w-4 h-4 text-muted-foreground" />
-            </button>
-          </div>
-        )}
-
-        {/* Center Column: Tab Bar + Editor */}
-        <div className="flex-1 flex flex-col min-h-0 min-w-0 mt-3">
-          {!isFocusMode && (
-            <div className="mb-2 flex gap-2">
-              <div className="flex-1 min-w-0">
-                <EditorTabBar
-                  items={tabItems}
-                  activeItemId={activeFileId}
-                  onSelect={handleSelectFileTab}
-                  onClose={handleCloseFileTab}
-                  idPrefix="script-tab-"
-                  titleMaxWidthClassName="max-w-[240px]"
-                />
-              </div>
-              <div className="h-12 overflow-hidden rounded-lg border border-border/80 bg-card/55 opacity-100 backdrop-blur-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
-                <div className="h-full flex items-center justify-end px-3">
-                  <FocusModeToggle
-                    ref={focusToggleRef}
-                    isFocusMode={isFocusMode}
-                    onToggle={handleFocusModeToggle}
-                  />
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Main Editor */}
-          <div className="flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
-            <div className="bg-card/50 border border-border rounded-lg h-full overflow-hidden min-h-0 min-w-0">
-              {activeProjectFile ? (
-                <ScriptEditor
-                  ref={editorRef}
-                  content={activeFileContent}
-                  scrollToLine={scrollToLine}
-                  onChange={(value) => {
-                    setEditedFileContent(value);
-                  }}
-                />
-              ) : activeLabel ? (
-                <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-3">
-                  <div className="flex items-center gap-2 text-destructive">
-                    <X size={16} />
-                    <span className="font-medium">Scene not found</span>
-                  </div>
-                  <p className="text-sm max-w-md text-center">
-                    The file containing this scene could not be found. It may
-                    have been deleted or there was an error loading the project
-                    files.
-                  </p>
-                  <Button variant="outline" size="sm" onClick={refreshFiles}>
-                    Refresh files
-                  </Button>
-                </div>
-              ) : (
-                <div className="flex items-center justify-center h-full text-muted-foreground">
-                  Select a file or scene to view its content
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-
-        {/* Right Sidebar */}
-        <CharacterReferencePanel
-          sceneCharacters={sceneCharacters}
-          projectCharacters={projectCharacters}
-          activeLabel={activeLabel}
-          statusColor={statusColor}
-          isCollapsed={isRightSidebarCollapsed || isFocusMode}
-          onCollapseToggle={
-            !isFocusMode
-              ? () => setIsRightSidebarCollapsed((prev) => !prev)
-              : undefined
-          }
-        />
-      </div>
-
-      {/* Status Bar */}
-      <StatusBar
-        language="Ren'Py"
-        projectId={projectId}
+      <ScriptModeEditorLayout
         projectName={projectName}
-        gitlabBranch={gitlabBranch}
-        fileSourceType={primaryFileSourceType}
-        saveStatus={activeProjectFile ? fileSaveStatus : undefined}
-        saveConflict={activeProjectFile ? hasSaveConflict : undefined}
-        onSaveRequest={activeProjectFile ? retryFileSave : undefined}
+        projectFiles={projectFiles}
+        activeFileId={activeFileId}
+        activeLabelId={activeLabelId}
+        activeLabel={activeLabel}
+        activeProjectFile={activeProjectFile}
+        activeFileContent={activeFileContent}
+        scrollToLine={scrollToLine}
+        initialExpandedFolders={initialExpandedFolders}
+        tabItems={tabItems}
+        sceneCharacters={sceneCharacters}
+        projectCharacters={projectCharacters}
+        statusColor={statusColor}
+        isLeftSidebarCollapsed={isLeftSidebarCollapsed}
+        setIsLeftSidebarCollapsed={setIsLeftSidebarCollapsed}
+        isRightSidebarCollapsed={isRightSidebarCollapsed}
+        setIsRightSidebarCollapsed={setIsRightSidebarCollapsed}
+        focusModeState={focusModeState}
+        editorRef={editorRef}
+        onFocusModeToggle={handleFocusModeToggle}
+        onFileSelect={handleGitLabFileSelect}
+        onSceneSelect={handleGitLabSceneSelect}
+        onSelectTab={handleSelectFileTab}
+        onCloseTab={handleCloseFileTab}
+        onContentChange={setEditedFileContent}
+        onRefreshFiles={refreshFiles}
       />
 
-      {/* Sync Dialog */}
+      {statusBar}
+
       {projectId && isLinked && linkedRepo && (
         <GitLabSyncDialog
           open={showSyncDialog}
@@ -1024,7 +368,6 @@ export function ScriptMode({
         />
       )}
 
-      {/* Zip Import Dialog (always available for non-empty projects too) */}
       {projectId && (
         <ZipImportDialog
           open={showZipImportDialog}

--- a/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
+++ b/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
@@ -1,0 +1,256 @@
+import { useCallback } from "react";
+import { Sparkles, X, ChevronRight, ChevronLeft } from "lucide-react";
+import { cva } from "class-variance-authority";
+import {
+  CharacterReferencePanel,
+  ScriptEditor,
+} from "@/components/script-mode";
+import { ProjectFileTree } from "@/components/script-mode/ProjectFileTree";
+import { FocusModeToggle } from "@/components/write-mode/FocusModeToggle";
+import { EditorTabBar, type EditorTabBarItem } from "@/components/ide-shared";
+import { Button } from "@/components/ui/button";
+import type { LabelDetail } from "@branchforge/shared";
+import type { Character } from "@branchforge/shared";
+import type { ScriptEditorRef } from "@/components/script-mode/ScriptEditor";
+import type { FocusModeState } from "@/hooks/useFocusModeState";
+import type { ProjectFileNode } from "@/hooks/useProjectFiles";
+import type {
+  Dispatch,
+  KeyboardEvent,
+  MouseEvent,
+  RefObject,
+  SetStateAction,
+} from "react";
+
+const sidebarVariants = cva(
+  "min-h-0 shrink-0 rounded-lg border border-border bg-card/50 overflow-hidden mt-3 transition-all duration-300 ease-out",
+  {
+    variants: {
+      variant: {
+        collapsed: "w-0 opacity-0 -translate-x-full pointer-events-none",
+        expanded: "w-56 opacity-100 translate-x-0",
+      },
+    },
+    defaultVariants: {
+      variant: "expanded",
+    },
+  }
+);
+
+interface ScriptModeEditorLayoutProps {
+  projectName?: string;
+  projectFiles: ProjectFileNode[];
+  activeFileId: string | null;
+  activeLabelId: string | null;
+  activeLabel: LabelDetail | undefined;
+  activeProjectFile: ProjectFileNode | null;
+  activeFileContent: string;
+  scrollToLine: number | null;
+  initialExpandedFolders: string[];
+  tabItems: EditorTabBarItem[];
+  sceneCharacters: LabelDetail["characters"];
+  projectCharacters: Character[];
+  statusColor: string;
+  isLeftSidebarCollapsed: boolean;
+  setIsLeftSidebarCollapsed: Dispatch<SetStateAction<boolean>>;
+  isRightSidebarCollapsed: boolean;
+  setIsRightSidebarCollapsed: Dispatch<SetStateAction<boolean>>;
+  focusModeState: FocusModeState;
+  editorRef: RefObject<ScriptEditorRef | null>;
+  onFocusModeToggle: () => void;
+  onFileSelect: (fileId: string) => void;
+  onSceneSelect: (sceneId: string) => void;
+  onSelectTab: (fileId: string) => void | Promise<void>;
+  onCloseTab: (event: MouseEvent | KeyboardEvent, fileId: string) => void;
+  onContentChange: (value: string) => void;
+  onRefreshFiles: () => Promise<unknown>;
+  onNewChapter?: () => void;
+}
+
+export function ScriptModeEditorLayout({
+  projectName,
+  projectFiles,
+  activeFileId,
+  activeLabelId,
+  activeLabel,
+  activeProjectFile,
+  activeFileContent,
+  scrollToLine,
+  initialExpandedFolders,
+  tabItems,
+  sceneCharacters,
+  projectCharacters,
+  statusColor,
+  isLeftSidebarCollapsed,
+  setIsLeftSidebarCollapsed,
+  isRightSidebarCollapsed,
+  setIsRightSidebarCollapsed,
+  focusModeState,
+  editorRef,
+  onFocusModeToggle,
+  onFileSelect,
+  onSceneSelect,
+  onSelectTab,
+  onCloseTab,
+  onContentChange,
+  onRefreshFiles,
+  onNewChapter,
+}: ScriptModeEditorLayoutProps) {
+  const { isFocusMode, focusToggleRef } = focusModeState;
+
+  const toggleRightSidebar = useCallback(
+    () => setIsRightSidebarCollapsed((previous) => !previous),
+    [setIsRightSidebarCollapsed]
+  );
+
+  return (
+    <>
+      {isFocusMode && (
+        <div className="fixed top-2 right-2 z-[100] pointer-events-auto">
+          <FocusModeToggle
+            ref={focusToggleRef}
+            isFocusMode={isFocusMode}
+            onToggle={onFocusModeToggle}
+          />
+        </div>
+      )}
+
+      <div className="flex-1 flex gap-4 px-4 pb-4 overflow-hidden min-h-0 min-w-0">
+        <div
+          aria-hidden={isFocusMode}
+          className={sidebarVariants({
+            variant:
+              isFocusMode || isLeftSidebarCollapsed ? "collapsed" : "expanded",
+          })}
+        >
+          <div className="h-full overflow-y-auto relative">
+            <div className="sticky top-0 z-20 bg-card border-b border-border pl-10 pr-4 py-3">
+              <button
+                onClick={() => setIsLeftSidebarCollapsed(true)}
+                className="absolute top-2 left-2 z-30 p-1 rounded-md hover:bg-muted/80 transition-colors"
+                aria-label="Collapse project files sidebar"
+                title="Collapse project files sidebar"
+              >
+                <ChevronLeft className="w-4 h-4 text-muted-foreground" />
+              </button>
+              <div className="flex items-center gap-3">
+                <div className="w-7 h-7 rounded bg-[var(--theme-color)] flex items-center justify-center shadow-sm shrink-0">
+                  <Sparkles className="w-4 h-4 text-white" />
+                </div>
+                <div className="min-w-0">
+                  <span className="text-sm font-medium block truncate">
+                    {projectName || "Script Mode"}
+                  </span>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {projectFiles.length} file
+                    {projectFiles.length !== 1 ? "s" : ""}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="p-3 space-y-3">
+              <button
+                type="button"
+                onClick={onNewChapter}
+                disabled={!onNewChapter}
+                className="w-full py-2 px-3 rounded-lg text-sm font-medium transition-colors bg-[var(--theme-color)] text-white hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                + New Chapter
+              </button>
+
+              <ProjectFileTree
+                files={projectFiles}
+                activeFileId={activeFileId ?? undefined}
+                activeSceneId={activeLabelId ?? undefined}
+                onFileSelect={onFileSelect}
+                onSceneSelect={onSceneSelect}
+                initialExpandedFolders={initialExpandedFolders}
+              />
+            </div>
+          </div>
+        </div>
+
+        {isLeftSidebarCollapsed && !isFocusMode && (
+          <div className="min-h-0 shrink-0 mt-3 flex items-center -ml-4">
+            <button
+              onClick={() => setIsLeftSidebarCollapsed(false)}
+              className="p-2 rounded-lg border border-border bg-card/50 hover:bg-muted/80 transition-colors"
+              aria-label="Expand project files sidebar"
+              title="Expand project files sidebar"
+            >
+              <ChevronRight className="w-4 h-4 text-muted-foreground" />
+            </button>
+          </div>
+        )}
+
+        <div className="flex-1 flex flex-col min-h-0 min-w-0 mt-3">
+          {!isFocusMode && (
+            <div className="mb-2 flex gap-2">
+              <div className="flex-1 min-w-0">
+                <EditorTabBar
+                  items={tabItems}
+                  activeItemId={activeFileId}
+                  onSelect={onSelectTab}
+                  onClose={onCloseTab}
+                  idPrefix="script-tab-"
+                  titleMaxWidthClassName="max-w-[240px]"
+                />
+              </div>
+              <div className="h-12 overflow-hidden rounded-lg border border-border/80 bg-card/55 opacity-100 backdrop-blur-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
+                <div className="h-full flex items-center justify-end px-3">
+                  <FocusModeToggle
+                    ref={focusToggleRef}
+                    isFocusMode={isFocusMode}
+                    onToggle={onFocusModeToggle}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
+            <div className="bg-card/50 border border-border rounded-lg h-full overflow-hidden min-h-0 min-w-0">
+              {activeProjectFile ? (
+                <ScriptEditor
+                  ref={editorRef}
+                  content={activeFileContent}
+                  scrollToLine={scrollToLine}
+                  onChange={onContentChange}
+                />
+              ) : activeLabel ? (
+                <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-3">
+                  <div className="flex items-center gap-2 text-destructive">
+                    <X size={16} />
+                    <span className="font-medium">Scene not found</span>
+                  </div>
+                  <p className="text-sm max-w-md text-center">
+                    The file containing this scene could not be found. It may
+                    have been deleted or there was an error loading the project
+                    files.
+                  </p>
+                  <Button variant="outline" size="sm" onClick={onRefreshFiles}>
+                    Refresh files
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex items-center justify-center h-full text-muted-foreground">
+                  Select a file or scene to view its content
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <CharacterReferencePanel
+          sceneCharacters={sceneCharacters}
+          projectCharacters={projectCharacters}
+          activeLabel={activeLabel}
+          statusColor={statusColor}
+          isCollapsed={isRightSidebarCollapsed || isFocusMode}
+          onCollapseToggle={!isFocusMode ? toggleRightSidebar : undefined}
+        />
+      </div>
+    </>
+  );
+}

--- a/apps/frontend/src/pages/ide/components/ScriptModeEmptyState.tsx
+++ b/apps/frontend/src/pages/ide/components/ScriptModeEmptyState.tsx
@@ -1,0 +1,80 @@
+import { Download, Package } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { GitLabSyncDialog } from "@/components/script-mode/GitLabSyncDialog";
+import { ZipImportDialog } from "@/components/zip-import";
+
+interface ScriptModeEmptyStateProps {
+  projectId?: string;
+  projectName?: string;
+  isLinked: boolean;
+  linkedRepoDefaultBranch?: string;
+  showSyncDialog: boolean;
+  onShowSyncDialogChange: (open: boolean) => void;
+  showZipImportDialog: boolean;
+  onShowZipImportDialogChange: (open: boolean) => void;
+}
+
+export function ScriptModeEmptyState({
+  projectId,
+  projectName,
+  isLinked,
+  linkedRepoDefaultBranch,
+  showSyncDialog,
+  onShowSyncDialogChange,
+  showZipImportDialog,
+  onShowZipImportDialogChange,
+}: ScriptModeEmptyStateProps) {
+  return (
+    <div className="flex-1 flex flex-col pt-16">
+      <div className="flex-1 flex flex-col items-center justify-center gap-4">
+        <p className="text-muted-foreground">No files imported yet</p>
+        <p className="text-sm text-muted-foreground">
+          {isLinked
+            ? "Import from GitLab or import from a zip file to get started"
+            : "Import from a zip file to get started"}
+        </p>
+        <div className="flex gap-2">
+          {projectId && isLinked && linkedRepoDefaultBranch && (
+            <Button
+              variant="outline"
+              onClick={() => onShowSyncDialogChange(true)}
+              className="mt-2"
+            >
+              <Download className="w-4 h-4 mr-2" />
+              Import from GitLab
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            onClick={() => onShowZipImportDialogChange(true)}
+            className="mt-2"
+            disabled={!projectId}
+          >
+            <Package className="w-4 h-4 mr-2" />
+            Import from Zip
+          </Button>
+        </div>
+      </div>
+
+      {projectId && isLinked && linkedRepoDefaultBranch && (
+        <GitLabSyncDialog
+          open={showSyncDialog}
+          onOpenChange={onShowSyncDialogChange}
+          operationType="import"
+          projectId={projectId}
+          projectName={projectName}
+          defaultBranch={linkedRepoDefaultBranch}
+        />
+      )}
+
+      {projectId && (
+        <ZipImportDialog
+          open={showZipImportDialog}
+          onOpenChange={onShowZipImportDialogChange}
+          projectId={projectId}
+          projectName={projectName}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
ScriptMode.tsx was 1008 lines and contained multiple responsibilities. Extracted custom hooks for file editing with autosave, tab management, and file switching logic and reduced component complexity and improved maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - File tab persistence per project (save/restore open tabs and active file)
  - Autosave with conflict detection and safe-save blocking during unsafe switches
  - Label-driven navigation that opens files and scrolls to label lines
  - Redesigned editor layout and improved empty-state UI

* **Tests**
  - Added comprehensive tests covering editor hooks: tab behavior, autosave/conflict flows, label-sync, project reset, and refresh logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->