### PR TITLE
Fix dialogue extraction and reconstruction for menu titles

### DIFF
--- a/apps/backend/src/services/__tests__/rpy-parser.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/rpy-parser.service.unit.test.ts
@@ -263,6 +263,26 @@ label START:
 
       expect(dialogue[0].text).toContain("multiline dialogue");
     });
+
+    it("should extract menu titles as editable dialogue", () => {
+      const menuRPY = `label start:
+    "Before menu"
+    menu:
+        "Menu title"
+        "Choice 1":
+            jump somewhere
+        "Choice 2":
+            jump elsewhere
+    "After menu"
+`;
+      const dialogue = extractDialogue(menuRPY);
+
+      // Menu titles are editable in write mode — extract them as narration
+      expect(dialogue).toHaveLength(3);
+      expect(dialogue[0].text).toBe("Before menu");
+      expect(dialogue[1].text).toBe("Menu title");
+      expect(dialogue[2].text).toBe("After menu");
+    });
   });
 
   describe("extractChoices", () => {
@@ -776,6 +796,29 @@ label title:
       );
       expect(resultWithPartial.fileType).toBe("STORY");
     });
+
+    it("should extract menu titles as editable dialogue in label dialogue", () => {
+      const menuRPY = `label start:
+    "Before menu"
+    menu:
+        "Menu title"
+        "Choice 1":
+            jump somewhere
+        "Choice 2":
+            jump elsewhere
+    "After menu"
+`;
+      const result = parseRPYFileWithLabels(menuRPY);
+
+      const startLabel = result.labels.find((l) => l.label === "start");
+      expect(startLabel).toBeDefined();
+
+      // Menu titles are editable in write mode — extract them as narration
+      expect(startLabel?.dialogue).toHaveLength(3);
+      expect(startLabel?.dialogue[0].text).toBe("Before menu");
+      expect(startLabel?.dialogue[1].text).toBe("Menu title");
+      expect(startLabel?.dialogue[2].text).toBe("After menu");
+    });
   });
 
   describe("convertToBranchForgeFormatFromLabels", () => {
@@ -1123,6 +1166,70 @@ label chapter1:
       });
 
       expect(result).toContain('e "Updated speaker"');
+    });
+
+    it("should NOT duplicate menu title during reconstruction", () => {
+      const originalContent = `label start:
+    "Some narration"
+    menu:
+        "Are you sure?"
+        "Yes":
+            jump yes_label
+        "No":
+            jump no_label
+`;
+
+      const updatedDialogue = new Map([
+        [
+          "start",
+          [
+            { speaker: null, text: "Some narration" },
+            { speaker: null, text: "Are you sure?" },
+          ],
+        ],
+      ]);
+
+      const result = reconstructRPYFile({
+        originalContent,
+        updatedDialogue,
+      });
+
+      // The menu title "Are you sure?" should NOT be duplicated outside the menu
+      expect(result).toContain("menu:");
+      expect(result).toContain('"Are you sure?"');
+
+      // Count occurrences of "Are you sure?" - should be exactly 1.
+      // Pre-fix, the second entry would be inserted before `menu:` and the
+      // original title line preserved inside the menu, producing two matches.
+      const matches = result.match(/"Are you sure\?"/g);
+      expect(matches).toHaveLength(1);
+    });
+
+    it("should NOT duplicate jump statements during reconstruction", () => {
+      const originalContent = `label end:
+    ma "Always."
+    jump end
+`;
+
+      const updatedDialogue = new Map([
+        ["end", [{ speaker: "ma", text: "Always." }]],
+      ]);
+
+      const result = reconstructRPYFile({
+        originalContent,
+        updatedDialogue,
+      });
+
+      // Should contain the jump statement exactly once
+      const jumpMatches = result.match(/jump end/g);
+      expect(jumpMatches).toHaveLength(1);
+
+      // Should NOT contain jump statement as a dialogue string
+      expect(result).not.toContain('"jump end"');
+
+      // Verify the reconstruction preserves the original structure
+      expect(result).toContain('ma "Always."');
+      expect(result).toContain("jump end");
     });
   });
 

--- a/apps/backend/src/services/rpy-parser.service.ts
+++ b/apps/backend/src/services/rpy-parser.service.ts
@@ -450,12 +450,14 @@ export function extractChoices(
     }
 
     // Check for menu end (indentation decreases)
