### PR TITLE
chore: version packages to v0.8.0 [skip-coderabbit]

### DIFF
--- a/.changeset/eager-cows-happen.md
+++ b/.changeset/eager-cows-happen.md
@@ -1,5 +1,0 @@
----
-"@branchforge/frontend": patch
----
-
-Added undo/redo functionality to the script editor

--- a/.changeset/mighty-humans-itch.md
+++ b/.changeset/mighty-humans-itch.md
@@ -1,5 +1,0 @@
----
-"@branchforge/frontend": patch
----
-
-Refined the Settings modal UI and improved toggle accessibility

--- a/.changeset/sharp-kings-draw.md
+++ b/.changeset/sharp-kings-draw.md
@@ -1,7 +1,0 @@
----
-"@branchforge/shared": patch
-"@branchforge/frontend": patch
-"@branchforge/backend": patch
----
-
-Fixed autosave sync

--- a/.changeset/short-pugs-raise.md
+++ b/.changeset/short-pugs-raise.md
@@ -1,7 +1,0 @@
----
-"@branchforge/shared": minor
-"@branchforge/frontend": minor
-"@branchforge/backend": minor
----
-
-Unified project imports and management in a single settings view

--- a/.changeset/thin-clubs-cross.md
+++ b/.changeset/thin-clubs-cross.md
@@ -1,7 +1,0 @@
----
-"@branchforge/backend": patch
-"@branchforge/frontend": patch
-"@branchforge/shared": patch
----
-
-Added editing and deleting projects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to BranchForge will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.8.0 - 2026-04-24
+
+- Unified project imports and management in a single settings view
+- Added undo/redo functionality to the script editor
+- Refined the Settings modal UI and improved toggle accessibility
+- Fixed autosave sync
+- Added editing and deleting projects
+
 ## v0.7.4 - 2026-04-13
 
 - Fixed release workflow

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/backend",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/frontend",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branchforge",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "private": true,
   "description": "Visual Novel IDE for Ren'Py",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/shared",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
<!-- release-automation:version-workflow -->
## Summary
- Consume pending changesets and bump package versions to v0.8.0.
- Run build, typecheck, and tests before opening this release PR.
- Merge this PR to trigger version tagging and release workflows.

## Notes
- Generated by .github/workflows/version.yml.
- Title includes [skip-coderabbit] to skip CodeRabbit on this automation PR.