### PR TITLE
Add undo/redo to script editor

### DIFF
--- a/.changeset/eager-cows-happen.md
+++ b/.changeset/eager-cows-happen.md
@@ -1,0 +1,5 @@
+---
+"@branchforge/frontend": patch
+---
+
+Added undo/redo function to script editor

--- a/.changeset/eager-cows-happen.md
+++ b/.changeset/eager-cows-happen.md
@@ -2,4 +2,4 @@
 "@branchforge/frontend": patch
 ---
 
-Added undo/redo function to script editor
+Added undo/redo functionality to the script editor

--- a/apps/frontend/src/components/FontSizeSwitcher.tsx
+++ b/apps/frontend/src/components/FontSizeSwitcher.tsx
@@ -270,7 +270,13 @@ export function FontSizeSwitcher({
         <span aria-hidden="true">{currentOption.label}</span>
         <svg
           className={`w-3 h-3 transition-transform ${
-            isOpen ? "rotate-180" : ""
+            isOpen
+              ? direction === "up"
+                ? ""
+                : "rotate-180"
+              : direction === "up"
+                ? "rotate-180"
+                : ""
           }`}
           fill="none"
           viewBox="0 0 24 24"

--- a/apps/frontend/src/components/ide-shared/UndoRedoControls.tsx
+++ b/apps/frontend/src/components/ide-shared/UndoRedoControls.tsx
@@ -34,7 +34,7 @@ export function UndoRedoControls({
       }
 
       // Ctrl+Z for undo
-      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === "z") {
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.code === "KeyZ") {
         e.preventDefault();
         if (canUndo) {
           onUndo();
@@ -44,7 +44,8 @@ export function UndoRedoControls({
       // Ctrl+Y or Ctrl+Shift+Z for redo
       if (
         (e.ctrlKey || e.metaKey) &&
-        ((!e.shiftKey && e.key === "y") || (e.shiftKey && e.key === "z"))
+        ((!e.shiftKey && e.code === "KeyY") ||
+          (e.shiftKey && e.code === "KeyZ"))
       ) {
         e.preventDefault();
         if (canRedo) {

--- a/apps/frontend/src/components/ide-shared/UndoRedoControls.tsx
+++ b/apps/frontend/src/components/ide-shared/UndoRedoControls.tsx
@@ -1,7 +1,7 @@
 /**
  * UndoRedoControls Component
  *
- * Undo/redo buttons with keyboard shortcuts (Ctrl+Z / Ctrl+Shift+Z).
+ * Undo/redo buttons with keyboard shortcuts (Ctrl+Z / Ctrl+Y).
  * Uses local in-memory undo only for instant response.
  */
 
@@ -41,12 +41,10 @@ export function UndoRedoControls({
         }
       }
 
-      // Ctrl+Shift+Z or Ctrl+Y for redo
+      // Ctrl+Y or Ctrl+Shift+Z for redo
       if (
-        ((e.ctrlKey || e.metaKey) &&
-          e.shiftKey &&
-          e.key.toLowerCase() === "z") ||
-        ((e.ctrlKey || e.metaKey) && e.key === "y")
+        (e.ctrlKey || e.metaKey) &&
+        ((!e.shiftKey && e.key === "y") || (e.shiftKey && e.key === "z"))
       ) {
         e.preventDefault();
         if (canRedo) {
@@ -73,7 +71,7 @@ export function UndoRedoControls({
             ? "hover:bg-muted text-foreground hover:text-[var(--theme-color)]"
             : "text-muted-foreground/30 cursor-not-allowed"
         }`}
-        title="Undo (Ctrl+Z)"
+        title="Undo (Ctrl+Z / Cmd+Z)"
         aria-label="Undo"
       >
         <Undo2 className="w-4 h-4" />
@@ -87,7 +85,7 @@ export function UndoRedoControls({
             ? "hover:bg-muted text-foreground hover:text-[var(--theme-color)]"
             : "text-muted-foreground/30 cursor-not-allowed"
         }`}
-        title="Redo (Ctrl+Shift+Z)"
+        title="Redo (Ctrl+Y / Cmd+Shift+Z)"
         aria-label="Redo"
       >
         <Redo2 className="w-4 h-4" />

--- a/apps/frontend/src/components/ide-shared/UndoRedoControls.tsx
+++ b/apps/frontend/src/components/ide-shared/UndoRedoControls.tsx
@@ -1,7 +1,13 @@
 /**
  * UndoRedoControls Component
  *
- * Undo/redo buttons with keyboard shortcuts (Ctrl+Z / Ctrl+Y).
+ * Undo/redo buttons with keyboard shortcuts.
+ *
+ * Shortcuts:
+ * - Undo: Ctrl+Z (Windows/Linux) or Cmd+Z (macOS)
+ * - Redo: Ctrl+Y or Ctrl+Shift+Z (Windows/Linux)
+ *         Cmd+Y or Cmd+Shift+Z (macOS)
+ *
  * Uses local in-memory undo only for instant response.
  */
 

--- a/apps/frontend/src/components/ide-shared/__tests__/UndoRedoControls.test.tsx
+++ b/apps/frontend/src/components/ide-shared/__tests__/UndoRedoControls.test.tsx
@@ -102,7 +102,7 @@ describe("UndoRedoControls", () => {
         <UndoRedoControls canUndo={true} canRedo={false} {...mockHandlers} />
       );
 
-      fireEvent.keyDown(document, { key: "z", ctrlKey: true });
+      fireEvent.keyDown(document, { key: "z", code: "KeyZ", ctrlKey: true });
 
       expect(mockHandlers.onUndo).toHaveBeenCalledOnce();
     });
@@ -112,7 +112,7 @@ describe("UndoRedoControls", () => {
         <UndoRedoControls canUndo={true} canRedo={false} {...mockHandlers} />
       );
 
-      fireEvent.keyDown(document, { key: "z", metaKey: true });
+      fireEvent.keyDown(document, { key: "z", code: "KeyZ", metaKey: true });
 
       expect(mockHandlers.onUndo).toHaveBeenCalledOnce();
     });
@@ -122,7 +122,7 @@ describe("UndoRedoControls", () => {
         <UndoRedoControls canUndo={false} canRedo={false} {...mockHandlers} />
       );
 
-      fireEvent.keyDown(document, { key: "z", ctrlKey: true });
+      fireEvent.keyDown(document, { key: "z", code: "KeyZ", ctrlKey: true });
 
       expect(mockHandlers.onUndo).not.toHaveBeenCalled();
     });
@@ -132,7 +132,12 @@ describe("UndoRedoControls", () => {
         <UndoRedoControls canUndo={false} canRedo={false} {...mockHandlers} />
       );
 
-      fireEvent.keyDown(document, { key: "z", ctrlKey: true, shiftKey: true });
+      fireEvent.keyDown(document, {
+        key: "z",
+        code: "KeyZ",
+        ctrlKey: true,
+        shiftKey: true,
+      });
 
       expect(mockHandlers.onRedo).not.toHaveBeenCalled();
     });
@@ -142,7 +147,7 @@ describe("UndoRedoControls", () => {
         <UndoRedoControls canUndo={false} canRedo={true} {...mockHandlers} />
       );
 
-      fireEvent.keyDown(document, { key: "y", ctrlKey: true });
+      fireEvent.keyDown(document, { key: "y", code: "KeyY", ctrlKey: true });
 
       expect(mockHandlers.onRedo).toHaveBeenCalledOnce();
     });
@@ -152,7 +157,7 @@ describe("UndoRedoControls", () => {
         <UndoRedoControls canUndo={false} canRedo={true} {...mockHandlers} />
       );
 
-      fireEvent.keyDown(document, { key: "y", metaKey: true });
+      fireEvent.keyDown(document, { key: "y", code: "KeyY", metaKey: true });
 
       expect(mockHandlers.onRedo).toHaveBeenCalledOnce();
     });
@@ -162,7 +167,7 @@ describe("UndoRedoControls", () => {
         <UndoRedoControls canUndo={false} canRedo={false} {...mockHandlers} />
       );
 
-      fireEvent.keyDown(document, { key: "y", ctrlKey: true });
+      fireEvent.keyDown(document, { key: "y", code: "KeyY", ctrlKey: true });
 
       expect(mockHandlers.onRedo).not.toHaveBeenCalled();
     });
@@ -176,7 +181,7 @@ describe("UndoRedoControls", () => {
       document.body.appendChild(input);
 
       try {
-        fireEvent.keyDown(input, { key: "z", ctrlKey: true });
+        fireEvent.keyDown(input, { key: "z", code: "KeyZ", ctrlKey: true });
 
         expect(mockHandlers.onUndo).not.toHaveBeenCalled();
       } finally {
@@ -193,7 +198,7 @@ describe("UndoRedoControls", () => {
       document.body.appendChild(textarea);
 
       try {
-        fireEvent.keyDown(textarea, { key: "z", ctrlKey: true });
+        fireEvent.keyDown(textarea, { key: "z", code: "KeyZ", ctrlKey: true });
 
         expect(mockHandlers.onUndo).not.toHaveBeenCalled();
       } finally {
@@ -214,7 +219,7 @@ describe("UndoRedoControls", () => {
       document.body.appendChild(div);
 
       try {
-        fireEvent.keyDown(div, { key: "z", ctrlKey: true });
+        fireEvent.keyDown(div, { key: "z", code: "KeyZ", ctrlKey: true });
 
         expect(mockHandlers.onUndo).not.toHaveBeenCalled();
       } finally {

--- a/apps/frontend/src/components/ide-shared/__tests__/UndoRedoControls.test.tsx
+++ b/apps/frontend/src/components/ide-shared/__tests__/UndoRedoControls.test.tsx
@@ -127,14 +127,14 @@ describe("UndoRedoControls", () => {
       expect(mockHandlers.onUndo).not.toHaveBeenCalled();
     });
 
-    it("should call onRedo when Ctrl+Shift+Z is pressed", () => {
+    it("should not call onRedo when Ctrl+Shift+Z is pressed", () => {
       render(
         <UndoRedoControls canUndo={false} canRedo={true} {...mockHandlers} />
       );
 
       fireEvent.keyDown(document, { key: "z", ctrlKey: true, shiftKey: true });
 
-      expect(mockHandlers.onRedo).toHaveBeenCalledOnce();
+      expect(mockHandlers.onRedo).not.toHaveBeenCalled();
     });
 
     it("should call onRedo when Ctrl+Y is pressed", () => {
@@ -147,12 +147,22 @@ describe("UndoRedoControls", () => {
       expect(mockHandlers.onRedo).toHaveBeenCalledOnce();
     });
 
-    it("should not call onRedo when Ctrl+Shift+Z is pressed but disabled", () => {
+    it("should call onRedo when Cmd+Y is pressed (Mac)", () => {
+      render(
+        <UndoRedoControls canUndo={false} canRedo={true} {...mockHandlers} />
+      );
+
+      fireEvent.keyDown(document, { key: "y", metaKey: true });
+
+      expect(mockHandlers.onRedo).toHaveBeenCalledOnce();
+    });
+
+    it("should not call onRedo when Ctrl+Y is pressed but disabled", () => {
       render(
         <UndoRedoControls canUndo={false} canRedo={false} {...mockHandlers} />
       );
 
-      fireEvent.keyDown(document, { key: "z", ctrlKey: true, shiftKey: true });
+      fireEvent.keyDown(document, { key: "y", ctrlKey: true });
 
       expect(mockHandlers.onRedo).not.toHaveBeenCalled();
     });
@@ -165,11 +175,13 @@ describe("UndoRedoControls", () => {
       const input = document.createElement("input");
       document.body.appendChild(input);
 
-      fireEvent.keyDown(input, { key: "z", ctrlKey: true });
+      try {
+        fireEvent.keyDown(input, { key: "z", ctrlKey: true });
 
-      expect(mockHandlers.onUndo).not.toHaveBeenCalled();
-
-      document.body.removeChild(input);
+        expect(mockHandlers.onUndo).not.toHaveBeenCalled();
+      } finally {
+        document.body.removeChild(input);
+      }
     });
 
     it("should not trigger undo when typing in a textarea", () => {
@@ -180,11 +192,13 @@ describe("UndoRedoControls", () => {
       const textarea = document.createElement("textarea");
       document.body.appendChild(textarea);
 
-      fireEvent.keyDown(textarea, { key: "z", ctrlKey: true });
+      try {
+        fireEvent.keyDown(textarea, { key: "z", ctrlKey: true });
 
-      expect(mockHandlers.onUndo).not.toHaveBeenCalled();
-
-      document.body.removeChild(textarea);
+        expect(mockHandlers.onUndo).not.toHaveBeenCalled();
+      } finally {
+        document.body.removeChild(textarea);
+      }
     });
 
     it("should not trigger undo when typing in a contenteditable element", () => {
@@ -199,11 +213,13 @@ describe("UndoRedoControls", () => {
       });
       document.body.appendChild(div);
 
-      fireEvent.keyDown(div, { key: "z", ctrlKey: true });
+      try {
+        fireEvent.keyDown(div, { key: "z", ctrlKey: true });
 
-      expect(mockHandlers.onUndo).not.toHaveBeenCalled();
-
-      document.body.removeChild(div);
+        expect(mockHandlers.onUndo).not.toHaveBeenCalled();
+      } finally {
+        document.body.removeChild(div);
+      }
     });
   });
 
@@ -234,9 +250,11 @@ describe("UndoRedoControls", () => {
         <UndoRedoControls canUndo={true} canRedo={true} {...mockHandlers} />
       );
 
-      expect(screen.getByTitle(/Undo \((Ctrl|Cmd)\+Z\)/)).toBeInTheDocument();
       expect(
-        screen.getByTitle(/Redo \((Ctrl|Cmd)\+Shift\+Z\)/)
+        screen.getByTitle(/Undo \(Ctrl\+Z \/ Cmd\+Z\)/)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTitle(/Redo \(Ctrl\+Y \/ Cmd\+Y\)/)
       ).toBeInTheDocument();
     });
   });

--- a/apps/frontend/src/components/ide-shared/__tests__/UndoRedoControls.test.tsx
+++ b/apps/frontend/src/components/ide-shared/__tests__/UndoRedoControls.test.tsx
@@ -127,9 +127,9 @@ describe("UndoRedoControls", () => {
       expect(mockHandlers.onUndo).not.toHaveBeenCalled();
     });
 
-    it("should not call onRedo when Ctrl+Shift+Z is pressed", () => {
+    it("should not call onRedo when Ctrl+Shift+Z is pressed but canRedo is false", () => {
       render(
-        <UndoRedoControls canUndo={false} canRedo={true} {...mockHandlers} />
+        <UndoRedoControls canUndo={false} canRedo={false} {...mockHandlers} />
       );
 
       fireEvent.keyDown(document, { key: "z", ctrlKey: true, shiftKey: true });
@@ -254,7 +254,7 @@ describe("UndoRedoControls", () => {
         screen.getByTitle(/Undo \(Ctrl\+Z \/ Cmd\+Z\)/)
       ).toBeInTheDocument();
       expect(
-        screen.getByTitle(/Redo \(Ctrl\+Y \/ Cmd\+Y\)/)
+        screen.getByTitle(/Redo \(Ctrl\+Y \/ Cmd\+Shift\+Z\)/)
       ).toBeInTheDocument();
     });
   });

--- a/apps/frontend/src/components/ide-shared/index.ts
+++ b/apps/frontend/src/components/ide-shared/index.ts
@@ -10,6 +10,7 @@ export { GitLabSettingsContent } from "./GitLabSettingsContent";
 export { GitLabRepositoryLinkingDialog } from "./GitLabRepositoryLinkingDialog";
 export { EditorTabBar } from "./EditorTabBar";
 export type { EditorTabBarItem } from "./EditorTabBar";
+export { UndoRedoControls } from "./UndoRedoControls";
 
 // Re-export write-mode components for convenience
 export {

--- a/apps/frontend/src/components/script-mode/PaletteSwitcher.tsx
+++ b/apps/frontend/src/components/script-mode/PaletteSwitcher.tsx
@@ -6,10 +6,16 @@ import {
 } from "../../lib/codemirror/palettes";
 import { useLocalStorageNumber } from "@/hooks/useLocalStorage";
 
+interface PaletteSwitcherProps {
+  direction?: "up" | "down";
+}
+
 /**
  * Palette switcher for syntax highlighting colors
  */
-export function PaletteSwitcher() {
+export function PaletteSwitcher({
+  direction = "up",
+}: PaletteSwitcherProps = {}) {
   const [selectedIndex, setSelectedIndex] = useLocalStorageNumber(
     "editor:syntax-palette",
     0,
@@ -47,6 +53,9 @@ export function PaletteSwitcher() {
     return groups;
   }, []);
 
+  const dropdownPositionClasses =
+    direction === "up" ? "bottom-full left-0 mb-1" : "top-full mt-1";
+
   return (
     <div className="relative z-50 flex items-center gap-2">
       <button
@@ -62,7 +71,13 @@ export function PaletteSwitcher() {
         <span>{PALETTES[selectedIndex].name}</span>
         <svg
           className={`w-3 h-3 transition-transform ${
-            isOpen ? "rotate-180" : ""
+            isOpen
+              ? direction === "up"
+                ? ""
+                : "rotate-180"
+              : direction === "up"
+                ? "rotate-180"
+                : ""
           }`}
           fill="none"
           viewBox="0 0 24 24"
@@ -80,7 +95,9 @@ export function PaletteSwitcher() {
       {isOpen && (
         <>
           <div className="fixed inset-0" onClick={() => setIsOpen(false)} />
-          <div className="absolute bottom-full left-0 mb-1 bg-card border border-border rounded-md shadow-lg overflow-hidden min-w-[200px]">
+          <div
+            className={`absolute ${dropdownPositionClasses} bg-card border border-border rounded-md shadow-lg overflow-hidden min-w-[200px]`}
+          >
             {Object.entries(groupedPalettes).map(([groupName, palettes]) => (
               <div key={groupName}>
                 <div className="px-3 py-1 text-xs font-semibold text-muted-foreground bg-muted/30">

--- a/apps/frontend/src/components/script-mode/ScriptEditor.tsx
+++ b/apps/frontend/src/components/script-mode/ScriptEditor.tsx
@@ -360,6 +360,8 @@ export const ScriptEditor = forwardRef<ScriptEditorRef, ScriptEditorProps>(
           }}
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
+          onFocusCapture={() => setIsHovered(true)}
+          onBlurCapture={() => setIsHovered(false)}
         >
           <div className="flex items-center gap-2">
             <FontSizeSwitcher mode="script" direction="up" />

--- a/apps/frontend/src/components/script-mode/ScriptEditor.tsx
+++ b/apps/frontend/src/components/script-mode/ScriptEditor.tsx
@@ -25,6 +25,8 @@ import {
   EDITOR_FONT_SIZE_CHANGED,
 } from "../FontSizeSwitcher";
 import { LineWrapSwitcher } from "./LineWrapSwitcher";
+import { SaveIndicator } from "../write-mode";
+import type { SaveStatus } from "@/hooks/useAutosave";
 
 export interface ScriptEditorRef {
   focus: () => void;
@@ -35,6 +37,10 @@ interface ScriptEditorProps {
   onChange?: (value: string) => void;
   scrollToLine?: number | null;
   readOnly?: boolean;
+  isFocusMode?: boolean;
+  saveStatus?: SaveStatus;
+  saveConflict?: boolean;
+  onSaveRequest?: () => void;
 }
 
 const TARGET_LINE_HIGHLIGHT_MS = 920;
@@ -78,12 +84,22 @@ const createHighlightExtension = () => {
 
 export const ScriptEditor = forwardRef<ScriptEditorRef, ScriptEditorProps>(
   function ScriptEditor(
-    { content, onChange, scrollToLine, readOnly = false }: ScriptEditorProps,
+    {
+      content,
+      onChange,
+      scrollToLine,
+      readOnly = false,
+      isFocusMode = false,
+      saveStatus,
+      saveConflict,
+      onSaveRequest,
+    }: ScriptEditorProps,
     ref
   ) {
     const [lineWrapExtension, setLineWrapExtension] = useState<
       Extension | readonly Extension[]
     >([]);
+    const [isHovered, setIsHovered] = useState(false);
     const cleanContent = useMemo(() => stripBOM(content), [content]);
 
     // Track if we've scrolled to avoid re-scrolling on every render
@@ -337,13 +353,31 @@ export const ScriptEditor = forwardRef<ScriptEditorRef, ScriptEditorProps>(
             }}
           />
         </div>
-        <div className="flex items-center justify-between px-2 py-1 border-t border-border bg-muted/20 font-code text-xs text-muted-foreground">
+        <div
+          className="flex items-center justify-between px-2 py-1 border-t border-border bg-muted/20 font-code text-xs text-muted-foreground transition-opacity duration-300 ease-out"
+          style={{
+            opacity: isFocusMode ? (isHovered ? 1 : 0.4) : 1,
+          }}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
           <div className="flex items-center gap-2">
             <FontSizeSwitcher mode="script" direction="up" />
             <LineWrapSwitcher onChange={handleLineWrapChange} />
             <PaletteSwitcher />
           </div>
           <div className="flex items-center gap-3">
+            {saveStatus && (
+              <>
+                <SaveIndicator
+                  saveStatus={saveStatus}
+                  displayMode="compact"
+                  saveConflict={saveConflict}
+                  onRetry={onSaveRequest}
+                />
+                <span className="w-px h-3 bg-border" aria-hidden="true" />
+              </>
+            )}
             <span>Ren'Py</span>
             <span className="w-px h-3 bg-border" aria-hidden="true" />
             <span>UTF-8</span>

--- a/apps/frontend/src/components/script-mode/StatusBar.tsx
+++ b/apps/frontend/src/components/script-mode/StatusBar.tsx
@@ -91,6 +91,8 @@ export function StatusBar({
         }}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
+        onFocusCapture={() => setIsHovered(true)}
+        onBlurCapture={() => setIsHovered(false)}
       >
         <div className="flex items-center gap-4">
           <div className="text-muted-foreground border-r border-border/30 pr-4">

--- a/apps/frontend/src/components/script-mode/StatusBar.tsx
+++ b/apps/frontend/src/components/script-mode/StatusBar.tsx
@@ -6,9 +6,7 @@ import {
 } from "@/components/script-mode/GitLabSyncDialog";
 import { ConflictReviewDialog } from "@/components/script-mode/ConflictReviewDialog";
 import { ZipImportDialog } from "@/components/zip-import";
-import { SaveIndicator } from "@/components/write-mode";
 import { cn } from "@/lib/utils";
-import type { SaveStatus } from "@/hooks/useAutosave";
 import type { FileSourceType } from "@branchforge/shared";
 
 // Status bar styled like a storybook footer
@@ -19,10 +17,8 @@ interface StatusBarProps {
   gitlabBranch?: string;
   // File source type - determines which import/export controls to show
   fileSourceType?: FileSourceType;
-  // Save status
-  saveStatus?: SaveStatus;
-  saveConflict?: boolean;
-  onSaveRequest?: () => void;
+  // Focus mode
+  isFocusMode?: boolean;
 }
 
 export function StatusBar({
@@ -31,9 +27,7 @@ export function StatusBar({
   projectName,
   gitlabBranch,
   fileSourceType,
-  saveStatus = "saved",
-  saveConflict = false,
-  onSaveRequest,
+  isFocusMode = false,
 }: StatusBarProps) {
   // Dialog state
   const [syncDialogOpen, setSyncDialogOpen] = useState(false);
@@ -41,6 +35,7 @@ export function StatusBar({
     useState<SyncOperationType>("export");
   const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
   const [zipImportDialogOpen, setZipImportDialogOpen] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
 
   /**
    * Handle export click
@@ -89,8 +84,13 @@ export function StatusBar({
   return (
     <>
       <div
-        className="flex items-center justify-between px-4 py-2 text-xs bg-card/50 border-t border-dashed"
-        style={{ borderColor: "var(--theme-border-subtle)" }}
+        className="flex items-center justify-between px-4 py-2 text-xs bg-card/50 border-t border-dashed transition-opacity duration-300 ease-out"
+        style={{
+          borderColor: "var(--theme-border-subtle)",
+          opacity: isFocusMode ? (isHovered ? 1 : 0.6) : 1,
+        }}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
       >
         <div className="flex items-center gap-4">
           <div className="text-muted-foreground border-r border-border/30 pr-4">
@@ -152,16 +152,6 @@ export function StatusBar({
               </button>
             </div>
           )}
-
-          {/* Save status indicator - using unified SaveIndicator component */}
-          <div className="border-l border-border/30 pl-4">
-            <SaveIndicator
-              saveStatus={saveStatus}
-              displayMode="verbose"
-              saveConflict={saveConflict}
-              onRetry={onSaveRequest}
-            />
-          </div>
         </div>
       </div>
 

--- a/apps/frontend/src/components/script-mode/index.ts
+++ b/apps/frontend/src/components/script-mode/index.ts
@@ -5,5 +5,6 @@ export { StatusBar } from "./StatusBar";
 export { GitLabSyncDialog } from "./GitLabSyncDialog";
 export { ConflictReviewDialog } from "./ConflictReviewDialog";
 export { CharacterReferencePanel } from "./CharacterReferencePanel";
+export { UndoRedoControls } from "@/components/ide-shared";
 export type { ScriptFile as File } from "./FileTree";
 export type { SyncOperationType } from "./GitLabSyncDialog";

--- a/apps/frontend/src/components/write-mode/FocusModeToggle.tsx
+++ b/apps/frontend/src/components/write-mode/FocusModeToggle.tsx
@@ -36,7 +36,7 @@ export const FocusModeToggle = memo(
           "focus-visible:ring-[var(--theme-color)]/35",
           isFocusMode
             ? "gap-2 rounded-full border border-border/70 bg-card/90 px-3.5 py-2 whitespace-nowrap text-sm font-medium text-foreground shadow-lg backdrop-blur-sm hover:border-[var(--theme-color)]/35 hover:bg-card"
-            : "gap-2 rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+            : "gap-2 rounded-md px-3 py-1.5 text-sm text-muted-foreground bg-muted/30 hover:bg-muted/60 hover:text-foreground hover:border-border/80"
         )}
       >
         {isFocusMode ? (

--- a/apps/frontend/src/components/write-mode/FontFamilySwitcher.tsx
+++ b/apps/frontend/src/components/write-mode/FontFamilySwitcher.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { cva } from "class-variance-authority";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 
 export type FontFamilyOption = {
@@ -20,11 +21,27 @@ const FONT_FAMILY_OPTIONS: Readonly<FontFamilyOption[]> = [
   { label: "Noto Serif", value: "noto-serif", family: "'Noto Serif', serif" },
 ] as const;
 
+const dropdownVariants = cva(
+  "absolute z-50 bg-card border border-border rounded-md shadow-lg overflow-hidden min-w-[160px] animate-in fade-in-50 zoom-in-95 duration-150",
+  {
+    variants: {
+      direction: {
+        up: "bottom-full mb-1",
+        down: "top-full mt-1",
+      },
+    },
+    defaultVariants: {
+      direction: "down",
+    },
+  }
+);
+
 const STORAGE_KEY = "write:font-family";
 const CSS_VARIABLE = "--prose-editor-font-family";
 
 interface FontFamilySwitcherProps {
   className?: string;
+  direction?: "up" | "down";
 }
 
 /**
@@ -34,6 +51,7 @@ interface FontFamilySwitcherProps {
  */
 export function FontFamilySwitcher({
   className = "",
+  direction = "down",
 }: FontFamilySwitcherProps = {}) {
   const [fontFamily, setFontFamily] = useLocalStorage<string>(
     STORAGE_KEY,
@@ -238,7 +256,13 @@ export function FontFamilySwitcher({
         <span aria-hidden="true">{currentOption.label}</span>
         <svg
           className={`w-3 h-3 transition-transform ${
-            dropdownState.isOpen ? "rotate-180" : ""
+            dropdownState.isOpen
+              ? direction === "up"
+                ? ""
+                : "rotate-180"
+              : direction === "up"
+                ? "rotate-180"
+                : ""
           }`}
           fill="none"
           viewBox="0 0 24 24"
@@ -275,7 +299,7 @@ export function FontFamilySwitcher({
                 ? `font-family-option-${currentFocusedIndex}`
                 : undefined
             }
-            className="absolute z-50 top-full mt-1 bg-card border border-border rounded-md shadow-lg overflow-hidden min-w-[160px] animate-in fade-in-50 zoom-in-95 duration-150"
+            className={dropdownVariants({ direction })}
             onKeyDown={handleKeyDown}
           >
             {FONT_FAMILY_OPTIONS.map((option, index) => (

--- a/apps/frontend/src/components/write-mode/ProseEditor.tsx
+++ b/apps/frontend/src/components/write-mode/ProseEditor.tsx
@@ -22,8 +22,8 @@ import { SaveIndicator } from "./SaveIndicator";
 import { FontSizeSwitcher } from "../FontSizeSwitcher";
 import { FontFamilySwitcher } from "./FontFamilySwitcher";
 import { useWritingGoals } from "@/hooks/useWritingGoals";
-import { useInMemoryUndo } from "./useInMemoryUndo";
-import { UndoRedoControls } from "./UndoRedoControls";
+import { useEntriesUndo } from "@/hooks/useEntriesUndo";
+import { UndoRedoControls } from "@/components/ide-shared";
 import { BookOpen, PenLine } from "lucide-react";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import type { DialogueEntry } from "@/lib/prose-types";
@@ -229,7 +229,7 @@ export const ProseEditor = forwardRef<ProseEditorRef, ProseEditorProps>(
     );
 
     // In-memory undo for immediate response
-    const inMemoryUndo = useInMemoryUndo(
+    const inMemoryUndo = useEntriesUndo(
       entries,
       handleInMemoryHistoryChange,
       50 // Max 50 in-memory undo steps

--- a/apps/frontend/src/components/write-mode/ProseEditor.tsx
+++ b/apps/frontend/src/components/write-mode/ProseEditor.tsx
@@ -177,7 +177,6 @@ export const ProseEditor = forwardRef<ProseEditorRef, ProseEditorProps>(
     const { settings: writingGoalSettings } = useWritingGoals();
 
     // Hover state for focus mode dimming
-    const [isTopBarHovered, setIsTopBarHovered] = useState(false);
     const [isBottomBarHovered, setIsBottomBarHovered] = useState(false);
     const [entries, setEntries] = useState<DialogueEntry[]>(() =>
       convertLabelLinesToEntries(activeLabel)
@@ -633,51 +632,45 @@ export const ProseEditor = forwardRef<ProseEditorRef, ProseEditorProps>(
     return (
       <div className="flex flex-col h-full tracking-normal pb-3">
         {/* Top Bar */}
-        <div
-          className="px-4 py-3 border-b border-border bg-card rounded-t-lg flex items-center justify-between gap-4 transition-opacity duration-300 ease-out"
-          style={{
-            opacity: isFocusMode ? (isTopBarHovered ? 1 : 0.4) : 1,
-          }}
-          onMouseEnter={() => setIsTopBarHovered(true)}
-          onMouseLeave={() => setIsTopBarHovered(false)}
-        >
-          <div className="flex items-center gap-3 min-w-0">
-            {/* Scene status badge */}
-            <span
-              className={`px-2 py-0.4 rounded-full text-xs font-medium border shrink-0 ${
-                activeLabel.status === "FINAL"
-                  ? "bg-[var(--theme-color)]/20 text-[var(--theme-color)] border-[var(--theme-border)]"
-                  : activeLabel.status === "REVIEW"
-                    ? "bg-[var(--theme-review-color)]/20 text-[var(--theme-review-color)] border-[var(--theme-review-color)]/30"
-                    : "bg-[var(--theme-draft-color)]/20 text-[var(--theme-draft-color)] border-[var(--theme-draft-color)]/30"
-              }`}
-            >
-              {activeLabel.status?.toLowerCase() || "draft"}
-            </span>
+        {!isFocusMode && (
+          <div className="px-4 py-3 border-b border-border bg-card rounded-t-lg flex items-center justify-between">
+            <div className="flex items-center gap-3 min-w-0">
+              {/* Scene status badge */}
+              <span
+                className={`px-2 py-0.4 rounded-full text-xs font-medium border shrink-0 ${
+                  activeLabel.status === "FINAL"
+                    ? "bg-[var(--theme-color)]/20 text-[var(--theme-color)] border-[var(--theme-border)]"
+                    : activeLabel.status === "REVIEW"
+                      ? "bg-[var(--theme-review-color)]/20 text-[var(--theme-review-color)] border-[var(--theme-review-color)]/30"
+                      : "bg-[var(--theme-draft-color)]/20 text-[var(--theme-draft-color)] border-[var(--theme-draft-color)]/30"
+                }`}
+              >
+                {activeLabel.status?.toLowerCase() || "draft"}
+              </span>
+            </div>
+            <div className="flex items-center gap-3 shrink-0">
+              <UndoRedoControls
+                canUndo={inMemoryUndo.canUndo}
+                canRedo={inMemoryUndo.canRedo}
+                onUndo={handleUndo}
+                onRedo={handleRedo}
+              />
+              <SaveIndicator
+                saveStatus={propsToSaveStatus(isSaving, saveError)}
+                displayMode="compact"
+                lastSaved={lastSaved}
+                saveConflict={saveConflict}
+              />
+            </div>
           </div>
-
-          <div className="flex items-center gap-2 shrink-0">
-            <FontFamilySwitcher />
-            <FontSizeSwitcher mode="write" direction="down" />
-
-            <button
-              onClick={() =>
-                setLayoutMode((prev) =>
-                  prev === "inline" ? "stacked" : "inline"
-                )
-              }
-              className="px-3 py-1.5 rounded-lg border border-border hover:bg-muted text-xs transition-colors"
-              title="Toggle line layout"
-            >
-              {layoutMode === "inline" ? "Inline" : "Stacked"}
-            </button>
-          </div>
-        </div>
+        )}
 
         {/* Editor Content */}
         <div
           data-prose-editor-scroll="true"
-          className="flex-1 overflow-y-auto px-4 sm:px-6 py-6 bg-background scroll-pb-24"
+          className={`flex-1 overflow-y-auto px-4 sm:px-6 py-6 bg-background scroll-pb-24 ${
+            isFocusMode ? "border-t border-border" : ""
+          }`}
         >
           <div className="mx-auto w-full max-w-[75ch] space-y-1 pb-20">
             {entries.map((entry, index) => (
@@ -748,18 +741,19 @@ export const ProseEditor = forwardRef<ProseEditorRef, ProseEditorProps>(
             </div>
 
             <div className="flex items-center gap-4">
-              <UndoRedoControls
-                canUndo={inMemoryUndo.canUndo}
-                canRedo={inMemoryUndo.canRedo}
-                onUndo={handleUndo}
-                onRedo={handleRedo}
-              />
-              <SaveIndicator
-                saveStatus={propsToSaveStatus(isSaving, saveError)}
-                displayMode="compact"
-                lastSaved={lastSaved}
-                saveConflict={saveConflict}
-              />
+              <FontFamilySwitcher direction="up" />
+              <FontSizeSwitcher mode="write" direction="up" />
+              <button
+                onClick={() =>
+                  setLayoutMode((prev) =>
+                    prev === "inline" ? "stacked" : "inline"
+                  )
+                }
+                className="px-2 py-1 rounded border border-[hsl(var(--border)/0.6)] hover:bg-[hsl(var(--muted)/0.4)] text-xs text-muted-foreground hover:text-foreground transition-colors"
+                title="Toggle line layout"
+              >
+                {layoutMode === "inline" ? "Inline" : "Stacked"}
+              </button>
             </div>
           </div>
         </div>

--- a/apps/frontend/src/components/write-mode/ProseEditor.tsx
+++ b/apps/frontend/src/components/write-mode/ProseEditor.tsx
@@ -709,6 +709,8 @@ export const ProseEditor = forwardRef<ProseEditorRef, ProseEditorProps>(
             }}
             onMouseEnter={() => setIsBottomBarHovered(true)}
             onMouseLeave={() => setIsBottomBarHovered(false)}
+            onFocusCapture={() => setIsBottomBarHovered(true)}
+            onBlurCapture={() => setIsBottomBarHovered(false)}
           >
             <WritingGoalPill
               current={todayWordCount}
@@ -726,6 +728,8 @@ export const ProseEditor = forwardRef<ProseEditorRef, ProseEditorProps>(
           }}
           onMouseEnter={() => setIsBottomBarHovered(true)}
           onMouseLeave={() => setIsBottomBarHovered(false)}
+          onFocusCapture={() => setIsBottomBarHovered(true)}
+          onBlurCapture={() => setIsBottomBarHovered(false)}
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4 text-sm">

--- a/apps/frontend/src/components/write-mode/index.ts
+++ b/apps/frontend/src/components/write-mode/index.ts
@@ -12,4 +12,3 @@ export { FocusModeToggle } from "./FocusModeToggle";
 export { SaveIndicator } from "./SaveIndicator";
 export type { SaveIndicatorDisplayMode } from "./SaveIndicator";
 export { WritingGoalPill } from "./WritingGoalPill";
-export { UndoRedoControls } from "./UndoRedoControls";

--- a/apps/frontend/src/hooks/__tests__/useEntriesUndo.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useEntriesUndo.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useInMemoryUndo } from "../useInMemoryUndo";
+import { useEntriesUndo } from "../useEntriesUndo";
 import type { DialogueEntry } from "@/lib/prose-types";
 
 const entriesA: DialogueEntry[] = [
@@ -35,10 +35,10 @@ const entriesB2: DialogueEntry[] = [
   },
 ];
 
-describe("useInMemoryUndo", () => {
+describe("useEntriesUndo", () => {
   it("does not emit changes when undo/redo are unavailable", () => {
     const onChange = vi.fn();
-    const { result } = renderHook(() => useInMemoryUndo(entriesA, onChange));
+    const { result } = renderHook(() => useEntriesUndo(entriesA, onChange));
 
     act(() => {
       result.current.undo();
@@ -50,7 +50,7 @@ describe("useInMemoryUndo", () => {
 
   it("returns true when undo succeeds", () => {
     const onChange = vi.fn();
-    const { result } = renderHook(() => useInMemoryUndo(entriesA, onChange));
+    const { result } = renderHook(() => useEntriesUndo(entriesA, onChange));
 
     // Verify initial state
     expect(result.current.canUndo).toBe(false);
@@ -70,15 +70,12 @@ describe("useInMemoryUndo", () => {
     });
 
     // Verify undo succeeded
-    expect(undoResult).toBeDefined();
-    if (undoResult !== undefined) {
-      expect(undoResult).toBe(true);
-    }
+    expect(undoResult).toBe(true);
   });
 
   it("calls onChange when undo is available", () => {
     const onChange = vi.fn();
-    const { result } = renderHook(() => useInMemoryUndo(entriesA, onChange));
+    const { result } = renderHook(() => useEntriesUndo(entriesA, onChange));
 
     act(() => {
       result.current.recordChange(entriesB);
@@ -93,7 +90,7 @@ describe("useInMemoryUndo", () => {
 
   it("clears history with explicit initial entries", () => {
     const onChange = vi.fn();
-    const { result } = renderHook(() => useInMemoryUndo(entriesA, onChange));
+    const { result } = renderHook(() => useEntriesUndo(entriesA, onChange));
 
     // Record first change
     act(() => {

--- a/apps/frontend/src/hooks/__tests__/useEntriesUndo.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useEntriesUndo.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useEntriesUndo } from "../useEntriesUndo";
+import { useEntriesUndo } from "@/hooks/useEntriesUndo";
 import type { DialogueEntry } from "@/lib/prose-types";
 
 const entriesA: DialogueEntry[] = [

--- a/apps/frontend/src/hooks/__tests__/useTextUndo.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useTextUndo.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTextUndo } from "../useTextUndo";
+
+describe("useTextUndo", () => {
+  it("does not emit changes when undo/redo are unavailable", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useTextUndo("Alpha", onChange));
+
+    act(() => {
+      result.current.undo();
+      result.current.redo();
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("returns true when undo succeeds", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useTextUndo("Alpha", onChange));
+
+    expect(result.current.canUndo).toBe(false);
+
+    act(() => {
+      result.current.recordChange("Alpha edited");
+    });
+
+    expect(result.current.canUndo).toBe(true);
+
+    let undoResult: boolean | undefined;
+    act(() => {
+      undoResult = result.current.undo();
+    });
+
+    expect(undoResult).toBe(true);
+  });
+
+  it("calls onChange when undo is available", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useTextUndo("Alpha", onChange));
+
+    act(() => {
+      result.current.recordChange("Beta");
+    });
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(onChange).toHaveBeenCalledWith("Alpha");
+  });
+
+  it("clears history with explicit initial content", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useTextUndo("Alpha", onChange));
+
+    act(() => {
+      result.current.recordChange("Alpha edited");
+    });
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => {
+      result.current.clear("Beta");
+    });
+    expect(result.current.canUndo).toBe(false);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.recordChange("Beta edited");
+    });
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("Beta");
+  });
+
+  it("does not record changes when content is the same", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useTextUndo("Alpha", onChange));
+
+    act(() => {
+      result.current.recordChange("Alpha");
+    });
+
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it("limits history size to maxHistory", () => {
+    const onChange = vi.fn();
+    const maxHistory = 3;
+    const { result } = renderHook(() =>
+      useTextUndo("Initial", onChange, maxHistory)
+    );
+
+    act(() => {
+      result.current.recordChange("Change 1");
+      result.current.recordChange("Change 2");
+      result.current.recordChange("Change 3");
+      result.current.recordChange("Change 4");
+    });
+
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => {
+      result.current.undo();
+      result.current.undo();
+      result.current.undo();
+    });
+
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it("clears future when recording new change", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useTextUndo("Alpha", onChange));
+
+    act(() => {
+      result.current.recordChange("Beta");
+    });
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => {
+      result.current.recordChange("Gamma");
+    });
+
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("calls onChange when redo is available", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useTextUndo("Alpha", onChange));
+
+    act(() => {
+      result.current.recordChange("Beta");
+    });
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(onChange).toHaveBeenCalledWith("Alpha");
+    onChange.mockClear();
+
+    act(() => {
+      result.current.redo();
+    });
+
+    expect(onChange).toHaveBeenCalledWith("Beta");
+  });
+});

--- a/apps/frontend/src/hooks/useEntriesUndo.ts
+++ b/apps/frontend/src/hooks/useEntriesUndo.ts
@@ -1,10 +1,3 @@
-/**
- * useInMemoryUndo Hook
- *
- * In-memory undo stack for immediate undo without server roundtrip.
- * Works in tandem with server-side undo for persistence.
- */
-
 import { useState, useCallback, useRef, useEffect } from "react";
 import type { DialogueEntry } from "@/lib/prose-types";
 import { areDialogueEntriesEqual } from "@/lib/prose-converter";
@@ -15,7 +8,7 @@ interface UndoState {
   future: DialogueEntry[][];
 }
 
-export function useInMemoryUndo(
+export function useEntriesUndo(
   entries: DialogueEntry[],
   onChange: (entries: DialogueEntry[]) => void,
   maxHistory: number = 50
@@ -136,7 +129,7 @@ export function useInMemoryUndo(
   // Clear history (call when switching labels)
   const clear = useCallback(
     (initialEntries?: DialogueEntry[]) => {
-      const nextPresent = initialEntries ?? entries;
+      const nextPresent = initialEntries ?? stateRef.current.present ?? [];
 
       commitState({
         past: [],
@@ -145,7 +138,7 @@ export function useInMemoryUndo(
       });
       lastSyncedEntriesRef.current = nextPresent;
     },
-    [commitState, entries]
+    [commitState]
   );
 
   // Sync internal state with entries prop when it changes from external sources

--- a/apps/frontend/src/hooks/useTextUndo.ts
+++ b/apps/frontend/src/hooks/useTextUndo.ts
@@ -1,0 +1,148 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+
+interface UndoState {
+  past: string[];
+  present: string;
+  future: string[];
+}
+
+export function useTextUndo(
+  content: string,
+  onChange: (content: string) => void,
+  maxHistory: number = 50
+) {
+  const initialState: UndoState = {
+    past: [],
+    present: content,
+    future: [],
+  };
+
+  const [state, setState] = useState<UndoState>(initialState);
+  const stateRef = useRef<UndoState>(initialState);
+
+  const lastSyncedContentRef = useRef<string>(content);
+
+  const commitState = useCallback((nextState: UndoState) => {
+    stateRef.current = nextState;
+    setState(nextState);
+  }, []);
+
+  const updatePresent = useCallback(
+    (newContent: string) => {
+      const nextState: UndoState = {
+        ...stateRef.current,
+        present: newContent,
+        future: [],
+      };
+
+      commitState(nextState);
+      lastSyncedContentRef.current = newContent;
+    },
+    [commitState]
+  );
+
+  const undo = useCallback((): boolean => {
+    const current = stateRef.current;
+    const { past, present, future } = current;
+
+    if (past.length === 0) return false;
+
+    const previous = past[past.length - 1];
+    const newPast = past.slice(0, past.length - 1);
+    const nextState: UndoState = {
+      past: newPast,
+      present: previous,
+      future: [present, ...future],
+    };
+
+    commitState(nextState);
+    onChange(previous);
+    lastSyncedContentRef.current = previous;
+
+    return true;
+  }, [commitState, onChange]);
+
+  const redo = useCallback((): boolean => {
+    const current = stateRef.current;
+    const { past, present, future } = current;
+
+    if (future.length === 0) return false;
+
+    const next = future[0];
+    const newFuture = future.slice(1);
+    const nextState: UndoState = {
+      past: [...past, present],
+      present: next,
+      future: newFuture,
+    };
+
+    commitState(nextState);
+    onChange(next);
+    lastSyncedContentRef.current = next;
+
+    return true;
+  }, [commitState, onChange]);
+
+  const recordChange = useCallback(
+    (newContent: string) => {
+      const current = stateRef.current;
+      const { past } = current;
+
+      if (lastSyncedContentRef.current === newContent) {
+        return;
+      }
+
+      const previousState = lastSyncedContentRef.current;
+
+      const newPast = [...past, previousState];
+      if (newPast.length > maxHistory) {
+        newPast.shift();
+      }
+
+      commitState({
+        past: newPast,
+        present: newContent,
+        future: [],
+      });
+
+      lastSyncedContentRef.current = newContent;
+    },
+    [commitState, maxHistory]
+  );
+
+  const clear = useCallback(
+    (initialContent?: string) => {
+      const nextPresent = initialContent ?? content;
+
+      commitState({
+        past: [],
+        present: nextPresent,
+        future: [],
+      });
+      lastSyncedContentRef.current = nextPresent;
+    },
+    [commitState, content]
+  );
+
+  useEffect(() => {
+    if (content !== lastSyncedContentRef.current) {
+      const nextState: UndoState = {
+        ...stateRef.current,
+        present: content,
+        future: [],
+      };
+      commitState(nextState);
+      lastSyncedContentRef.current = content;
+    }
+  }, [content, commitState]);
+
+  return {
+    undo,
+    redo,
+    recordChange,
+    updatePresent,
+    clear,
+    canUndo: state.past.length > 0,
+    canRedo: state.future.length > 0,
+  };
+}

--- a/apps/frontend/src/hooks/useTextUndo.ts
+++ b/apps/frontend/src/hooks/useTextUndo.ts
@@ -112,7 +112,7 @@ export function useTextUndo(
 
   const clear = useCallback(
     (initialContent?: string) => {
-      const nextPresent = initialContent ?? content;
+      const nextPresent = initialContent ?? stateRef.current.present;
 
       commitState({
         past: [],
@@ -121,13 +121,13 @@ export function useTextUndo(
       });
       lastSyncedContentRef.current = nextPresent;
     },
-    [commitState, content]
+    [commitState]
   );
 
   useEffect(() => {
     if (content !== lastSyncedContentRef.current) {
       const nextState: UndoState = {
-        ...stateRef.current,
+        past: [],
         present: content,
         future: [],
       };

--- a/apps/frontend/src/pages/ide/ScriptMode.tsx
+++ b/apps/frontend/src/pages/ide/ScriptMode.tsx
@@ -230,12 +230,7 @@ export function ScriptMode({
 
     (async () => {
       const success = await switchToFile(activeProjectFile);
-      if (success) {
-        pendingUndoClearRef.current = {
-          fileId: activeProjectFile.id,
-          content: activeProjectFile.content || "",
-        };
-      } else if (previousEditFileIdRef.current) {
+      if (!success && previousEditFileIdRef.current) {
         void selectFileTab(previousEditFileIdRef.current, { notify: false });
       }
     })();
@@ -280,23 +275,13 @@ export function ScriptMode({
   );
 
   const previousUndoFileIdRef = useRef<string | null>(activeFileId);
-  const pendingUndoClearRef = useRef<{
-    fileId: string;
-    content: string;
-  } | null>(null);
 
   useEffect(() => {
-    const pending = pendingUndoClearRef.current;
-    if (pending) {
-      if (previousUndoFileIdRef.current !== pending.fileId) {
-        previousUndoFileIdRef.current = pending.fileId;
-        clear(pending.content);
-      }
-      requestAnimationFrame(() => {
-        pendingUndoClearRef.current = null;
-      });
+    if (activeFileId && previousUndoFileIdRef.current !== activeFileId) {
+      previousUndoFileIdRef.current = activeFileId;
+      clear(activeFileContent);
     }
-  }, [activeFileContent, activeFileId, clear]);
+  }, [activeFileId, activeFileContent, clear]);
 
   const handleGitLabFileSelect = useCallback(
     (fileId: string) => {

--- a/apps/frontend/src/pages/ide/ScriptMode.tsx
+++ b/apps/frontend/src/pages/ide/ScriptMode.tsx
@@ -351,9 +351,7 @@ export function ScriptMode({
       projectName={projectName}
       gitlabBranch={gitlabBranch}
       fileSourceType={primaryFileSourceType}
-      saveStatus={activeProjectFile ? fileSaveStatus : undefined}
-      saveConflict={activeProjectFile ? hasSaveConflict : undefined}
-      onSaveRequest={activeProjectFile ? retryFileSave : undefined}
+      isFocusMode={isFocusMode}
     />
   );
 
@@ -421,6 +419,9 @@ export function ScriptMode({
         canRedo={canRedo}
         onUndo={undo}
         onRedo={redo}
+        saveStatus={activeProjectFile ? fileSaveStatus : undefined}
+        saveConflict={activeProjectFile ? hasSaveConflict : undefined}
+        onSaveRequest={activeProjectFile ? retryFileSave : undefined}
       />
 
       {statusBar}

--- a/apps/frontend/src/pages/ide/ScriptMode.tsx
+++ b/apps/frontend/src/pages/ide/ScriptMode.tsx
@@ -19,6 +19,7 @@ import type { ScriptEditorRef } from "@/components/script-mode/ScriptEditor";
 import { useLocalStorageBoolean } from "@/hooks/useLocalStorage";
 import { ScriptModeEditorLayout } from "./components/ScriptModeEditorLayout";
 import { ScriptModeEmptyState } from "./components/ScriptModeEmptyState";
+import { useTextUndo } from "@/hooks/useTextUndo";
 
 interface ScriptModeProps {
   projectId?: string;
@@ -229,7 +230,12 @@ export function ScriptMode({
 
     (async () => {
       const success = await switchToFile(activeProjectFile);
-      if (!success && previousEditFileIdRef.current) {
+      if (success) {
+        pendingUndoClearRef.current = {
+          fileId: activeProjectFile.id,
+          content: activeProjectFile.content || "",
+        };
+      } else if (previousEditFileIdRef.current) {
         void selectFileTab(previousEditFileIdRef.current, { notify: false });
       }
     })();
@@ -252,6 +258,45 @@ export function ScriptMode({
     activeProjectFile && currentEditFileId === activeProjectFile.id
       ? editedFileContent
       : activeProjectFile?.content || "";
+
+  const handleUndoRedoChange = useCallback(
+    (content: string) => {
+      setEditedFileContent(content);
+    },
+    [setEditedFileContent]
+  );
+
+  const { canUndo, canRedo, undo, redo, recordChange, clear } = useTextUndo(
+    activeFileContent,
+    handleUndoRedoChange
+  );
+
+  const handleContentChange = useCallback(
+    (value: string) => {
+      setEditedFileContent(value);
+      recordChange(value);
+    },
+    [recordChange, setEditedFileContent]
+  );
+
+  const previousUndoFileIdRef = useRef<string | null>(activeFileId);
+  const pendingUndoClearRef = useRef<{
+    fileId: string;
+    content: string;
+  } | null>(null);
+
+  useEffect(() => {
+    const pending = pendingUndoClearRef.current;
+    if (pending) {
+      if (previousUndoFileIdRef.current !== pending.fileId) {
+        previousUndoFileIdRef.current = pending.fileId;
+        clear(pending.content);
+      }
+      requestAnimationFrame(() => {
+        pendingUndoClearRef.current = null;
+      });
+    }
+  }, [activeFileContent, activeFileId, clear]);
 
   const handleGitLabFileSelect = useCallback(
     (fileId: string) => {
@@ -370,8 +415,12 @@ export function ScriptMode({
         onSceneSelect={handleGitLabSceneSelect}
         onSelectTab={handleSelectFileTab}
         onCloseTab={handleCloseFileTab}
-        onContentChange={setEditedFileContent}
+        onContentChange={handleContentChange}
         onRefreshFiles={refreshFiles}
+        canUndo={canUndo}
+        canRedo={canRedo}
+        onUndo={undo}
+        onRedo={redo}
       />
 
       {statusBar}

--- a/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
+++ b/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
@@ -5,6 +5,7 @@ import {
   CharacterReferencePanel,
   ScriptEditor,
 } from "@/components/script-mode";
+import { UndoRedoControls } from "@/components/ide-shared";
 import { ProjectFileTree } from "@/components/script-mode/ProjectFileTree";
 import { FocusModeToggle } from "@/components/write-mode/FocusModeToggle";
 import { EditorTabBar, type EditorTabBarItem } from "@/components/ide-shared";
@@ -65,6 +66,10 @@ interface ScriptModeEditorLayoutProps {
   onContentChange: (value: string) => void;
   onRefreshFiles: () => Promise<unknown>;
   onNewChapter?: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
 }
 
 export function ScriptModeEditorLayout({
@@ -95,6 +100,10 @@ export function ScriptModeEditorLayout({
   onContentChange,
   onRefreshFiles,
   onNewChapter,
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
 }: ScriptModeEditorLayoutProps) {
   const { isFocusMode, focusToggleRef } = focusModeState;
 
@@ -198,7 +207,13 @@ export function ScriptModeEditorLayout({
                 />
               </div>
               <div className="h-12 overflow-hidden rounded-lg border border-border/80 bg-card/55 opacity-100 backdrop-blur-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
-                <div className="h-full flex items-center justify-end px-3">
+                <div className="h-full flex items-center justify-end gap-2 px-3">
+                  <UndoRedoControls
+                    canUndo={canUndo}
+                    canRedo={canRedo}
+                    onUndo={onUndo}
+                    onRedo={onRedo}
+                  />
                   <FocusModeToggle
                     ref={focusToggleRef}
                     isFocusMode={isFocusMode}

--- a/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
+++ b/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
@@ -5,16 +5,20 @@ import {
   CharacterReferencePanel,
   ScriptEditor,
 } from "@/components/script-mode";
-import { UndoRedoControls } from "@/components/ide-shared";
 import { ProjectFileTree } from "@/components/script-mode/ProjectFileTree";
 import { FocusModeToggle } from "@/components/write-mode/FocusModeToggle";
-import { EditorTabBar, type EditorTabBarItem } from "@/components/ide-shared";
+import {
+  EditorTabBar,
+  type EditorTabBarItem,
+  UndoRedoControls,
+} from "@/components/ide-shared";
 import { Button } from "@/components/ui/button";
 import type { LabelDetail } from "@branchforge/shared";
 import type { Character } from "@branchforge/shared";
 import type { ScriptEditorRef } from "@/components/script-mode/ScriptEditor";
 import type { FocusModeState } from "@/hooks/useFocusModeState";
 import type { ProjectFileNode } from "@/hooks/useProjectFiles";
+import type { SaveStatus } from "@/hooks/useAutosave";
 import type {
   Dispatch,
   KeyboardEvent,
@@ -70,6 +74,9 @@ interface ScriptModeEditorLayoutProps {
   canRedo: boolean;
   onUndo: () => void;
   onRedo: () => void;
+  saveStatus?: SaveStatus;
+  saveConflict?: boolean;
+  onSaveRequest?: () => void;
 }
 
 export function ScriptModeEditorLayout({
@@ -104,6 +111,9 @@ export function ScriptModeEditorLayout({
   canRedo,
   onUndo,
   onRedo,
+  saveStatus = "saved",
+  saveConflict = false,
+  onSaveRequest,
 }: ScriptModeEditorLayoutProps) {
   const { isFocusMode, focusToggleRef } = focusModeState;
 
@@ -159,14 +169,15 @@ export function ScriptModeEditorLayout({
             </div>
 
             <div className="p-3 space-y-3">
-              <button
-                type="button"
-                onClick={onNewChapter}
-                disabled={!onNewChapter}
-                className="w-full py-2 px-3 rounded-lg text-sm font-medium transition-colors bg-[var(--theme-color)] text-white hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                + New Chapter
-              </button>
+              {onNewChapter && (
+                <button
+                  type="button"
+                  onClick={onNewChapter}
+                  className="w-full py-2 px-3 rounded-lg text-sm font-medium transition-colors bg-[var(--theme-color)] text-white hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  + New Chapter
+                </button>
+              )}
 
               <ProjectFileTree
                 files={projectFiles}
@@ -207,7 +218,7 @@ export function ScriptModeEditorLayout({
                 />
               </div>
               <div className="h-12 overflow-hidden rounded-lg border border-border/80 bg-card/55 opacity-100 backdrop-blur-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
-                <div className="h-full flex items-center justify-end gap-2 px-3">
+                <div className="h-full flex items-center justify-end gap-3 px-3">
                   <UndoRedoControls
                     canUndo={canUndo}
                     canRedo={canRedo}
@@ -232,6 +243,10 @@ export function ScriptModeEditorLayout({
                   content={activeFileContent}
                   scrollToLine={scrollToLine}
                   onChange={onContentChange}
+                  isFocusMode={isFocusMode}
+                  saveStatus={saveStatus}
+                  saveConflict={saveConflict}
+                  onSaveRequest={onSaveRequest}
                 />
               ) : activeLabel ? (
                 <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-3">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Undo/redo added to the script editor with keyboard shortcuts (Ctrl/Cmd+Z for undo; Ctrl+Y / Cmd+Shift+Z for redo).
  * Autosave UI: save indicator now appears in the editor footer when applicable.

* **Improvements**
  * Focus mode visuals refined—footer/status opacity and hover/focus behavior improved.
  * Dropdowns (font family/size, palette) now support configurable up/down positioning and corrected chevron rotation.
  * Various UI controls re-arranged for clearer editor toolbars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->