### PR TITLE
Replace useContext with use in Toast and Theme contexts

### DIFF
--- a/apps/frontend/src/contexts/ToastContext.tsx
+++ b/apps/frontend/src/contexts/ToastContext.tsx
@@ -1,10 +1,4 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useCallback,
-  ReactNode,
-} from "react";
+import { createContext, use, useState, useCallback, ReactNode } from "react";
 
 type ToastVariant = "default" | "success" | "destructive";
 
@@ -25,7 +19,7 @@ interface ToastContextType {
 const ToastContext = createContext<ToastContextType | null>(null);
 
 export function useToast() {
-  const context = useContext(ToastContext);
+  const context = use(ToastContext);
   if (!context) {
     throw new Error("useToast must be used within ToastProvider");
   }

--- a/apps/frontend/src/contexts/useTheme.ts
+++ b/apps/frontend/src/contexts/useTheme.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, use } from "react";
 
 export type ThemePalette =
   | "forest"
@@ -22,7 +22,7 @@ export const ThemeContext = createContext<ThemeContextType | undefined>(
 );
 
 export function useTheme(): ThemeContextType {
-  const context = useContext(ThemeContext);
+  const context = use(ThemeContext);
   if (!context) {
     throw new Error("useTheme must be used within ThemeProvider");
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal React context consumption patterns to align with current React best practices. User-facing functionality and behavior remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mikkisguy/branchforge/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->