### PR TITLE
chore: version packages to v0.9.0 [skip-coderabbit]

### DIFF
--- a/.changeset/brown-words-jam.md
+++ b/.changeset/brown-words-jam.md
@@ -1,7 +1,0 @@
----
-"@branchforge/shared": minor
-"@branchforge/frontend": minor
-"@branchforge/backend": minor
----
-
-Added meter management

--- a/.changeset/funky-sheep-kick.md
+++ b/.changeset/funky-sheep-kick.md
@@ -1,6 +1,0 @@
----
-"@branchforge/frontend": patch
-"@branchforge/backend": patch
----
-
-Added the possibility to add a new label on write mode, also some styling updates for the label and file lists

--- a/.changeset/jolly-parts-obey.md
+++ b/.changeset/jolly-parts-obey.md
@@ -1,7 +1,0 @@
----
-"@branchforge/backend": patch
-"@branchforge/frontend": patch
-"@branchforge/shared": patch
----
-
-Added for labels: edit dialog for title and name, title display to script mode and filtering in write mode

--- a/.changeset/khaki-colts-doubt.md
+++ b/.changeset/khaki-colts-doubt.md
@@ -1,6 +1,0 @@
----
-"@branchforge/frontend": patch
-"@branchforge/backend": patch
----
-
-Added sorting toggle for labels: file order/recent

--- a/.changeset/plain-things-drop.md
+++ b/.changeset/plain-things-drop.md
@@ -1,7 +1,0 @@
----
-"@branchforge/backend": patch
-"@branchforge/frontend": patch
-"@branchforge/shared": patch
----
-
-Fixed GitLab export flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to BranchForge will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.9.0 - 2026-05-22
+
+- Added meter management
+- Added the possibility to add a new label on write mode, also some styling updates for the label and file lists
+- Added for labels: edit dialog for title and name, title display to script mode and filtering in write mode
+- Added sorting toggle for labels: file order/recent
+- Fixed GitLab export flow
+
 ## v0.8.0 - 2026-04-24
 
 - Unified project imports and management in a single settings view

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/backend",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/frontend",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branchforge",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "description": "Visual Novel IDE for Ren'Py",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/shared",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
<!-- release-automation:version-workflow -->
## Summary
- Consume pending changesets and bump package versions to v0.9.0.
- Run build, typecheck, and tests before opening this release PR.
- Merge this PR to trigger version tagging and release workflows.

## Notes
- Generated by .github/workflows/version.yml.
- Title includes [skip-coderabbit] to skip CodeRabbit on this automation PR.