### PR TITLE
Add file-scoped label creation and reordering to backend

### DIFF
--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -375,7 +375,7 @@ export const createLabelSchema = z
     visibility: labelVisibilitySchema.optional(),
     title: z.string().trim().min(1, "Title is required").max(255),
     projectFileId: uuidSchema.optional(),
-    afterLabelId: uuidSchema.optional(),
+    afterLabelId: uuidSchema.optional().nullable(),
   })
   .strict();
 

--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -374,6 +374,8 @@ export const createLabelSchema = z
     status: labelStatusSchema.optional(),
     visibility: labelVisibilitySchema.optional(),
     title: z.string().trim().min(1, "Title is required").max(255),
+    projectFileId: uuidSchema.optional(),
+    afterLabelId: uuidSchema.optional(),
   })
   .strict();
 
@@ -407,6 +409,34 @@ export const updateLabelDialogueBodySchema = z
     expectedContentHash: expectedContentHashSchema,
   })
   .strict();
+
+/**
+ * Reorder labels in file request validation
+ */
+export const reorderLabelsInFileSchema = z
+  .object({
+    projectFileId: uuidSchema,
+    labelOrders: z
+      .array(
+        z.object({
+          labelId: uuidSchema,
+          newPosition: z.number().int().min(0),
+        })
+      )
+      .min(1, "At least one label must be reordered"),
+  })
+  .strict()
+  .refine(
+    (data) => {
+      const labelIds = data.labelOrders.map((lo) => lo.labelId);
+      const uniqueIds = new Set(labelIds);
+      return labelIds.length === uniqueIds.size;
+    },
+    {
+      message: "labelId values must be unique",
+      path: ["labelOrders"],
+    }
+  );
 
 // ============================================================================
 // Route Configuration Schemas
@@ -1021,6 +1051,9 @@ export type CreateLabelInput = z.infer<typeof createLabelSchema>;
 export type UpdateLabelInput = z.infer<typeof updateLabelSchema>;
 export type UpdateLabelDialogueInput = z.infer<
   typeof updateLabelDialogueBodySchema
+>;
+export type ReorderLabelsInFileInput = z.infer<
+  typeof reorderLabelsInFileSchema
 >;
 
 export type CreateCharacterInput = z.infer<typeof createCharacterSchema>;

--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -377,7 +377,16 @@ export const createLabelSchema = z
     projectFileId: uuidSchema.optional(),
     afterLabelId: uuidSchema.optional().nullable(),
   })
-  .strict();
+  .strict()
+  .superRefine((data, ctx) => {
+    if (data.afterLabelId && !data.projectFileId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["afterLabelId"],
+        message: "afterLabelId can only be used with projectFileId",
+      });
+    }
+  });
 
 /**
  * Update label request validation

--- a/apps/backend/src/routes/labels.routes.ts
+++ b/apps/backend/src/routes/labels.routes.ts
@@ -14,6 +14,7 @@ import {
   updateLabel,
   deleteLabel,
   getLabelCharacters,
+  reorderLabelsInFile,
   type PublicLabel,
   type LabelDetail,
   type ListLabelsFilters,
@@ -28,6 +29,7 @@ import {
 import {
   NotFoundError,
   ForbiddenError,
+  ValidationError,
 } from "../middleware/error-handler.middleware.js";
 import {
   listLabelsQuerySchema,
@@ -35,10 +37,12 @@ import {
   updateLabelDialogueBodySchema,
   createLabelSchema,
   updateLabelSchema,
+  reorderLabelsInFileSchema,
   type ListLabelsQuery,
   type UpdateLabelDialogueInput,
   type CreateLabelInput,
   type UpdateLabelInput,
+  type ReorderLabelsInFileInput,
 } from "../lib/validation.js";
 import { getDb } from "../db/index.js";
 import {
@@ -100,6 +104,10 @@ interface UpdateLabelDialogueResponse {
 
 interface LabelCharactersResponse {
   characters: LabelCharacterWithInfo[];
+}
+
+interface ReorderLabelsInFileResponse {
+  labels: PublicLabel[];
 }
 
 /**
@@ -838,6 +846,45 @@ async function getLabelCharactersHandler(
   }
 }
 
+/**
+ * Reorder labels within a file
+ *
+ * POST /labels/reorder-file
+ * Body: ReorderLabelsInFileInput
+ * Requires authentication
+ */
+async function reorderLabelsInFileHandler(
+  request: FastifyRequest<{ Body: ReorderLabelsInFileInput }>,
+  reply: FastifyReply
+): Promise<void> {
+  const user = request.user!;
+
+  try {
+    const labels = await reorderLabelsInFile(user.id, request.body);
+    reply.status(200).send({ labels } as ReorderLabelsInFileResponse);
+  } catch (error) {
+    request.log.error(error);
+
+    // Handle known error types
+    if (error instanceof NotFoundError) {
+      reply
+        .status(404)
+        .send({ error: "Project file not found" } as ErrorResponse);
+      return;
+    }
+    if (error instanceof ForbiddenError) {
+      reply.status(403).send({ error: "Forbidden" } as ErrorResponse);
+      return;
+    }
+    if (error instanceof ValidationError) {
+      reply.status(400).send({ error: error.message } as ErrorResponse);
+      return;
+    }
+
+    reply.status(500).send({ error: "Internal server error" } as ErrorResponse);
+  }
+}
+
 // ============================================================================
 // Routes Registration
 // ============================================================================
@@ -905,5 +952,13 @@ export async function labelsRoutes(fastify: FastifyInstance): Promise<void> {
       preValidation: validateParams(labelIdParamsSchema),
     },
     getLabelCharactersHandler
+  );
+  fastify.post<{ Body: ReorderLabelsInFileInput }>(
+    "/labels/reorder-file",
+    {
+      onRequest: authenticate,
+      preValidation: validateBody(reorderLabelsInFileSchema),
+    },
+    reorderLabelsInFileHandler
   );
 }

--- a/apps/backend/src/routes/labels.routes.ts
+++ b/apps/backend/src/routes/labels.routes.ts
@@ -712,6 +712,10 @@ async function createLabelHandler(
       reply.status(403).send({ error: "Forbidden" } as ErrorResponse);
       return;
     }
+    if (error instanceof ValidationError) {
+      reply.status(400).send({ error: "Bad request" } as ErrorResponse);
+      return;
+    }
 
     reply.status(500).send({ error: "Internal server error" } as ErrorResponse);
   }
@@ -877,7 +881,10 @@ async function reorderLabelsInFileHandler(
       return;
     }
     if (error instanceof ValidationError) {
-      reply.status(400).send({ error: error.message } as ErrorResponse);
+      request.log.error(error);
+      reply
+        .status(400)
+        .send({ error: "Invalid request payload" } as ErrorResponse);
       return;
     }
 