-    // Pop from stack until we find the appropriate menu level
+    // Pop from stack until we find the appropriate menu level.
+    // A line at the same indent as `menu:` is outside the menu (a sibling
+    // of the menu block, e.g. the next label or a keyword), so pop with `<=`.
     const lineIndent = line.search(/\S/);
     if (
       menuStack.length > 0 &&
       trimmed &&
-      lineIndent < menuStack[menuStack.length - 1]
+      lineIndent <= menuStack[menuStack.length - 1]
     ) {
       menuStack.pop();
     }
@@ -1122,8 +1124,19 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
   const labelIndentation = new Map<string, string>();
   let lastDialogueIndent = "    "; // Default RPY indentation
 
-  // Keywords that signal the end of a label's dialogue block
-  const labelEndKeywords = new Set(["return", "menu", "jump", "call"]);
+  // Track menu block nesting to prevent premature dialogue insertion.
+  // Menu titles are editable dialogue entries, so they must be matched and
+  // replaced inside menu blocks. However, jump/call/return statements inside
+  // menu choice bodies should NOT trigger dialogue insertion — they're part of
+  // the menu structure, not the label's main dialogue flow.
+  const menuStack: number[] = [];
+
+  // Keywords that signal the end of a label's dialogue block.
+  // The `menuStack.length === 0` guard below prevents premature insertion at
+  // `menu:` (and any other line inside a menu block). This is the mechanism
+  // that stops the menu title from being inserted before `menu:` and again
+  // matched in place, which would produce duplicate dialogue entries.
+  const labelEndKeywords = new Set(["return", "jump", "call"]);
   const isLabelEndKeyword = (trimmed: string): boolean => {
     const firstWord = trimmed.split(/\s+/)[0];
     // Normalize by stripping trailing colon and other punctuation
@@ -1171,8 +1184,23 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
 
       currentLabel = labelMatch[1];
       labelDialogueIndices.set(currentLabel, 0);
+      // Reset menu tracking on label boundary
+      menuStack.length = 0;
       result.push(line);
       continue;
+    }
+
+    // Track menu block nesting: push on menu:, pop on dedent
+    if (trimmed === "menu:") {
+      menuStack.push(line.search(/\S/));
+    } else if (menuStack.length > 0 && trimmed) {
+      const lineIndent = line.search(/\S/);
+      while (
+        menuStack.length > 0 &&
+        lineIndent <= menuStack[menuStack.length - 1]
+      ) {
+        menuStack.pop();
+      }
     }
 
     // Check if this is a dialogue line
@@ -1181,6 +1209,10 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
     );
     const narrationMatch = trimmed.match(/^"(.*)"$/);
 
+    // Match and replace dialogue/narration both outside AND inside menu blocks.
+    // Menu titles are editable entries that should be updated like any other
+    // dialogue. The label-end insertion below handles the case where there are
+    // more entries than original lines.
     if (
       (dialogueMatch || narrationMatch) &&
       currentLabel &&
@@ -1216,8 +1248,14 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
       // The line will be added by the fall-through below.
     }
 
-    // Before adding a line that ends the label block, insert any remaining dialogue
-    if (currentLabel && updatedDialogue.has(currentLabel)) {
+    // Before adding a line that ends the label block, insert any remaining dialogue.
+    // Only do this OUTSIDE menu blocks — jump/call/return inside menu choice
+    // bodies are part of the menu structure, not the label's dialogue flow.
+    if (
+      currentLabel &&
+      updatedDialogue.has(currentLabel) &&
+      menuStack.length === 0
+    ) {
       const labelDialogue = updatedDialogue.get(currentLabel)!;
       const currentIndex = labelDialogueIndices.get(currentLabel) ?? 0;
 

--- a/apps/backend/src/services/rpy-parser.service.ts
+++ b/apps/backend/src/services/rpy-parser.service.ts
@@ -453,8 +453,10 @@ export function extractChoices(
     // Pop from stack until we find the appropriate menu level.
     // A line at the same indent as `menu:` is outside the menu (a sibling
     // of the menu block, e.g. the next label or a keyword), so pop with `<=`.
+    // Use a while loop so a single dedent unwinds all nested menu levels
+    // the line has escaped.
     const lineIndent = line.search(/\S/);
-    if (
+    while (
       menuStack.length > 0 &&
       trimmed &&
       lineIndent <= menuStack[menuStack.length - 1]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Menu titles are now correctly handled as editable dialogue entries.
  * Prevented duplicate menu titles and duplicate jump/call/return lines during file reconstruction.
  * Improved detection of menu block boundaries for accurate choice parsing.

* **Tests**
  * Added tests for menu title extraction and reconstruction idempotency to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->