--- a/apps/backend/src/services/__tests__/labels-file-scoped.integration.test.ts
+++ b/apps/backend/src/services/__tests__/labels-file-scoped.integration.test.ts
@@ -1,0 +1,1057 @@
+/**
+ * Labels Service - File Scoped Integration Tests
+ *
+ * Tests for file-scoped label creation and reordering functionality.
+ * These tests cover the new features for creating labels within specific
+ * RPY files at specified positions, and reordering labels via drag-and-drop.
+ *
+ * Prerequisites:
+ * - DATABASE_URL_TEST environment variable must be set
+ * - Test database must exist and have proper schema
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
+import { getDb } from "../../db/index.js";
+import {
+  users,
+  projects,
+  labels,
+  projectFiles,
+  type NewUser,
+  type NewProject,
+  type NewProjectFile,
+} from "../../db/schema/index.js";
+import { eq, inArray } from "drizzle-orm";
+import { createLabel, reorderLabelsInFile } from "../labels.service.js";
+import { testEmail, testUuid } from "../../utils/test-ids.js";
+import { calculateContentHash } from "../../lib/hash.js";
+import {
+  ValidationError,
+  NotFoundError,
+  ForbiddenError,
+} from "../../middleware/error-handler.middleware.js";
+
+describe("LabelsService - File Scoped (Integration)", () => {
+  let db: ReturnType<typeof getDb>;
+
+  beforeAll(async () => {
+    db = getDb();
+  });
+
+  // Test fixtures
+  const testUserId = testUuid("03000000", 1);
+  const otherUserId = testUuid("03000000", 2);
+
+  const testUser: NewUser = {
+    id: testUserId,
+    email: testEmail("labels-file-scoped", "owner"),
+    passwordHash: "hashed_password",
+    role: "OWNER",
+  };
+
+  const otherUser: NewUser = {
+    id: otherUserId,
+    email: testEmail("labels-file-scoped", "other"),
+    passwordHash: "hashed_password",
+    role: "OWNER",
+  };
+
+  const testProject: NewProject = {
+    id: testUuid("13000000", 1),
+    userId: testUserId,
+    name: "Test Project",
+    description: "A project for testing file-scoped labels",
+    maxMeterDelta: 10,
+    source: "ZIP",
+  };
+
+  // Helper to clean up all test data in reverse dependency order
+  async function cleanupTestData() {
+    // Delete in reverse dependency order to handle foreign key constraints
+    // First, fetch all project IDs owned by the test users
+    const userProjects = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(inArray(projects.userId, [testUserId, otherUserId]));
+
+    const projectIds = userProjects.map((p) => p.id);
+
+    // Delete all labels and files for those projects
+    if (projectIds.length > 0) {
+      await db.delete(labels).where(inArray(labels.projectId, projectIds));
+      await db
+        .delete(projectFiles)
+        .where(inArray(projectFiles.projectId, projectIds));
+    }
+
+    // Then delete all projects (including any created during tests)
+    await db.delete(projects).where(eq(projects.userId, testUserId));
+    await db.delete(projects).where(eq(projects.userId, otherUserId));
+
+    // Finally delete users
+    await db.delete(users).where(eq(users.id, testUserId));
+    await db.delete(users).where(eq(users.id, otherUserId));
+  }
+
+  // Helper to set up test data
+  async function setupTestData() {
+    // Insert users
+    await db.insert(users).values([testUser, otherUser]);
+
+    // Insert project
+    await db.insert(projects).values(testProject);
+  }
+
+  beforeEach(async () => {
+    await cleanupTestData();
+    await setupTestData();
+  });
+
+  afterEach(async () => {
+    await cleanupTestData();
+  });
+
+  describe("createLabel with file-scoped parameters", () => {
+    describe("projectFileId parameter", () => {
+      it("should create a label associated with a project file", async () => {
+        // Create a project file
+        const projectFile: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/act_i.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "Hello World"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "Hello World"'),
+        };
+
+        await db.insert(projectFiles).values(projectFile);
+
+        // Create a label with projectFileId
+        const result = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "New Label in File",
+          labelNumber: 1,
+          projectFileId: projectFile.id!,
+        });
+
+        expect(result.id).toBeDefined();
+        expect(result.title).toBe("New Label in File");
+        expect(result.projectFileId).toBe(projectFile.id);
+        expect(result.fileName).toBe("act_i.rpy");
+      });
+
+      it("should throw NotFoundError when projectFileId does not exist", async () => {
+        const nonExistentFileId = testUuid("13000005", 999999);
+
+        await expect(
+          createLabel(testUserId, {
+            projectId: testProject.id!,
+            title: "Label with Non-existent File",
+            labelNumber: 1,
+            projectFileId: nonExistentFileId,
+          })
+        ).rejects.toThrow(NotFoundError);
+      });
+
+      it("should throw ForbiddenError when project file belongs to different project", async () => {
+        // Create a file in a different project
+        const otherProject: NewProject = {
+          id: testUuid("13000000", 2),
+          userId: otherUserId,
+          name: "Other Project",
+          source: "ZIP",
+        };
+
+        await db.insert(projects).values(otherProject);
+
+        const otherProjectFile: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: otherProject.id!,
+          filePath: "labels/other.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "Other"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "Other"'),
+        };
+
+        await db.insert(projectFiles).values(otherProjectFile);
+
+        // Try to create a label in testProject with a file from otherProject
+        await expect(
+          createLabel(testUserId, {
+            projectId: testProject.id!,
+            title: "Label with Wrong File",
+            labelNumber: 1,
+            projectFileId: otherProjectFile.id!,
+          })
+        ).rejects.toThrow(ForbiddenError);
+      });
+
+      it("should throw ForbiddenError when user is not project owner", async () => {
+        const projectFile: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/act_i.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "Hello"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "Hello"'),
+        };
+
+        await db.insert(projectFiles).values(projectFile);
+
+        // Try to create a label as otherUser (who doesn't own testProject)
+        await expect(
+          createLabel(otherUserId, {
+            projectId: testProject.id!,
+            title: "Unauthorized Label",
+            labelNumber: 1,
+            projectFileId: projectFile.id!,
+          })
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    describe("afterLabelId parameter", () => {
+      it("should create a label positioned after another label in the same file", async () => {
+        // Create a project file
+        const projectFile: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/act_i.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "Hello"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "Hello"'),
+        };
+
+        await db.insert(projectFiles).values(projectFile);
+
+        // Create first label
+        const firstLabel = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "First Label",
+          labelNumber: 1,
+          projectFileId: projectFile.id!,
+        });
+
+        // Create second label after first label
+        const secondLabel = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "Second Label",
+          labelNumber: 2,
+          projectFileId: projectFile.id!,
+          afterLabelId: firstLabel.id,
+        });
+
+        // Verify positions
+        const [firstLabelDb] = await db
+          .select()
+          .from(labels)
+          .where(eq(labels.id, firstLabel.id))
+          .limit(1);
+
+        const [secondLabelDb] = await db
+          .select()
+          .from(labels)
+          .where(eq(labels.id, secondLabel.id))
+          .limit(1);
+
+        expect(firstLabelDb.labelPosition).toBe(0);
+        expect(secondLabelDb.labelPosition).toBe(1);
+      });
+
+      it("should create a label at the beginning when afterLabelId is null", async () => {
+        // Create a project file
+        const projectFile: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/act_i.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "Hello"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "Hello"'),
+        };
+
+        await db.insert(projectFiles).values(projectFile);
+
+        // Create first label
+        const firstLabel = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "First Label",
+          labelNumber: 1,
+          projectFileId: projectFile.id!,
+        });
+
+        // Create second label with afterLabelId: null (should go to beginning)
+        const secondLabel = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "Second Label",
+          labelNumber: 2,
+          projectFileId: projectFile.id!,
+          afterLabelId: null,
+        });
+
+        // Verify positions (second label should be at position 0, first at 1)
+        const [firstLabelDb] = await db
+          .select()
+          .from(labels)
+          .where(eq(labels.id, firstLabel.id))
+          .limit(1);
+
+        const [secondLabelDb] = await db
+          .select()
+          .from(labels)
+          .where(eq(labels.id, secondLabel.id))
+          .limit(1);
+
+        expect(firstLabelDb.labelPosition).toBe(1);
+        expect(secondLabelDb.labelPosition).toBe(0);
+      });
+
+      it("should throw NotFoundError when afterLabelId does not exist", async () => {
+        const projectFile: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/act_i.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "Hello"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "Hello"'),
+        };
+
+        await db.insert(projectFiles).values(projectFile);
+
+        const nonExistentLabelId = testUuid("13000002", 999999);
+
+        await expect(
+          createLabel(testUserId, {
+            projectId: testProject.id!,
+            title: "Label with Non-existent After Label",
+            labelNumber: 1,
+            projectFileId: projectFile.id!,
+            afterLabelId: nonExistentLabelId,
+          })
+        ).rejects.toThrow(NotFoundError);
+      });
+
+      it("should throw ValidationError when afterLabelId is in a different file", async () => {
+        // Create two project files
+        const file1: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/file1.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "File 1"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "File 1"'),
+        };
+
+        const file2: NewProjectFile = {
+          id: testUuid("13000005", 2),
+          projectId: testProject.id!,
+          filePath: "labels/file2.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "File 2"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "File 2"'),
+        };
+
+        await db.insert(projectFiles).values([file1, file2]);
+
+        // Create a label in file1
+        const labelInFile1 = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "Label in File 1",
+          labelNumber: 1,
+          projectFileId: file1.id!,
+        });
+
+        // Try to create a label in file2 after the label in file1
+        await expect(
+          createLabel(testUserId, {
+            projectId: testProject.id!,
+            title: "Label in File 2",
+            labelNumber: 2,
+            projectFileId: file2.id!,
+            afterLabelId: labelInFile1.id,
+          })
+        ).rejects.toThrow(ValidationError);
+      });
+
+      it("should throw ValidationError when afterLabelId has no file association", async () => {
+        // Create a label without file association
+        const orphanLabel = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "Orphan Label",
+          labelNumber: 1,
+        });
+
+        const projectFile: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/act_i.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "Hello"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "Hello"'),
+        };
+
+        await db.insert(projectFiles).values(projectFile);
+
+        // Try to create a label in a file after the orphan label
+        await expect(
+          createLabel(testUserId, {
+            projectId: testProject.id!,
+            title: "Label with Orphan After Label",
+            labelNumber: 2,
+            projectFileId: projectFile.id!,
+            afterLabelId: orphanLabel.id,
+          })
+        ).rejects.toThrow(ValidationError);
+      });
+    });
+
+    describe("label name collision handling", () => {
+      it("should append counter suffix when label name collision occurs", async () => {
+        const projectFile: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/act_i.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "Hello"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "Hello"'),
+        };
+
+        await db.insert(projectFiles).values(projectFile);
+
+        // Create first label with title "My Label"
+        const firstLabel = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "My Label",
+          labelNumber: 1,
+          projectFileId: projectFile.id!,
+        });
+
+        // Create second label with same title
+        const secondLabel = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "My Label",
+          labelNumber: 2,
+          projectFileId: projectFile.id!,
+        });
+
+        // Verify counter suffix was added
+        expect(firstLabel.title).toBe("My Label");
+        expect(secondLabel.title).toBe("My Label_2");
+      });
+
+      it("should increment counter suffix for multiple collisions", async () => {
+        const projectFile: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/act_i.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "Hello"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "Hello"'),
+        };
+
+        await db.insert(projectFiles).values(projectFile);
+
+        // Create first label
+        const label1 = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "Collision Label",
+          labelNumber: 1,
+          projectFileId: projectFile.id!,
+        });
+
+        // Create second label with same title
+        const label2 = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "Collision Label",
+          labelNumber: 2,
+          projectFileId: projectFile.id!,
+        });
+
+        // Create third label with same title
+        const label3 = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "Collision Label",
+          labelNumber: 3,
+          projectFileId: projectFile.id!,
+        });
+
+        expect(label1.title).toBe("Collision Label");
+        expect(label2.title).toBe("Collision Label_2");
+        expect(label3.title).toBe("Collision Label_3");
+      });
+
+      it("should only check for collisions within the same file", async () => {
+        // Create two files
+        const file1: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/file1.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "File 1"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "File 1"'),
+        };
+
+        const file2: NewProjectFile = {
+          id: testUuid("13000005", 2),
+          projectId: testProject.id!,
+          filePath: "labels/file2.rpy",
+          fileType: "STORY",
+          content: 'label start:\n    "File 2"',
+          source: "ZIP",
+          contentHash: calculateContentHash('label start:\n    "File 2"'),
+        };
+
+        await db.insert(projectFiles).values([file1, file2]);
+
+        // Create label in file1
+        const label1 = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "Same Title",
+          labelNumber: 1,
+          projectFileId: file1.id!,
+        });
+
+        // Create label in file2 with same title (no collision expected)
+        const label2 = await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "Same Title",
+          labelNumber: 2,
+          projectFileId: file2.id!,
+        });
+
+        expect(label1.title).toBe("Same Title");
+        expect(label2.title).toBe("Same Title");
+      });
+    });
+
+    describe("RPY content updates", () => {
+      it("should insert label into RPY content when creating file-scoped label", async () => {
+        const initialContent = 'label start:\n    "Hello World"\n    return';
+        const projectFile: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/act_i.rpy",
+          fileType: "STORY",
+          content: initialContent,
+          source: "ZIP",
+          contentHash: calculateContentHash(initialContent),
+        };
+
+        await db.insert(projectFiles).values(projectFile);
+
+        // Create a label
+        await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "New Label",
+          labelNumber: 1,
+          projectFileId: projectFile.id!,
+        });
+
+        // Verify the file content was updated
+        const [updatedFile] = await db
+          .select()
+          .from(projectFiles)
+          .where(eq(projectFiles.id, projectFile.id!))
+          .limit(1);
+
+        expect(updatedFile.content).toContain("label new_label:");
+      });
+
+      it("should update contentHash when modifying RPY content", async () => {
+        const initialContent = 'label start:\n    "Hello"';
+        const initialHash = calculateContentHash(initialContent);
+        const projectFile: NewProjectFile = {
+          id: testUuid("13000005", 1),
+          projectId: testProject.id!,
+          filePath: "labels/act_i.rpy",
+          fileType: "STORY",
+          content: initialContent,
+          source: "ZIP",
+          contentHash: initialHash,
+        };
+
+        await db.insert(projectFiles).values(projectFile);
+
+        // Create a label
+        await createLabel(testUserId, {
+          projectId: testProject.id!,
+          title: "New Label",
+          labelNumber: 1,
+          projectFileId: projectFile.id!,
+        });
+
+        // Verify the contentHash was updated
+        const [updatedFile] = await db
+          .select()
+          .from(projectFiles)
+          .where(eq(projectFiles.id, projectFile.id!))
+          .limit(1);
+
+        expect(updatedFile.contentHash).not.toBe(initialHash);
+      });
+    });
+  });
+
+  describe("reorderLabelsInFile", () => {
+    it("should reorder labels within a file", async () => {
+      // Create a project file
+      const projectFile: NewProjectFile = {
+        id: testUuid("13000005", 1),
+        projectId: testProject.id!,
+        filePath: "labels/act_i.rpy",
+        fileType: "STORY",
+        content: 'label start:\n    "Hello"',
+        source: "ZIP",
+        contentHash: calculateContentHash('label start:\n    "Hello"'),
+      };
+
+      await db.insert(projectFiles).values(projectFile);
+
+      // Create three labels
+      const label1 = await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 1",
+        labelNumber: 1,
+        projectFileId: projectFile.id!,
+      });
+
+      const label2 = await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 2",
+        labelNumber: 2,
+        projectFileId: projectFile.id!,
+      });
+
+      const label3 = await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 3",
+        labelNumber: 3,
+        projectFileId: projectFile.id!,
+      });
+
+      // Reorder: label3 -> position 0, label1 -> position 1, label2 -> position 2
+      await reorderLabelsInFile(testUserId, {
+        projectFileId: projectFile.id!,
+        labelOrders: [
+          { labelId: label3.id, newPosition: 0 },
+          { labelId: label1.id, newPosition: 1 },
+          { labelId: label2.id, newPosition: 2 },
+        ],
+      });
+
+      // Verify new positions
+      const [label1Db] = await db
+        .select()
+        .from(labels)
+        .where(eq(labels.id, label1.id))
+        .limit(1);
+
+      const [label2Db] = await db
+        .select()
+        .from(labels)
+        .where(eq(labels.id, label2.id))
+        .limit(1);
+
+      const [label3Db] = await db
+        .select()
+        .from(labels)
+        .where(eq(labels.id, label3.id))
+        .limit(1);
+
+      expect(label3Db.labelPosition).toBe(0);
+      expect(label1Db.labelPosition).toBe(1);
+      expect(label2Db.labelPosition).toBe(2);
+    });
+
+    it("should throw NotFoundError when projectFileId does not exist", async () => {
+      const nonExistentFileId = testUuid("13000005", 999999);
+
+      await expect(
+        reorderLabelsInFile(testUserId, {
+          projectFileId: nonExistentFileId,
+          labelOrders: [{ labelId: testUuid("13000002", 1), newPosition: 0 }],
+        })
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("should throw ForbiddenError when user is not project owner", async () => {
+      const projectFile: NewProjectFile = {
+        id: testUuid("13000005", 1),
+        projectId: testProject.id!,
+        filePath: "labels/act_i.rpy",
+        fileType: "STORY",
+        content: 'label start:\n    "Hello"',
+        source: "ZIP",
+        contentHash: calculateContentHash('label start:\n    "Hello"'),
+      };
+
+      await db.insert(projectFiles).values(projectFile);
+
+      const label = await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Test Label",
+        labelNumber: 1,
+        projectFileId: projectFile.id!,
+      });
+
+      // Try to reorder as otherUser
+      await expect(
+        reorderLabelsInFile(otherUserId, {
+          projectFileId: projectFile.id!,
+          labelOrders: [{ labelId: label.id, newPosition: 0 }],
+        })
+      ).rejects.toThrow(ForbiddenError);
+    });
+
+    it("should throw ValidationError when labelId does not exist", async () => {
+      const projectFile: NewProjectFile = {
+        id: testUuid("13000005", 1),
+        projectId: testProject.id!,
+        filePath: "labels/act_i.rpy",
+        fileType: "STORY",
+        content: 'label start:\n    "Hello"',
+        source: "ZIP",
+        contentHash: calculateContentHash('label start:\n    "Hello"'),
+      };
+
+      await db.insert(projectFiles).values(projectFile);
+
+      const nonExistentLabelId = testUuid("13000002", 999999);
+
+      await expect(
+        reorderLabelsInFile(testUserId, {
+          projectFileId: projectFile.id!,
+          labelOrders: [{ labelId: nonExistentLabelId, newPosition: 0 }],
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw ValidationError when label is in a different file", async () => {
+      // Create two files
+      const file1: NewProjectFile = {
+        id: testUuid("13000005", 1),
+        projectId: testProject.id!,
+        filePath: "labels/file1.rpy",
+        fileType: "STORY",
+        content: 'label start:\n    "File 1"',
+        source: "ZIP",
+        contentHash: calculateContentHash('label start:\n    "File 1"'),
+      };
+
+      const file2: NewProjectFile = {
+        id: testUuid("13000005", 2),
+        projectId: testProject.id!,
+        filePath: "labels/file2.rpy",
+        fileType: "STORY",
+        content: 'label start:\n    "File 2"',
+        source: "ZIP",
+        contentHash: calculateContentHash('label start:\n    "File 2"'),
+      };
+
+      await db.insert(projectFiles).values([file1, file2]);
+
+      // Create a label in file1
+      const labelInFile1 = await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label in File 1",
+        labelNumber: 1,
+        projectFileId: file1.id!,
+      });
+
+      // Try to reorder in file2 (but the label is in file1)
+      await expect(
+        reorderLabelsInFile(testUserId, {
+          projectFileId: file2.id!,
+          labelOrders: [{ labelId: labelInFile1.id, newPosition: 0 }],
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("should resync all label positions after reordering", async () => {
+      const projectFile: NewProjectFile = {
+        id: testUuid("13000005", 1),
+        projectId: testProject.id!,
+        filePath: "labels/act_i.rpy",
+        fileType: "STORY",
+        content: 'label start:\n    "Hello"',
+        source: "ZIP",
+        contentHash: calculateContentHash('label start:\n    "Hello"'),
+      };
+
+      await db.insert(projectFiles).values(projectFile);
+
+      // Create three labels
+      await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 1",
+        labelNumber: 1,
+        projectFileId: projectFile.id!,
+      });
+
+      await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 2",
+        labelNumber: 2,
+        projectFileId: projectFile.id!,
+      });
+
+      const label3 = await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 3",
+        labelNumber: 3,
+        projectFileId: projectFile.id!,
+      });
+
+      // Reorder: move label3 to position 1 (should resync all positions)
+      await reorderLabelsInFile(testUserId, {
+        projectFileId: projectFile.id!,
+        labelOrders: [{ labelId: label3.id, newPosition: 1 }],
+      });
+
+      // Verify all labels have sequential positions
+      const allLabels = await db
+        .select()
+        .from(labels)
+        .where(eq(labels.projectFileId, projectFile.id!))
+        .orderBy(labels.labelPosition);
+
+      expect(allLabels).toHaveLength(3);
+      expect(allLabels[0].labelPosition).toBe(0);
+      expect(allLabels[1].labelPosition).toBe(1);
+      expect(allLabels[2].labelPosition).toBe(2);
+    });
+
+    it("should handle partial reordering (only some labels)", async () => {
+      const projectFile: NewProjectFile = {
+        id: testUuid("13000005", 1),
+        projectId: testProject.id!,
+        filePath: "labels/act_i.rpy",
+        fileType: "STORY",
+        content: 'label start:\n    "Hello"',
+        source: "ZIP",
+        contentHash: calculateContentHash('label start:\n    "Hello"'),
+      };
+
+      await db.insert(projectFiles).values(projectFile);
+
+      // Create four labels
+      const label1 = await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 1",
+        labelNumber: 1,
+        projectFileId: projectFile.id!,
+      });
+
+      await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 2",
+        labelNumber: 2,
+        projectFileId: projectFile.id!,
+      });
+
+      const label3 = await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 3",
+        labelNumber: 3,
+        projectFileId: projectFile.id!,
+      });
+
+      await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 4",
+        labelNumber: 4,
+        projectFileId: projectFile.id!,
+      });
+
+      // Reorder only label3 and label1
+      await reorderLabelsInFile(testUserId, {
+        projectFileId: projectFile.id!,
+        labelOrders: [
+          { labelId: label3.id, newPosition: 2 },
+          { labelId: label1.id, newPosition: 0 },
+        ],
+      });
+
+      // Verify all labels are still sequential
+      const allLabels = await db
+        .select()
+        .from(labels)
+        .where(eq(labels.projectFileId, projectFile.id!))
+        .orderBy(labels.labelPosition);
+
+      expect(allLabels).toHaveLength(4);
+      expect(allLabels[0].id).toBe(label1.id);
+      expect(allLabels[0].labelPosition).toBe(0);
+      expect(allLabels[1].labelPosition).toBe(1);
+      expect(allLabels[2].id).toBe(label3.id);
+      expect(allLabels[2].labelPosition).toBe(2);
+      expect(allLabels[3].labelPosition).toBe(3);
+    });
+
+    it("should throw ValidationError when labelOrders array is empty", async () => {
+      const projectFile: NewProjectFile = {
+        id: testUuid("13000005", 1),
+        projectId: testProject.id!,
+        filePath: "labels/act_i.rpy",
+        fileType: "STORY",
+        content: 'label start:\n    "Hello"',
+        source: "ZIP",
+        contentHash: calculateContentHash('label start:\n    "Hello"'),
+      };
+
+      await db.insert(projectFiles).values(projectFile);
+
+      await expect(
+        reorderLabelsInFile(testUserId, {
+          projectFileId: projectFile.id!,
+          labelOrders: [],
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw ForbiddenError when project file belongs to different project", async () => {
+      const otherProject: NewProject = {
+        id: testUuid("13000000", 2),
+        userId: otherUserId,
+        name: "Other Project",
+        source: "ZIP",
+      };
+
+      await db.insert(projects).values(otherProject);
+
+      const otherProjectFile: NewProjectFile = {
+        id: testUuid("13000005", 1),
+        projectId: otherProject.id!,
+        filePath: "labels/other.rpy",
+        fileType: "STORY",
+        content: 'label start:\n    "Other"',
+        source: "ZIP",
+        contentHash: calculateContentHash('label start:\n    "Other"'),
+      };
+
+      await db.insert(projectFiles).values(otherProjectFile);
+
+      const label = await createLabel(otherUserId, {
+        projectId: otherProject.id!,
+        title: "Label",
+        labelNumber: 1,
+        projectFileId: otherProjectFile.id!,
+      });
+
+      // Try to reorder in testProject with a file from otherProject
+      await expect(
+        reorderLabelsInFile(testUserId, {
+          projectFileId: otherProjectFile.id!,
+          labelOrders: [{ labelId: label.id, newPosition: 0 }],
+        })
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe("transaction safety", () => {
+    it("should create label with non-standard RPY content", async () => {
+      // This test verifies that label creation succeeds with non-standard RPY content
+      // The parser handles this content gracefully, allowing the label to be created
+      const nonStandardContent = "invalid rpy content {{{";
+      const projectFile: NewProjectFile = {
+        id: testUuid("13000005", 1),
+        projectId: testProject.id!,
+        filePath: "labels/act_i.rpy",
+        fileType: "STORY",
+        content: nonStandardContent,
+        source: "ZIP",
+        contentHash: calculateContentHash(nonStandardContent),
+      };
+
+      await db.insert(projectFiles).values(projectFile);
+
+      const result = await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Test Label",
+        labelNumber: 1,
+        projectFileId: projectFile.id!,
+      });
+
+      expect(result.id).toBeDefined();
+
+      // Verify the label was actually created
+      const [label] = await db
+        .select()
+        .from(labels)
+        .where(eq(labels.id, result.id))
+        .limit(1);
+
+      expect(label).toBeDefined();
+    });
+
+    it("should rollback reordering on failure", async () => {
+      const projectFile: NewProjectFile = {
+        id: testUuid("13000005", 1),
+        projectId: testProject.id!,
+        filePath: "labels/act_i.rpy",
+        fileType: "STORY",
+        content: 'label start:\n    "Hello"',
+        source: "ZIP",
+        contentHash: calculateContentHash('label start:\n    "Hello"'),
+      };
+
+      await db.insert(projectFiles).values(projectFile);
+
+      const label1 = await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 1",
+        labelNumber: 1,
+        projectFileId: projectFile.id!,
+      });
+
+      await createLabel(testUserId, {
+        projectId: testProject.id!,
+        title: "Label 2",
+        labelNumber: 2,
+        projectFileId: projectFile.id!,
+      });
+
+      // Get original positions
+      const [originalLabel1] = await db
+        .select()
+        .from(labels)
+        .where(eq(labels.id, label1.id))
+        .limit(1);
+
+      const originalPosition = originalLabel1.labelPosition;
+
+      // Try to reorder with a non-existent label (should fail)
+      try {
+        await reorderLabelsInFile(testUserId, {
+          projectFileId: projectFile.id!,
+          labelOrders: [
+            { labelId: label1.id, newPosition: 1 },
+            { labelId: testUuid("13000002", 999999), newPosition: 0 }, // non-existent
+          ],
+        });
+      } catch {
+        // Expected to fail
+      }
+
+      // Verify positions were not changed (transaction rolled back)
+      const [rolledBackLabel1] = await db
+        .select()
+        .from(labels)
+        .where(eq(labels.id, label1.id))
+        .limit(1);
+
+      expect(rolledBackLabel1.labelPosition).toBe(originalPosition);
+    });
+  });
+});

--- a/apps/backend/src/services/labels.service.ts
+++ b/apps/backend/src/services/labels.service.ts
@@ -16,19 +16,32 @@ import {
   routeConfigs,
   projectFiles,
 } from "../db/schema/index.js";
-import { eq, and, asc, or, isNull } from "drizzle-orm";
+import { eq, and, asc, or, isNull, inArray, sql } from "drizzle-orm";
 import type { Label, LabelLine } from "../db/schema/index.js";
 import type { PublicLabel } from "@branchforge/shared";
-import { LabelStatus } from "@branchforge/shared";
+import { LabelStatus, sanitizeLabelName } from "@branchforge/shared";
 import { createAuditFields, updateAuditFields } from "../lib/audit.js";
 import {
   NotFoundError,
   ForbiddenError,
+  ValidationError,
 } from "../middleware/error-handler.middleware.js";
 import { logWarn, LogEventType } from "../lib/logger.js";
+import {
+  addLabelToRPYContent,
+  reorderLabelsInRPYContent,
+} from "./rpy-parser.service.js";
+import { calculateContentHash } from "../lib/hash.js";
 
 // Re-export PublicLabel from shared for route handlers
 export type { PublicLabel };
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// Maximum attempts to find a unique label name before falling back to timestamp/UUID
+const MAX_LABEL_ATTEMPTS = 1000;
 
 // ============================================================================
 // Derived Character Query
@@ -78,6 +91,56 @@ function extractFileName(filePath: string | null): string | null {
   if (!filePath) return null;
   const parts = filePath.split("/");
   return parts[parts.length - 1] || null;
+}
+
+/**
+ * Resync label positions for all labels in a file
+ * Ensures positions are sequential starting from 0
+ *
+ * @param tx - Database transaction or connection
+ * @param projectFileId - The project file ID
+ */
+async function resyncLabelPositions(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tx: any,
+  projectFileId: string
+): Promise<void> {
+  const fileLabels = await tx
+    .select()
+    .from(labels)
+    .where(
+      and(eq(labels.projectFileId, projectFileId), isNull(labels.deletedAt))
+    )
+    .orderBy(asc(labels.labelPosition));
+
+  // Sort labels: those with same position maintain their relative order
+  // but when multiple labels have position 0 (newly inserted at beginning),
+  // the newest one (most recent createdAt) should come first
+  fileLabels.sort((a: Label, b: Label) => {
+    if (a.labelPosition !== b.labelPosition) {
+      return (a.labelPosition ?? 0) - (b.labelPosition ?? 0);
+    }
+    // Same position: newer labels come first
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+
+  // Batch update all label positions in a single query using CASE statement
+  // This avoids N round-trips to the database
+  if (fileLabels.length > 0) {
+    const caseStatements = fileLabels
+      .map((label: Label, i: number) => `WHEN '${label.id}' THEN ${i}`)
+      .join("\n        ");
+
+    const labelIds = fileLabels.map((l: Label) => `'${l.id}'`).join(", ");
+
+    await tx.execute(
+      sql`UPDATE labels SET "label_position" = CASE id
+          ${sql.raw(caseStatements)}
+          ELSE "label_position"
+        END
+        WHERE id IN (${sql.raw(labelIds)})`
+    );
+  }
 }
 
 // ============================================================================
@@ -451,93 +514,215 @@ export async function createLabel(
     status?: LabelStatus | null;
     visibility?: "EXCLUSIVE" | "SHARED" | "DUO_PAIR" | null;
     projectFileId?: string | null;
+    afterLabelId?: string | null;
   }
 ): Promise<PublicLabel> {
   const db = getDb();
 
-  // Verify user has access to the project
-  const [project] = await db
-    .select({ userId: projects.userId })
-    .from(projects)
-    .where(eq(projects.id, data.projectId))
-    .limit(1);
-
-  if (!project) {
-    throw new NotFoundError("Project");
-  }
-
-  if (project.userId !== userId) {
-    throw new ForbiddenError("Insufficient permissions");
-  }
-
-  // Validate route exists in route_configs for this project
-  // If route is provided but doesn't exist, coerce to null
-  let validatedRoute = data.route ?? null;
-  if (validatedRoute !== null) {
-    const routeExists = await validateRouteExists(
-      data.projectId,
-      validatedRoute
-    );
-    if (!routeExists) {
-      // Coerce to null if route doesn't exist
-      logWarn(LogEventType.VALIDATION_WARNING, {
-        event: "invalid_route_configuration",
-        route: validatedRoute,
-        projectId: data.projectId,
-      });
-      validatedRoute = null;
-    }
-  }
-
-  // Validate projectFileId and fetch filePath in a single query to avoid extra round-trip
-  let filePath: string | null = null;
-  const validProjectFileId = data.projectFileId ?? null;
-  if (validProjectFileId !== null) {
-    const [projectFile] = await db
-      .select({
-        id: projectFiles.id,
-        filePath: projectFiles.filePath,
-        projectId: projectFiles.projectId,
-      })
-      .from(projectFiles)
-      .where(eq(projectFiles.id, validProjectFileId))
+  return await db.transaction(async (tx) => {
+    // Verify user has access to the project
+    const [project] = await tx
+      .select({ userId: projects.userId })
+      .from(projects)
+      .where(eq(projects.id, data.projectId))
       .limit(1);
 
-    if (!projectFile) {
-      throw new NotFoundError("ProjectFile");
+    if (!project) {
+      throw new NotFoundError("Project");
     }
 
-    if (projectFile.projectId !== data.projectId) {
-      throw new ForbiddenError(
-        "Project file does not belong to the specified project"
+    if (project.userId !== userId) {
+      throw new ForbiddenError("Insufficient permissions");
+    }
+
+    // Validate route exists in route_configs for this project
+    // If route is provided but doesn't exist, coerce to null
+    let validatedRoute = data.route ?? null;
+    if (validatedRoute !== null) {
+      const routeExists = await validateRouteExists(
+        data.projectId,
+        validatedRoute
       );
+      if (!routeExists) {
+        // Coerce to null if route doesn't exist
+        logWarn(LogEventType.VALIDATION_WARNING, {
+          event: "invalid_route_configuration",
+          route: validatedRoute,
+          projectId: data.projectId,
+        });
+        validatedRoute = null;
+      }
     }
 
-    filePath = projectFile.filePath;
-  }
+    // Validate projectFileId and fetch filePath in a single query to avoid extra round-trip
+    let filePath: string | null = null;
+    let rpyContent = "";
+    let afterLabelName = null;
+    let afterLabelPosition: number | null = null;
+    const validProjectFileId = data.projectFileId ?? null;
 
-  const auditFields = createAuditFields(userId);
+    if (validProjectFileId !== null) {
+      const [projectFile] = await tx
+        .select({
+          id: projectFiles.id,
+          filePath: projectFiles.filePath,
+          projectId: projectFiles.projectId,
+          content: projectFiles.content,
+        })
+        .from(projectFiles)
+        .where(eq(projectFiles.id, validProjectFileId))
+        .limit(1);
 
-  const [label] = await db
-    .insert(labels)
-    .values({
-      projectId: data.projectId,
-      title: data.title,
-      route: validatedRoute,
-      groupType: data.groupType ?? null,
-      groupValue: data.groupValue ?? null,
-      labelNumber: data.labelNumber,
-      sequenceOrder: data.sequenceOrder ?? 0,
-      status: data.status ?? "DRAFT",
-      visibility: data.visibility ?? "EXCLUSIVE",
-      projectFileId: data.projectFileId ?? null,
-      prerequisites: {},
-      effects: {},
-      ...auditFields,
-    })
-    .returning();
+      if (!projectFile) {
+        throw new NotFoundError("ProjectFile");
+      }
 
-  return mapToPublicLabel({ ...label, filePath });
+      if (projectFile.projectId !== data.projectId) {
+        throw new ForbiddenError(
+          "Project file does not belong to the specified project"
+        );
+      }
+
+      filePath = projectFile.filePath;
+      rpyContent = projectFile.content;
+
+      // Validate afterLabelId if provided
+      if (data.afterLabelId) {
+        const [afterLabel] = await tx
+          .select({
+            id: labels.id,
+            labelName: labels.labelName,
+            projectFileId: labels.projectFileId,
+            labelPosition: labels.labelPosition,
+          })
+          .from(labels)
+          .where(
+            and(eq(labels.id, data.afterLabelId), isNull(labels.deletedAt))
+          )
+          .limit(1);
+
+        if (!afterLabel) {
+          throw new NotFoundError("Label");
+        }
+
+        if (afterLabel.projectFileId !== validProjectFileId) {
+          throw new ValidationError("afterLabelId must be in the same file");
+        }
+
+        afterLabelName = afterLabel.labelName;
+        afterLabelPosition = afterLabel.labelPosition;
+      }
+    }
+
+    // Generate labelName
+    let labelName = sanitizeLabelName(data.title);
+    let finalTitle = data.title;
+
+    // Check for collisions in the same file
+    if (validProjectFileId) {
+      // Get all labels in the file that start with the sanitized base name
+      const existingLabels = await tx
+        .select()
+        .from(labels)
+        .where(
+          and(
+            eq(labels.projectFileId, validProjectFileId),
+            isNull(labels.deletedAt)
+          )
+        );
+
+      // Check for name collisions (with or without counter suffix)
+      const baseLabelName = labelName;
+      let counter = 2;
+      let hasCollision = existingLabels.some((l) => l.labelName === labelName);
+
+      let attempts = 0;
+      while (hasCollision) {
+        if (attempts >= MAX_LABEL_ATTEMPTS) {
+          // Fallback to timestamp-based unique suffix to avoid infinite loop
+          const timestampSuffix = Date.now().toString(36);
+          labelName = `${baseLabelName}_${timestampSuffix}`;
+          finalTitle = `${data.title}_${timestampSuffix}`;
+          logWarn(LogEventType.VALIDATION_WARNING, {
+            event: "max_label_name_attempts_exceeded",
+            baseLabelName,
+            attempts: MAX_LABEL_ATTEMPTS,
+            projectId: data.projectId,
+            projectFileId: validProjectFileId,
+          });
+          break;
+        }
+
+        const candidateName = `${baseLabelName}_${counter}`;
+        if (!existingLabels.some((l) => l.labelName === candidateName)) {
+          labelName = candidateName;
+          finalTitle = `${data.title}_${counter}`;
+          hasCollision = false;
+        }
+        counter++;
+        attempts++;
+      }
+    }
+
+    // Insert label block into RPY content
+    let updatedContent = rpyContent;
+    let insertPosition: number | null = null;
+
+    if (validProjectFileId) {
+      updatedContent = addLabelToRPYContent(
+        rpyContent,
+        labelName,
+        afterLabelName
+      );
+
+      // Determine insertion position
+      if (afterLabelName) {
+        insertPosition = (afterLabelPosition ?? 0) + 1;
+      } else {
+        // No afterLabelId provided, insert at beginning (position 0)
+        insertPosition = 0;
+      }
+    }
+
+    const auditFields = createAuditFields(userId);
+
+    const [label] = await tx
+      .insert(labels)
+      .values({
+        projectId: data.projectId,
+        title: finalTitle,
+        route: validatedRoute,
+        groupType: data.groupType ?? null,
+        groupValue: data.groupValue ?? null,
+        labelNumber: data.labelNumber,
+        sequenceOrder: data.sequenceOrder ?? 0,
+        status: data.status ?? "DRAFT",
+        visibility: data.visibility ?? "EXCLUSIVE",
+        projectFileId: validProjectFileId,
+        labelName,
+        labelPosition: insertPosition,
+        prerequisites: {},
+        effects: {},
+        ...auditFields,
+      })
+      .returning();
+
+    // Update project_files.content and contentHash
+    if (validProjectFileId) {
+      await tx
+        .update(projectFiles)
+        .set({
+          content: updatedContent,
+          contentHash: calculateContentHash(updatedContent),
+        })
+        .where(eq(projectFiles.id, validProjectFileId));
+
+      // Resync label positions
+      await resyncLabelPositions(tx, validProjectFileId);
+    }
+
+    return mapToPublicLabel({ ...label, filePath });
+  });
 }
 
 /**
@@ -705,6 +890,193 @@ export async function deleteLabel(
         })
         .where(eq(projectFiles.id, labelWithProject.projectFileId));
     }
+  });
+}
+
+/**
+ * Reorder labels within a specific file
+ * Updates both the RPY file content and label positions in the database
+ *
+ * @param userId - The ID of the user reordering the labels
+ * @param data - The reorder data
+ * @returns The updated labels
+ * @throws NotFoundError if project file not found
+ * @throws ForbiddenError if user lacks permission
+ * @throws ValidationError if labels belong to different files
+ */
+export async function reorderLabelsInFile(
+  userId: string,
+  data: {
+    projectFileId: string;
+    labelOrders: Array<{ labelId: string; newPosition: number }>;
+  }
+): Promise<PublicLabel[]> {
+  const db = getDb();
+
+  // Validate input
+  if (!data.labelOrders || data.labelOrders.length === 0) {
+    throw new ValidationError("At least one label must be reordered");
+  }
+
+  return await db.transaction(async (tx) => {
+    // Get the project file
+    const [projectFile] = await tx
+      .select({
+        id: projectFiles.id,
+        content: projectFiles.content,
+        projectId: projectFiles.projectId,
+        filePath: projectFiles.filePath,
+      })
+      .from(projectFiles)
+      .where(eq(projectFiles.id, data.projectFileId))
+      .limit(1);
+
+    if (!projectFile) {
+      throw new NotFoundError("ProjectFile");
+    }
+
+    // Verify user owns the project
+    const [project] = await tx
+      .select({ userId: projects.userId })
+      .from(projects)
+      .where(eq(projects.id, projectFile.projectId))
+      .limit(1);
+
+    if (!project || project.userId !== userId) {
+      throw new ForbiddenError("Insufficient permissions");
+    }
+
+    // Validate all labels exist and belong to the same file
+    const labelIds = data.labelOrders.map((l) => l.labelId);
+    const labelsToReorder = await tx
+      .select()
+      .from(labels)
+      .where(and(inArray(labels.id, labelIds), isNull(labels.deletedAt)));
+
+    if (labelsToReorder.length !== labelIds.length) {
+      throw new ValidationError("One or more labels not found");
+    }
+
+    for (const label of labelsToReorder) {
+      if (label.projectFileId !== data.projectFileId) {
+        throw new ValidationError("All labels must belong to the same file");
+      }
+    }
+
+    // Filter out labels without labelName (UI-only labels that aren't in RPY files)
+    const labelsWithoutName = labelsToReorder.filter((l) => !l.labelName);
+    const validLabelsToReorder = labelsToReorder.filter((l) => l.labelName);
+
+    if (labelsWithoutName.length > 0) {
+      const invalidNames = labelsWithoutName.map((l) => l.title).join(", ");
+      throw new ValidationError(
+        `Labels without file association cannot be reordered: ${invalidNames}`
+      );
+    }
+
+    if (validLabelsToReorder.length === 0) {
+      throw new ValidationError("At least one valid label must be reordered");
+    }
+
+    // Build array of label names in the new order
+    const validLabelIds = new Set(validLabelsToReorder.map((l) => l.id));
+    const labelMap = new Map(validLabelsToReorder.map((l) => [l.id, l]));
+    const newOrder: string[] = [];
+
+    // Only process labels that passed validation
+    const validOrders = data.labelOrders.filter((o) =>
+      validLabelIds.has(o.labelId)
+    );
+
+    const sortedOrders = [...validOrders].sort(
+      (a, b) => a.newPosition - b.newPosition
+    );
+
+    for (const order of sortedOrders) {
+      const label = labelMap.get(order.labelId);
+      // labelName is guaranteed to be non-null after validation
+      if (label?.labelName) {
+        newOrder.push(label.labelName);
+      }
+    }
+
+    // Reorder labels in RPY content
+    const updatedContent = reorderLabelsInRPYContent(
+      projectFile.content,
+      newOrder
+    );
+
+    // Update project_files.content and contentHash
+    await tx
+      .update(projectFiles)
+      .set({
+        content: updatedContent,
+        contentHash: calculateContentHash(updatedContent),
+      })
+      .where(eq(projectFiles.id, data.projectFileId));
+
+    // Update label positions for all labels in the file
+    const allFileLabels = await tx
+      .select()
+      .from(labels)
+      .where(
+        and(
+          eq(labels.projectFileId, data.projectFileId),
+          isNull(labels.deletedAt)
+        )
+      )
+      .orderBy(asc(labels.labelPosition));
+
+    const reorderedPositionMap = new Map(
+      validOrders.map((o) => [o.labelId, o.newPosition])
+    );
+
+    // Build new order array
+    const newLabelOrder = [...allFileLabels];
+    newLabelOrder.sort((a, b) => {
+      const aPos = reorderedPositionMap.get(a.id) ?? a.labelPosition ?? 0;
+      const bPos = reorderedPositionMap.get(b.id) ?? b.labelPosition ?? 0;
+      if (aPos !== bPos) {
+        return aPos - bPos;
+      }
+      // Tie-breaker: prioritize labels being explicitly reordered
+      const aIsReordered = reorderedPositionMap.has(a.id);
+      const bIsReordered = reorderedPositionMap.has(b.id);
+      if (aIsReordered && !bIsReordered) {
+        return -1; // a comes first
+      }
+      if (!aIsReordered && bIsReordered) {
+        return 1; // b comes first
+      }
+      // Both or neither reordered: use original position as tie-breaker
+      return (a.labelPosition ?? 0) - (b.labelPosition ?? 0);
+    });
+
+    // Update positions sequentially, skipping labels without labelName
+    // since they don't exist in RPY files and shouldn't have their positions changed
+    for (let i = 0; i < newLabelOrder.length; i++) {
+      const label = newLabelOrder[i];
+      if (label.labelName === null) {
+        continue; // Skip UI-only labels that aren't in RPY files
+      }
+      await tx
+        .update(labels)
+        .set({
+          labelPosition: i,
+          updatedBy: userId,
+        })
+        .where(eq(labels.id, label.id));
+    }
+
+    // Fetch and return updated labels
+    const updatedLabels = await tx
+      .select()
+      .from(labels)
+      .where(inArray(labels.id, Array.from(validLabelIds)));
+
+    return updatedLabels.map((l) =>
+      mapToPublicLabel({ ...l, filePath: projectFile.filePath })
+    );
   });
 }
 

--- a/apps/backend/src/services/labels.service.ts
+++ b/apps/backend/src/services/labels.service.ts
@@ -144,9 +144,11 @@ async function resyncLabelPositions(
   // Batch update all label positions in a single query using parameterized VALUES
   // This avoids N round-trips to the database and prevents SQL injection
   if (fileLabels.length > 0) {
-    // Create a parameterized VALUES list
+    // Create a parameterized VALUES list with explicit type casting
     const valuesList = sql.join(
-      fileLabels.map((label: Label, i: number) => sql`(${label.id}, ${i})`),
+      fileLabels.map(
+        (label: Label, i: number) => sql`(${label.id}::uuid, ${i}::integer)`
+      ),
       sql`, `
     );
 
@@ -984,9 +986,13 @@ export async function reorderLabelsInFile(
 
     if (labelsWithoutName.length > 0) {
       const invalidNames = labelsWithoutName.map((l) => l.title).join(", ");
-      throw new ValidationError(
-        `Labels without file association cannot be reordered: ${invalidNames}`
-      );
+      logWarn(LogEventType.VALIDATION_WARNING, {
+        event: "label_reorder_failed_no_file_association",
+        invalidNames,
+        projectFileId: data.projectFileId,
+        labelIds: labelsWithoutName.map((l) => l.id),
+      });
+      throw new ValidationError("One or more labels cannot be reordered");
     }
 
     if (validLabelsToReorder.length === 0) {
@@ -1080,9 +1086,11 @@ export async function reorderLabelsInFile(
     }
 
     if (labelsToUpdate.length > 0) {
-      // Create a parameterized VALUES list
+      // Create a parameterized VALUES list with explicit type casting
       const valuesList = sql.join(
-        labelsToUpdate.map((item) => sql`(${item.id}, ${item.position})`),
+        labelsToUpdate.map(
+          (item) => sql`(${item.id}::uuid, ${item.position}::integer)`
+        ),
         sql`, `
       );
 

--- a/apps/backend/src/services/labels.service.ts
+++ b/apps/backend/src/services/labels.service.ts
@@ -16,8 +16,25 @@ import {
   routeConfigs,
   projectFiles,
 } from "../db/schema/index.js";
-import { eq, and, asc, or, isNull, inArray, sql } from "drizzle-orm";
+import {
+  eq,
+  and,
+  asc,
+  or,
+  isNull,
+  inArray,
+  sql,
+  type ExtractTablesWithRelations,
+} from "drizzle-orm";
 import type { Label, LabelLine } from "../db/schema/index.js";
+import type { NodePgTransaction } from "drizzle-orm/node-postgres";
+
+// Transaction type that matches what TypeScript infers from db.transaction()
+// The schema is inferred as Record<string, unknown> due to TypeScript's limitations
+type Transaction = NodePgTransaction<
+  Record<string, unknown>,
+  ExtractTablesWithRelations<Record<string, unknown>>
+>;
 import type { PublicLabel } from "@branchforge/shared";
 import { LabelStatus, sanitizeLabelName } from "@branchforge/shared";
 import { createAuditFields, updateAuditFields } from "../lib/audit.js";
@@ -29,6 +46,7 @@ import {
 import { logWarn, LogEventType } from "../lib/logger.js";
 import {
   addLabelToRPYContent,
+  removeLabelFromRPYContent,
   reorderLabelsInRPYContent,
 } from "./rpy-parser.service.js";
 import { calculateContentHash } from "../lib/hash.js";
@@ -101,8 +119,7 @@ function extractFileName(filePath: string | null): string | null {
  * @param projectFileId - The project file ID
  */
 async function resyncLabelPositions(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  tx: any,
+  tx: Transaction,
   projectFileId: string
 ): Promise<void> {
   const fileLabels = await tx
@@ -124,21 +141,20 @@ async function resyncLabelPositions(
     return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
   });
 
-  // Batch update all label positions in a single query using CASE statement
-  // This avoids N round-trips to the database
+  // Batch update all label positions in a single query using parameterized VALUES
+  // This avoids N round-trips to the database and prevents SQL injection
   if (fileLabels.length > 0) {
-    const caseStatements = fileLabels
-      .map((label: Label, i: number) => `WHEN '${label.id}' THEN ${i}`)
-      .join("\n        ");
-
-    const labelIds = fileLabels.map((l: Label) => `'${l.id}'`).join(", ");
+    // Create a parameterized VALUES list
+    const valuesList = sql.join(
+      fileLabels.map((label: Label, i: number) => sql`(${label.id}, ${i})`),
+      sql`, `
+    );
 
     await tx.execute(
-      sql`UPDATE labels SET "label_position" = CASE id
-          ${sql.raw(caseStatements)}
-          ELSE "label_position"
-        END
-        WHERE id IN (${sql.raw(labelIds)})`
+      sql`UPDATE labels
+          SET "label_position" = new_positions.position
+          FROM (VALUES ${valuesList}) AS new_positions(id, position)
+          WHERE labels.id = new_positions.id`
     );
   }
 }
@@ -571,6 +587,7 @@ export async function createLabel(
         })
         .from(projectFiles)
         .where(eq(projectFiles.id, validProjectFileId))
+        .for("update")
         .limit(1);
 
       if (!projectFile) {
@@ -823,9 +840,6 @@ export async function deleteLabel(
 ): Promise<void> {
   const db = getDb();
 
-  // Import the removeLabelFromRPYContent function dynamically
-  const { removeLabelFromRPYContent } = await import("./rpy-parser.service.js");
-
   // Get label with project owner info and projectFileId
   const [labelWithProject] = await db
     .select({
@@ -919,7 +933,7 @@ export async function reorderLabelsInFile(
   }
 
   return await db.transaction(async (tx) => {
-    // Get the project file
+    // Get the project file with row-level lock to prevent concurrent modifications
     const [projectFile] = await tx
       .select({
         id: projectFiles.id,
@@ -929,6 +943,7 @@ export async function reorderLabelsInFile(
       })
       .from(projectFiles)
       .where(eq(projectFiles.id, data.projectFileId))
+      .for("update")
       .limit(1);
 
     if (!projectFile) {
@@ -1052,20 +1067,33 @@ export async function reorderLabelsInFile(
       return (a.labelPosition ?? 0) - (b.labelPosition ?? 0);
     });
 
-    // Update positions sequentially, skipping labels without labelName
-    // since they don't exist in RPY files and shouldn't have their positions changed
+    // Update positions in a single batch query using parameterized VALUES
+    // Skip labels without labelName since they don't exist in RPY files
+    const labelsToUpdate: Array<{ id: string; position: number }> = [];
+
     for (let i = 0; i < newLabelOrder.length; i++) {
       const label = newLabelOrder[i];
       if (label.labelName === null) {
         continue; // Skip UI-only labels that aren't in RPY files
       }
-      await tx
-        .update(labels)
-        .set({
-          labelPosition: i,
-          updatedBy: userId,
-        })
-        .where(eq(labels.id, label.id));
+      labelsToUpdate.push({ id: label.id, position: i });
+    }
+
+    if (labelsToUpdate.length > 0) {
+      // Create a parameterized VALUES list
+      const valuesList = sql.join(
+        labelsToUpdate.map((item) => sql`(${item.id}, ${item.position})`),
+        sql`, `
+      );
+
+      await tx.execute(
+        sql`UPDATE labels
+            SET "label_position" = new_positions.position,
+                "updated_by" = ${userId},
+                "updated_at" = NOW()
+            FROM (VALUES ${valuesList}) AS new_positions(id, position)
+            WHERE labels.id = new_positions.id`
+      );
     }
 
     // Fetch and return updated labels


### PR DESCRIPTION
- Add projectFileId and afterLabelId parameters to label creation
- Add POST /labels/reorder-file endpoint for drag-and-drop reordering
- Auto-append counter suffix to labels with duplicate names in same file
- Insert label definitions into RPY file content when created
- Add comprehensive integration tests for file-scoped labels


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create labels with optional file-scoped positioning (specify a file and insert after an existing label).
  * Reorder labels within a file via a new endpoint; returns updated label list.

* **Improvements**
  * Label creation and reordering are transactional, resync positions, and update file content/hash atomically.
  * Better validation and mapped error responses for invalid or unauthorized requests.

* **Tests**
  * Extensive integration tests for file-scoped creation, positioning, reordering, permissions, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->