### PR TITLE
Add structured menu support with incoming jumps tracking

### DIFF
--- a/apps/backend/src/lib/hash.ts
+++ b/apps/backend/src/lib/hash.ts
@@ -39,7 +39,13 @@ function normalizeToCanonicalString(
   entry:
     | { content: string }
     | { text?: string; target?: string }
-    | { type?: string; speaker?: string; text?: string; target?: string }
+    | {
+        type?: string;
+        speaker?: string;
+        text?: string;
+        target?: string;
+        menuOptions?: Array<Record<string, unknown>>;
+      }
     | { speakerId: string | null; text: string }
 ): string {
   // Handle database canonical format ({ content: string })
@@ -60,6 +66,12 @@ function normalizeToCanonicalString(
       case "FLAG":
         // Menu choice/flag: represent as dialogue with null speaker
         return `:${entry.text ?? ""}`;
+      case "MENU":
+        // Menu block: serialize menuOptions for consistent hashing
+        if ("menuOptions" in entry && entry.menuOptions) {
+          return `menu:${JSON.stringify(entry.menuOptions)}`;
+        }
+        return "";
       default:
         return "";
     }
@@ -124,7 +136,13 @@ export function calculateLinesHash(
   lines: Array<
     | { content: string }
     | { text?: string; target?: string }
-    | { type?: string; speaker?: string; text?: string; target?: string }
+    | {
+        type?: string;
+        speaker?: string;
+        text?: string;
+        target?: string;
+        menuOptions?: Array<Record<string, unknown>>;
+      }
     | { speakerId: string | null; text: string }
   >
 ): string {

--- a/apps/backend/src/routes/__tests__/labels.routes.integration.test.ts
+++ b/apps/backend/src/routes/__tests__/labels.routes.integration.test.ts
@@ -23,7 +23,7 @@ import {
   type NewUser,
   type NewProject,
 } from "../../db/schema/index.js";
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray, asc } from "drizzle-orm";
 import { calculateContentHash } from "../../lib/hash.js";
 
 describe("LabelsRoutes (Integration)", () => {
@@ -303,5 +303,147 @@ describe("LabelsRoutes (Integration)", () => {
         reason: "STALE_LABEL_VERSION",
       },
     });
+  });
+
+  it("preserves MENU and JUMP lines when updating dialogue", async () => {
+    const auth = await createAuthenticatedRequest(testUserId);
+
+    // Insert MENU and JUMP lines alongside the existing NARRATION (sequence 1)
+    await db.insert(labelLines).values([
+      {
+        labelId: introLabelId,
+        sequence: 2,
+        contentType: "MENU",
+        content: "",
+        projectFileId: testFileId,
+        menuOptions: [
+          {
+            label: "Go left",
+            targetLabelId: testUuid("23000009", 1),
+            targetLabelName: "left_path",
+          },
+        ],
+      },
+      {
+        labelId: introLabelId,
+        sequence: 3,
+        contentType: "JUMP",
+        content: "jump ending",
+        projectFileId: testFileId,
+      },
+    ]);
+
+    const response = await fastify.inject({
+      method: "PUT",
+      url: `/labels/${introLabelId}/dialogue`,
+      payload: {
+        dialogue: [{ speakerId: null, text: "Updated prose" }],
+      },
+      cookies: {
+        [SESSION_COOKIE_NAME]: auth.sessionId,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ success: true });
+
+    const lines = await db
+      .select()
+      .from(labelLines)
+      .where(eq(labelLines.labelId, introLabelId))
+      .orderBy(asc(labelLines.sequence));
+
+    expect(lines).toHaveLength(3);
+    expect(lines[0].contentType).toBe("NARRATION");
+    expect(lines[0].content).toBe("Updated prose");
+    expect(lines[1].contentType).toBe("MENU");
+    expect(lines[1].menuOptions).toEqual([
+      {
+        label: "Go left",
+        targetLabelId: testUuid("23000009", 1),
+        targetLabelName: "left_path",
+      },
+    ]);
+    expect(lines[2].contentType).toBe("JUMP");
+    expect(lines[2].content).toBe("jump ending");
+  });
+
+  it("appends new prose lines after non-prose lines when dialogue entries exceed existing prose", async () => {
+    const auth = await createAuthenticatedRequest(testUserId);
+
+    // Seed: 1 NARRATION (seq 1) + 1 MENU (seq 2) + 1 JUMP (seq 3)
+    await db.insert(labelLines).values([
+      {
+        labelId: introLabelId,
+        sequence: 2,
+        contentType: "MENU",
+        content: "",
+        projectFileId: testFileId,
+        menuOptions: [
+          {
+            label: "Go left",
+            targetLabelId: testUuid("23000009", 1),
+            targetLabelName: "left_path",
+          },
+        ],
+      },
+      {
+        labelId: introLabelId,
+        sequence: 3,
+        contentType: "JUMP",
+        content: "jump ending",
+        projectFileId: testFileId,
+      },
+    ]);
+
+    // Send 3 dialogue entries but only 1 prose line exists
+    const response = await fastify.inject({
+      method: "PUT",
+      url: `/labels/${introLabelId}/dialogue`,
+      payload: {
+        dialogue: [
+          { speakerId: null, text: "First prose" },
+          { speakerId: testCharacterId, text: "Second prose" },
+          { speakerId: null, text: "Third prose" },
+        ],
+      },
+      cookies: {
+        [SESSION_COOKIE_NAME]: auth.sessionId,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ success: true });
+
+    const lines = await db
+      .select()
+      .from(labelLines)
+      .where(eq(labelLines.labelId, introLabelId))
+      .orderBy(asc(labelLines.sequence));
+
+    // seq 1: updated NARRATION, seq 2: MENU, seq 3: JUMP, seq 4: new DIALOGUE, seq 5: new NARRATION
+    expect(lines).toHaveLength(5);
+
+    expect(lines[0].contentType).toBe("NARRATION");
+    expect(lines[0].content).toBe("First prose");
+
+    expect(lines[1].contentType).toBe("MENU");
+    expect(lines[1].menuOptions).toEqual([
+      {
+        label: "Go left",
+        targetLabelId: testUuid("23000009", 1),
+        targetLabelName: "left_path",
+      },
+    ]);
+
+    expect(lines[2].contentType).toBe("JUMP");
+    expect(lines[2].content).toBe("jump ending");
+
+    expect(lines[3].contentType).toBe("DIALOGUE");
+    expect(lines[3].content).toBe("Second prose");
+    expect(lines[3].speakerId).toBe(testCharacterId);
+
+    expect(lines[4].contentType).toBe("NARRATION");
+    expect(lines[4].content).toBe("Third prose");
   });
 });

--- a/apps/backend/src/routes/labels.routes.ts
+++ b/apps/backend/src/routes/labels.routes.ts
@@ -349,18 +349,28 @@ async function updateLabelDialogueHandler(
         )
         .orderBy(asc(labelLines.sequence));
 
-      const existingLinesBySequence = new Map(
-        existingLines.map((line) => [line.sequence, line])
+      // Separate prose lines (DIALOGUE/NARRATION) from non-prose lines (MENU/JUMP).
+      // Non-prose lines are structural and must be preserved during prose edits –
+      // the frontend only sends DIALOGUE/NARRATION entries, so mapping 1:1 by
+      // sequence would overwrite or delete MENU/JUMP lines.
+      const proseLines = existingLines.filter(
+        (line) =>
+          line.contentType === "DIALOGUE" || line.contentType === "NARRATION"
+      );
+      const _nonProseLines = existingLines.filter(
+        (line) =>
+          line.contentType !== "DIALOGUE" && line.contentType !== "NARRATION"
       );
 
-      const newSequences = new Set<number>();
+      const maxExistingSequence = Math.max(
+        ...existingLines.map((l) => l.sequence),
+        0
+      );
+      let nextSequence = maxExistingSequence + 1;
 
-      // 2. Update existing rows and insert new rows for each entry
+      // 2. Update existing prose lines by position among prose lines, insert new ones
       for (const [index, entry] of dialogue.entries()) {
-        const sequence = index + 1;
-        newSequences.add(sequence);
-
-        const existingLine = existingLinesBySequence.get(sequence);
+        const existingProseLine = proseLines[index];
 
         const values = {
           contentType: (entry.speakerId ? "DIALOGUE" : "NARRATION") as
@@ -371,39 +381,38 @@ async function updateLabelDialogueHandler(
           demoNotes: null,
           isDirty: true,
           projectFileId: lockedProjectFile.id,
-          linePosition: (lockedLabel.labelPosition ?? 0) + index,
           contentHash: calculateContentHash(entry.text),
           lastSyncedHash: null,
         };
 
-        if (existingLine) {
-          // Update existing row, preserving its ID
+        if (existingProseLine) {
+          // Update existing prose line, preserving its sequence position
+          // so non-prose lines at other sequences remain undisturbed
           await tx
             .update(labelLines)
             .set(values)
-            .where(eq(labelLines.id, existingLine.id));
+            .where(eq(labelLines.id, existingProseLine.id));
         } else {
-          // Insert new row for sequences that don't exist yet
+          // Insert new line after all existing sequences
           await tx.insert(labelLines).values({
             labelId,
-            sequence,
+            sequence: nextSequence++,
+            linePosition: existingLines.length + index,
             ...values,
           });
         }
       }
 
-      // 3. Delete rows whose sequences are no longer present
-      const sequencesToDelete = existingLines
-        .filter((line) => !newSequences.has(line.sequence))
-        .map((line) => line.id);
+      // 3. Delete only prose lines beyond the dialogue entry count.
+      // Non-prose lines (MENU/JUMP) are never deleted during prose edits.
+      const proseLinesToDelete = proseLines.slice(dialogue.length);
+      const idsToDelete = proseLinesToDelete.map((line) => line.id);
 
-      if (sequencesToDelete.length > 0) {
-        await tx
-          .delete(labelLines)
-          .where(inArray(labelLines.id, sequencesToDelete));
+      if (idsToDelete.length > 0) {
+        await tx.delete(labelLines).where(inArray(labelLines.id, idsToDelete));
       }
 
-      // 2. Update label with audit fields and sync status
+      // 4. Update label with audit fields and sync status
       const auditFields = updateAuditFields(lockedCurrentVersion, user.id);
       await tx
         .update(labels)

--- a/apps/backend/src/routes/labels.routes.ts
+++ b/apps/backend/src/routes/labels.routes.ts
@@ -52,9 +52,8 @@ import {
   characters,
 } from "../db/schema/index.js";
 import { eq, asc, inArray, isNull, and, sql } from "drizzle-orm";
-import { calculateDialogueHash } from "../lib/hash.js";
+import { calculateLinesHash, calculateContentHash } from "../lib/hash.js";
 import { updateAuditFields } from "../lib/audit.js";
-import { calculateContentHash } from "../lib/hash.js";
 import { trackWordsForLabel } from "../services/word-count.service.js";
 
 // ============================================================================
@@ -252,9 +251,6 @@ async function updateLabelDialogueHandler(
       }
     }
 
-    // Calculate content hash for new dialogue
-    const contentHash = calculateDialogueHash(dialogue);
-
     const updateResult = await db.transaction(async (tx) => {
       // Serialize concurrent updates for the same label to avoid duplicate rows
       // from overlapping delete + insert operations.
@@ -412,7 +408,19 @@ async function updateLabelDialogueHandler(
         await tx.delete(labelLines).where(inArray(labelLines.id, idsToDelete));
       }
 
-      // 4. Update label with audit fields and sync status
+      // 4. Compute content hash from the actual persisted label_lines
+      // (includes MENU/JUMP rows preserved during prose edits) so the hash
+      // stays consistent with sync/import flows that use calculateLinesHash.
+      const finalLines = await tx
+        .select()
+        .from(labelLines)
+        .where(
+          and(eq(labelLines.labelId, labelId), isNull(labelLines.deletedAt))
+        )
+        .orderBy(asc(labelLines.sequence));
+      const contentHash = calculateLinesHash(finalLines);
+
+      // 5. Update label with audit fields and sync status
       const auditFields = updateAuditFields(lockedCurrentVersion, user.id);
       await tx
         .update(labels)

--- a/apps/backend/src/services/__tests__/incoming-jumps.integration.test.ts
+++ b/apps/backend/src/services/__tests__/incoming-jumps.integration.test.ts
@@ -65,26 +65,32 @@ describe("Incoming Jumps", () => {
   });
 
   afterAll(async () => {
-    const lbls = await db
-      .select({ id: labelsTable.id })
-      .from(labelsTable)
-      .where(eq(labelsTable.projectId, testProjectId));
-    if (lbls.length > 0) {
-      await db.delete(labelLines).where(
-        inArray(
-          labelLines.labelId,
-          lbls.map((l) => l.id)
-        )
-      );
+    const zipUserId = testUuid("99110000", 9);
+    const zipProjectId = testUuid("99110000", 10);
+
+    // Clean up both testProjectId and zipProjectId data
+    for (const projectId of [testProjectId, zipProjectId]) {
+      const lbls = await db
+        .select({ id: labelsTable.id })
+        .from(labelsTable)
+        .where(eq(labelsTable.projectId, projectId));
+      if (lbls.length > 0) {
+        await db.delete(labelLines).where(
+          inArray(
+            labelLines.labelId,
+            lbls.map((l) => l.id)
+          )
+        );
+      }
+      await db.delete(labelsTable).where(eq(labelsTable.projectId, projectId));
+      await db
+        .delete(projectFiles)
+        .where(eq(projectFiles.projectId, projectId));
+      await db.delete(projects).where(eq(projects.id, projectId));
     }
-    await db
-      .delete(labelsTable)
-      .where(eq(labelsTable.projectId, testProjectId));
-    await db
-      .delete(projectFiles)
-      .where(eq(projectFiles.projectId, testProjectId));
-    await db.delete(projects).where(eq(projects.id, testProjectId));
-    await db.delete(users).where(eq(users.id, testUserId));
+    for (const userId of [testUserId, zipUserId]) {
+      await db.delete(users).where(eq(users.id, userId));
+    }
   });
 
   it("populates incomingJumps for labels targeted by menu choices", async () => {

--- a/apps/backend/src/services/__tests__/incoming-jumps.integration.test.ts
+++ b/apps/backend/src/services/__tests__/incoming-jumps.integration.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Incoming Jumps Integration Tests
+ *
+ * Verifies that `incomingJumps` is correctly computed during sync and
+ * returned by `getLabel`. Covers menu-choice jumps, automatic jumps,
+ * and cross-file jump resolution.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { getDb } from "../../db/index.js";
+import {
+  users,
+  projects,
+  labels as labelsTable,
+  labelLines,
+  projectFiles,
+} from "../../db/schema/index.js";
+import { eq, inArray } from "drizzle-orm";
+import { syncLabelsFromFile, getLabel } from "../labels.service.js";
+import { importZipFile } from "../zip-import.service.js";
+import { calculateContentHash } from "../../lib/hash.js";
+import { testEmail, testUuid } from "../../utils/test-ids.js";
+import JSZip from "jszip";
+
+describe("Incoming Jumps", () => {
+  const db = getDb();
+  const testUserId = testUuid("99110000", 1);
+  const testProjectId = testUuid("99110000", 2);
+  const testFile1Id = testUuid("99110000", 3);
+  const testFile2Id = testUuid("99110000", 4);
+
+  beforeAll(async () => {
+    await db.insert(users).values({
+      id: testUserId,
+      email: testEmail("incoming-jumps", "user"),
+      passwordHash: "hash",
+      role: "OWNER",
+    });
+    await db.insert(projects).values({
+      id: testProjectId,
+      userId: testUserId,
+      name: "Incoming Jumps Test",
+      source: "ZIP",
+    });
+    await db.insert(projectFiles).values([
+      {
+        id: testFile1Id,
+        projectId: testProjectId,
+        source: "ZIP",
+        filePath: "game/file1.rpy",
+        fileType: "STORY",
+        content: "",
+        contentHash: calculateContentHash(""),
+      },
+      {
+        id: testFile2Id,
+        projectId: testProjectId,
+        source: "ZIP",
+        filePath: "game/file2.rpy",
+        fileType: "STORY",
+        content: "",
+        contentHash: calculateContentHash(""),
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    const lbls = await db
+      .select({ id: labelsTable.id })
+      .from(labelsTable)
+      .where(eq(labelsTable.projectId, testProjectId));
+    if (lbls.length > 0) {
+      await db.delete(labelLines).where(
+        inArray(
+          labelLines.labelId,
+          lbls.map((l) => l.id)
+        )
+      );
+    }
+    await db
+      .delete(labelsTable)
+      .where(eq(labelsTable.projectId, testProjectId));
+    await db
+      .delete(projectFiles)
+      .where(eq(projectFiles.projectId, testProjectId));
+    await db.delete(projects).where(eq(projects.id, testProjectId));
+    await db.delete(users).where(eq(users.id, testUserId));
+  });
+
+  it("populates incomingJumps for labels targeted by menu choices", async () => {
+    // File 1: "start" label with menu jumping to "park_scene" and "home_scene"
+    const file1 = `
+label start:
+    "Welcome to the game"
+    menu:
+        "Go to park":
+            jump park_scene
+        "Stay home":
+            jump home_scene
+`.trim();
+
+    const result1 = await syncLabelsFromFile(
+      testProjectId,
+      { filePath: "game/file1.rpy", fileType: "STORY" },
+      file1,
+      testFile1Id
+    );
+    expect(result1.success).toBe(true);
+
+    // File 2: target labels
+    const file2 = `
+label park_scene:
+    "You went to the park"
+    return
+
+label home_scene:
+    "You stayed home"
+    return
+`.trim();
+
+    const result2 = await syncLabelsFromFile(
+      testProjectId,
+      { filePath: "game/file2.rpy", fileType: "STORY" },
+      file2,
+      testFile2Id
+    );
+    expect(result2.success).toBe(true);
+
+    // Check incomingJumps in database
+    const allLabels = await db
+      .select({
+        id: labelsTable.id,
+        title: labelsTable.title,
+        labelName: labelsTable.labelName,
+        incomingJumps: labelsTable.incomingJumps,
+      })
+      .from(labelsTable)
+      .where(eq(labelsTable.projectId, testProjectId));
+
+    const parkLabel = allLabels.find((l) => l.labelName === "park_scene");
+    const homeLabel = allLabels.find((l) => l.labelName === "home_scene");
+    const startLabel = allLabels.find((l) => l.labelName === "start");
+
+    // park_scene should have incoming jump from start
+    expect(parkLabel).toBeDefined();
+    expect(parkLabel!.incomingJumps).toBeDefined();
+    expect(parkLabel!.incomingJumps!.length).toBeGreaterThanOrEqual(1);
+    expect(parkLabel!.incomingJumps![0].sourceLabelTitle).toBe("start");
+    expect(parkLabel!.incomingJumps![0].jumpType).toBe("MENU_CHOICE");
+    expect(parkLabel!.incomingJumps![0].choiceText).toBe("Go to park");
+
+    // home_scene should have incoming jump from start
+    expect(homeLabel).toBeDefined();
+    expect(homeLabel!.incomingJumps).toBeDefined();
+    expect(homeLabel!.incomingJumps!.length).toBeGreaterThanOrEqual(1);
+    expect(homeLabel!.incomingJumps![0].choiceText).toBe("Stay home");
+
+    // start should have no incoming jumps
+    expect(startLabel).toBeDefined();
+    expect(
+      !startLabel!.incomingJumps || startLabel!.incomingJumps.length === 0
+    ).toBe(true);
+  });
+
+  it("populates incomingJumps for labels targeted by automatic jump statements", async () => {
+    const file3Id = testUuid("99110000", 5);
+    const file4Id = testUuid("99110000", 6);
+
+    await db.insert(projectFiles).values([
+      {
+        id: file3Id,
+        projectId: testProjectId,
+        source: "ZIP",
+        filePath: "game/file3.rpy",
+        fileType: "STORY",
+        content: "",
+        contentHash: calculateContentHash(""),
+      },
+      {
+        id: file4Id,
+        projectId: testProjectId,
+        source: "ZIP",
+        filePath: "game/file4.rpy",
+        fileType: "STORY",
+        content: "",
+        contentHash: calculateContentHash(""),
+      },
+    ]);
+
+    const file3 = `
+label chapter1:
+    "Some dialogue"
+    jump chapter2
+`.trim();
+
+    const file4 = `
+label chapter2:
+    "Chapter 2 begins"
+    return
+`.trim();
+
+    const r1 = await syncLabelsFromFile(
+      testProjectId,
+      { filePath: "game/file3.rpy", fileType: "STORY" },
+      file3,
+      file3Id
+    );
+    expect(r1.success).toBe(true);
+
+    const r2 = await syncLabelsFromFile(
+      testProjectId,
+      { filePath: "game/file4.rpy", fileType: "STORY" },
+      file4,
+      file4Id
+    );
+    expect(r2.success).toBe(true);
+
+    const allLabels = await db
+      .select({
+        id: labelsTable.id,
+        title: labelsTable.title,
+        labelName: labelsTable.labelName,
+        incomingJumps: labelsTable.incomingJumps,
+      })
+      .from(labelsTable)
+      .where(eq(labelsTable.projectId, testProjectId));
+
+    const ch2 = allLabels.find((l) => l.labelName === "chapter2");
+    expect(ch2).toBeDefined();
+    expect(ch2!.incomingJumps).toBeDefined();
+    expect(ch2!.incomingJumps!.length).toBeGreaterThanOrEqual(1);
+    expect(ch2!.incomingJumps![0].jumpType).toBe("AUTOMATIC");
+    expect(ch2!.incomingJumps![0].sourceLabelTitle).toBe("chapter1");
+  });
+
+  it("getLabel returns incomingJumps in the LabelDetail response", async () => {
+    const allLabels = await db
+      .select({ id: labelsTable.id, labelName: labelsTable.labelName })
+      .from(labelsTable)
+      .where(eq(labelsTable.projectId, testProjectId));
+
+    const parkLabel = allLabels.find((l) => l.labelName === "park_scene");
+    expect(parkLabel).toBeDefined();
+
+    const labelDetail = await getLabel(parkLabel!.id, testUserId);
+    expect(labelDetail).not.toBeNull();
+    expect(labelDetail!.incomingJumps).toBeDefined();
+    expect(labelDetail!.incomingJumps!.length).toBeGreaterThanOrEqual(1);
+    expect(labelDetail!.incomingJumps![0].sourceLabelTitle).toBe("start");
+    expect(labelDetail!.incomingJumps![0].jumpType).toBe("MENU_CHOICE");
+    expect(labelDetail!.incomingJumps![0].choiceText).toBe("Go to park");
+  });
+
+  it("populates incomingJumps when multiple files are synced within a single transaction", async () => {
+    const testFile5Id = testUuid("99110000", 7);
+    const testFile6Id = testUuid("99110000", 8);
+
+    await db.insert(projectFiles).values([
+      {
+        id: testFile5Id,
+        projectId: testProjectId,
+        source: "ZIP",
+        filePath: "game/file5.rpy",
+        fileType: "STORY",
+        content: "",
+        contentHash: calculateContentHash(""),
+      },
+      {
+        id: testFile6Id,
+        projectId: testProjectId,
+        source: "ZIP",
+        filePath: "game/file6.rpy",
+        fileType: "STORY",
+        content: "",
+        contentHash: calculateContentHash(""),
+      },
+    ]);
+
+    const file5 = `
+label start2:
+    "Welcome to the game"
+    menu:
+        "Go to park2":
+            jump park_scene2
+        "Stay home2":
+            jump home_scene2
+`.trim();
+
+    const file6 = `
+label park_scene2:
+    "You went to the park"
+    return
+
+label home_scene2:
+    "You stayed home"
+    return
+`.trim();
+
+    // Sync both files within a single transaction (like ZIP import does)
+    await db.transaction(async (tx) => {
+      await syncLabelsFromFile(
+        testProjectId,
+        { filePath: "game/file5.rpy", fileType: "STORY" },
+        file5,
+        testFile5Id,
+        { tx }
+      );
+
+      await syncLabelsFromFile(
+        testProjectId,
+        { filePath: "game/file6.rpy", fileType: "STORY" },
+        file6,
+        testFile6Id,
+        { tx }
+      );
+    });
+
+    // Check incomingJumps in database
+    const allLabels = await db
+      .select({
+        id: labelsTable.id,
+        title: labelsTable.title,
+        labelName: labelsTable.labelName,
+        incomingJumps: labelsTable.incomingJumps,
+      })
+      .from(labelsTable)
+      .where(eq(labelsTable.projectId, testProjectId));
+
+    const parkLabel2 = allLabels.find((l) => l.labelName === "park_scene2");
+    const homeLabel2 = allLabels.find((l) => l.labelName === "home_scene2");
+    const startLabel2 = allLabels.find((l) => l.labelName === "start2");
+
+    // park_scene2 should have incoming jump from start2
+    expect(parkLabel2).toBeDefined();
+    expect(parkLabel2!.incomingJumps).toBeDefined();
+    expect(parkLabel2!.incomingJumps!.length).toBeGreaterThanOrEqual(1);
+    expect(parkLabel2!.incomingJumps![0].sourceLabelTitle).toBe("start2");
+    expect(parkLabel2!.incomingJumps![0].jumpType).toBe("MENU_CHOICE");
+    expect(parkLabel2!.incomingJumps![0].choiceText).toBe("Go to park2");
+
+    // home_scene2 should have incoming jump from start2
+    expect(homeLabel2).toBeDefined();
+    expect(homeLabel2!.incomingJumps).toBeDefined();
+    expect(homeLabel2!.incomingJumps!.length).toBeGreaterThanOrEqual(1);
+    expect(homeLabel2!.incomingJumps![0].choiceText).toBe("Stay home2");
+
+    // start2 should have no incoming jumps
+    expect(startLabel2).toBeDefined();
+    expect(
+      !startLabel2!.incomingJumps || startLabel2!.incomingJumps.length === 0
+    ).toBe(true);
+  });
+
+  it("populates incomingJumps after a full ZIP import", async () => {
+    const zipUserId = testUuid("99110000", 9);
+    const zipProjectId = testUuid("99110000", 10);
+
+    await db.insert(users).values({
+      id: zipUserId,
+      email: testEmail("incoming-jumps-zip", "user"),
+      passwordHash: "hash",
+      role: "OWNER",
+    });
+
+    await db.insert(projects).values({
+      id: zipProjectId,
+      userId: zipUserId,
+      name: "ZIP Incoming Jumps Test",
+      source: "ZIP",
+    });
+
+    const zip = new JSZip();
+    zip.file(
+      "game/start.rpy",
+      'label start:\n    "Welcome"\n    menu:\n        "Go to park":\n            jump park\n        "Stay home":\n            jump home\n'
+    );
+    zip.file(
+      "game/park.rpy",
+      'label park:\n    "You went to the park"\n    return\n'
+    );
+    zip.file(
+      "game/home.rpy",
+      'label home:\n    "You stayed home"\n    return\n'
+    );
+
+    const zipBuffer = await zip.generateAsync({ type: "nodebuffer" });
+
+    const result = await importZipFile(zipProjectId, zipBuffer);
+    expect(result.success).toBe(true);
+
+    const allLabels = await db
+      .select({
+        id: labelsTable.id,
+        title: labelsTable.title,
+        labelName: labelsTable.labelName,
+        incomingJumps: labelsTable.incomingJumps,
+      })
+      .from(labelsTable)
+      .where(eq(labelsTable.projectId, zipProjectId));
+
+    const parkLabel = allLabels.find((l) => l.labelName === "park");
+    const homeLabel = allLabels.find((l) => l.labelName === "home");
+    const startLabel = allLabels.find((l) => l.labelName === "start");
+
+    expect(parkLabel).toBeDefined();
+    expect(parkLabel!.incomingJumps).toBeDefined();
+    expect(parkLabel!.incomingJumps!.length).toBeGreaterThanOrEqual(1);
+    expect(parkLabel!.incomingJumps![0].sourceLabelTitle).toBe("start");
+    expect(parkLabel!.incomingJumps![0].jumpType).toBe("MENU_CHOICE");
+    expect(parkLabel!.incomingJumps![0].choiceText).toBe("Go to park");
+
+    expect(homeLabel).toBeDefined();
+    expect(homeLabel!.incomingJumps).toBeDefined();
+    expect(homeLabel!.incomingJumps!.length).toBeGreaterThanOrEqual(1);
+    expect(homeLabel!.incomingJumps![0].choiceText).toBe("Stay home");
+
+    expect(startLabel).toBeDefined();
+    expect(
+      !startLabel!.incomingJumps || startLabel!.incomingJumps.length === 0
+    ).toBe(true);
+  });
+});

--- a/apps/backend/src/services/__tests__/rpy-parser.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/rpy-parser.service.unit.test.ts
@@ -833,6 +833,7 @@ label title:
           ],
           choices: [],
           jumps: [],
+          menus: [],
         },
         {
           label: "chapter1",
@@ -840,6 +841,7 @@ label title:
           dialogue: [{ speaker: "s", text: "Chapter content", lineNumber: 6 }],
           choices: [{ label: "Choice 1", target: "route_a", lineNumber: 7 }],
           jumps: [{ to: "ending", lineNumber: 8 }],
+          menus: [],
         },
       ],
       characters: [{ tag: "s", name: "Sylvie", color: "#c8ffc8" }],
@@ -984,6 +986,7 @@ label chapter1:
             ],
             choices: [],
             jumps: [],
+            menus: [],
           },
         ],
         characters: [],

--- a/apps/backend/src/services/__tests__/rpy-parser.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/rpy-parser.service.unit.test.ts
@@ -1231,6 +1231,26 @@ label chapter1:
       expect(result).toContain('ma "Always."');
       expect(result).toContain("jump end");
     });
+
+    it("should preserve legitimate narration that starts with 'jump'", () => {
+      const originalContent = `label test:
+    "jump over the fence"
+    return
+`;
+
+      const updatedDialogue = new Map([
+        ["test", [{ speaker: null, text: "jump over the fence" }]],
+      ]);
+
+      const result = reconstructRPYFile({
+        originalContent,
+        updatedDialogue,
+      });
+
+      // "jump over the fence" is NOT a keyword pattern (not followed by
+      // just an identifier), so it must be preserved as legitimate narration
+      expect(result).toContain('"jump over the fence"');
+    });
   });
 
   describe("addLabelToRPYContent", () => {

--- a/apps/backend/src/services/__tests__/zip-import.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/zip-import.service.unit.test.ts
@@ -61,6 +61,7 @@ vi.mock("../labels.service.js", () => ({
     skipped: false,
     affectedLabelIds: [],
   }),
+  updateIncomingJumpsForLabels: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("ZipImportService", () => {
@@ -270,6 +271,9 @@ describe("ZipImportService", () => {
       execute: vi.fn().mockResolvedValue(undefined),
       rollback: vi.fn(),
       commit: vi.fn(),
+      // Allow mockTx to be awaited (resolves to []) so that
+      // `await tx.select(…).from(…).where(…)` returns an array.
+      then: (resolve: (v: unknown[]) => void) => resolve([]),
     };
 
     const mockDb = {

--- a/apps/backend/src/services/gitlab-sync.service.ts
+++ b/apps/backend/src/services/gitlab-sync.service.ts
@@ -769,14 +769,28 @@ export async function importFromGitlab(
 
     // Compute incomingJumps for all labels in the project after import.
     // This must happen after all files are processed so cross-file jumps are captured.
-    await db.transaction(async (tx) => {
-      const allProjectLabels = await tx
-        .select({ id: labels.id })
-        .from(labels)
-        .where(and(eq(labels.projectId, projectId), isNull(labels.deletedAt)));
-      const allLabelIds = allProjectLabels.map((l) => l.id);
-      await updateIncomingJumpsForLabels(tx, allLabelIds, projectId);
-    });
+    // Wrapped in try/catch so a recompute failure does not invalidate per-file
+    // transactions that have already committed.
+    try {
+      await db.transaction(async (tx) => {
+        const allProjectLabels = await tx
+          .select({ id: labels.id })
+          .from(labels)
+          .where(
+            and(eq(labels.projectId, projectId), isNull(labels.deletedAt))
+          );
+        const allLabelIds = allProjectLabels.map((l) => l.id);
+        await updateIncomingJumpsForLabels(tx, allLabelIds, projectId);
+      });
+    } catch (recomputeError) {
+      logError("gitlab_sync.incoming_jumps_recompute_failed", {
+        projectId,
+        error:
+          recomputeError instanceof Error
+            ? recomputeError.message
+            : String(recomputeError),
+      });
+    }
 
     // Determine final status based on file processing failures
     const successfulFiles = parsedFiles.length - fileProcessingFailures.length;

--- a/apps/backend/src/services/gitlab-sync.service.ts
+++ b/apps/backend/src/services/gitlab-sync.service.ts
@@ -28,6 +28,7 @@ import {
   convertToBranchForgeFormatFromLabels,
   type ParsedRPYFileWithLabels,
 } from "./rpy-parser.service.js";
+import { updateIncomingJumpsForLabels } from "./labels.service.js";
 import {
   patchRPYWithVariables,
   generateVariablesFile,
@@ -750,7 +751,8 @@ export async function importFromGitlab(
       }
     }
 
-    // If all file fetches failed, mark operation as failed
+    // If all file fetches failed, mark operation as failed and skip
+    // the incomingJumps sweep (no new labels to compute for).
     if (!anySuccess && rpyFiles.length > 0) {
       const errorMessage = firstError?.message || "All file fetches failed";
       await updateSyncOperation(operation.id, {
@@ -764,6 +766,17 @@ export async function importFromGitlab(
         errorMessage,
       };
     }
+
+    // Compute incomingJumps for all labels in the project after import.
+    // This must happen after all files are processed so cross-file jumps are captured.
+    await db.transaction(async (tx) => {
+      const allProjectLabels = await tx
+        .select({ id: labels.id })
+        .from(labels)
+        .where(and(eq(labels.projectId, projectId), isNull(labels.deletedAt)));
+      const allLabelIds = allProjectLabels.map((l) => l.id);
+      await updateIncomingJumpsForLabels(tx, allLabelIds, projectId);
+    });
 
     // Determine final status based on file processing failures
     const successfulFiles = parsedFiles.length - fileProcessingFailures.length;

--- a/apps/backend/src/services/label-line-mapper.ts
+++ b/apps/backend/src/services/label-line-mapper.ts
@@ -73,6 +73,7 @@ export type LabelLineInsertValues = Pick<
   | "rpyIndentLevel"
   | "conditions"
   | "visualStatements"
+  | "menuOptions"
 >;
 
 // ============================================================================
@@ -253,12 +254,45 @@ export function mapEntriesToLabelLineValues(
     indentLevel?: number;
     conditions?: LineConditions;
     visuals?: VisualStatement[];
+    menuOptions?: Array<{
+      label: string;
+      targetLabelId: string;
+      targetLabelName: string;
+      conditionFlags?: string[];
+      effects?: {
+        stats?: Record<string, number>;
+      };
+    }>;
   }>,
   labelId: string,
   projectFileId: string,
   charactersByTag: Map<string, string>
 ): LabelLineInsertValues[] {
   return entries.map((entry, index) => {
+    // Handle MENU entries with menuOptions
+    if (entry.type === "MENU") {
+      const contentHash = calculateContentHash(
+        JSON.stringify(entry.menuOptions ?? [])
+      );
+      return {
+        labelId,
+        sequence: index + 1,
+        contentType: "MENU" as const,
+        content: "",
+        speakerId: null,
+        projectFileId,
+        linePosition: index,
+        contentHash,
+        lastSyncedHash: contentHash,
+        lastSyncedAt: new Date(),
+        rpyLineNumber: entry.lineNumber,
+        rpyIndentLevel: entry.indentLevel ?? 0,
+        conditions: null,
+        visualStatements: null,
+        menuOptions: entry.menuOptions ?? null,
+      };
+    }
+
     const mapped = mapEntryToDbContentType(entry);
     const entryContentHash = calculateContentHash(mapped.content);
     const speakerId = getCharacterIdByTag(entry.speaker, charactersByTag);
@@ -278,6 +312,7 @@ export function mapEntriesToLabelLineValues(
       rpyIndentLevel: entry.indentLevel ?? 0,
       conditions: normalizedConditions ?? null,
       visualStatements: entry.visuals ?? null,
+      menuOptions: null,
     };
   });
 }

--- a/apps/backend/src/services/labels.service.ts
+++ b/apps/backend/src/services/labels.service.ts
@@ -2651,7 +2651,7 @@ const UUID_REGEX =
  * @param labelIds - The label IDs to update incoming jumps for
  * @param projectId - The project ID to scan for incoming jumps
  */
-async function updateIncomingJumpsForLabels(
+export async function updateIncomingJumpsForLabels(
   context: Pick<ReturnType<typeof getDb>, "select" | "update">,
   labelIds: string[],
   projectId: string

--- a/apps/backend/src/services/labels.service.ts
+++ b/apps/backend/src/services/labels.service.ts
@@ -430,13 +430,22 @@ function buildLineValues(
     text?: string;
     lineNumber?: number;
     indentLevel?: number;
+    menuOptions?: Array<{
+      label: string;
+      targetLabelId: string;
+      targetLabelName: string;
+      conditionFlags?: string[];
+      effects?: {
+        stats?: Record<string, number>;
+      };
+    }>;
   }>,
   sourceId: string,
   lookupMaps: CharacterLookupMaps
 ): Array<{
   labelId: string;
   sequence: number;
-  contentType: "NARRATION" | "DIALOGUE" | "JUMP";
+  contentType: "NARRATION" | "DIALOGUE" | "JUMP" | "MENU";
   content: string;
   speakerId: string | null;
   visualType: "GENERATED";
@@ -447,8 +456,41 @@ function buildLineValues(
   lastSyncedAt: Date;
   rpyLineNumber: number | null;
   rpyIndentLevel: number;
+  menuOptions?: Array<{
+    label: string;
+    targetLabelId: string;
+    targetLabelName: string;
+    conditionFlags?: string[];
+    effects?: {
+      stats?: Record<string, number>;
+    };
+  }> | null;
 }> {
   return entries.map((entry, index) => {
+    // Handle MENU entries with menuOptions
+    if (entry.type === "MENU") {
+      const contentHash = calculateContentHash(
+        JSON.stringify(entry.menuOptions ?? [])
+      );
+      return {
+        labelId,
+        sequence: index + 1,
+        contentType: "MENU" as const,
+        content: "",
+        speakerId: null,
+        visualType: "GENERATED" as const,
+        projectFileId: sourceId,
+        linePosition: index,
+        contentHash,
+        lastSyncedHash: contentHash,
+        lastSyncedAt: new Date(),
+        rpyLineNumber: entry.lineNumber ?? null,
+        rpyIndentLevel: entry.indentLevel ?? 0,
+        menuOptions: entry.menuOptions ?? null,
+      };
+    }
+
+    // Existing logic for non-MENU entries
     const contentType = mapEntryToDbType(entry);
     const content = entry.target ? `jump ${entry.target}` : entry.text || "";
     const lineHash = calculateContentHash(content);
@@ -804,6 +846,9 @@ async function syncLabelsInTransaction(
         if (!renameCandidate && unmatchedExisting.length > 0) {
           const parsedHashes = new Set<string>(
             labelData.entries.map((entry) => {
+              if (entry.type === "MENU" && entry.menuOptions) {
+                return calculateContentHash(JSON.stringify(entry.menuOptions));
+              }
               const content = entry.target
                 ? `jump ${entry.target}`
                 : entry.text || "";

--- a/apps/backend/src/services/labels.service.ts
+++ b/apps/backend/src/services/labels.service.ts
@@ -1555,6 +1555,7 @@ export async function reconstructFileForLabel(
       labelId: labelLines.labelId,
       speakerId: labelLines.speakerId,
       speakerTag: characters.renpyTag,
+      contentType: labelLines.contentType,
       content: labelLines.content,
       sequence: labelLines.sequence,
     })
@@ -1574,7 +1575,11 @@ export async function reconstructFileForLabel(
   // Group lines by labelId in-memory
   const linesByLabelId = new Map<
     string,
-    Array<{ speaker: string | null; content: string }>
+    Array<{
+      speaker: string | null;
+      content: string;
+      contentType: string;
+    }>
   >();
   for (const line of allLabelLines) {
     if (!linesByLabelId.has(line.labelId)) {
@@ -1584,10 +1589,15 @@ export async function reconstructFileForLabel(
       // Use Ren'Py speaker tag for script-safe reconstruction
       speaker: line.speakerTag ?? null,
       content: line.content,
+      contentType: line.contentType,
     });
   }
 
-  // Build dialogue map from grouped lines
+  // Build dialogue map from grouped lines.
+  // Only include DIALOGUE and NARRATION entries. JUMP, MENU, and CHOICE lines are
+  // structural keywords already present in the original file (handled via menuStack
+  // and other mechanisms) and must not be emitted as quoted text, otherwise they
+  // appear duplicated (e.g. "jump end" + jump end).
   for (const l of allLabels) {
     // Skip labels without a labelName (UI-created labels that don't exist in RPY files)
     if (l.labelName === null) {
@@ -1596,10 +1606,15 @@ export async function reconstructFileForLabel(
 
     const labelLinesData = linesByLabelId.get(l.id) || [];
 
-    const labelDialogue = labelLinesData.map((line) => ({
-      speaker: line.speaker,
-      text: line.content,
-    }));
+    const labelDialogue = labelLinesData
+      .filter(
+        (line) =>
+          line.contentType === "DIALOGUE" || line.contentType === "NARRATION"
+      )
+      .map((line) => ({
+        speaker: line.speaker,
+        text: line.content,
+      }));
     updatedDialogue.set(l.labelName, labelDialogue);
   }
 

--- a/apps/backend/src/services/rpy-parser.service.ts
+++ b/apps/backend/src/services/rpy-parser.service.ts
@@ -1062,7 +1062,7 @@ export function parseRPYFileWithLabels(
         }> = [];
 
         // Look ahead for choice labels inside this menu
-        for (let j = i + 1; j < lines.length && j < i + 20; j++) {
+        for (let j = i + 1; j < lines.length; j++) {
           const choiceLine = lines[j];
           const choiceTrimmed = choiceLine.trim();
           const choiceIndent = choiceLine.search(/\S/);
@@ -1073,21 +1073,34 @@ export function parseRPYFileWithLabels(
             break;
           }
 
-          // Try double-quoted choice
+          // Try double-quoted, single-quoted, or unquoted choice
           const doubleQuoteMatch = choiceTrimmed.match(/^"(.+)":/);
-          if (doubleQuoteMatch) {
-            let choiceLabel = doubleQuoteMatch[1];
-            choiceLabel = choiceLabel
-              .replace(/"+$/, "")
-              .replace(/\\"/g, '"')
-              .replace(/""/g, '"');
+          const singleQuoteMatch = choiceTrimmed.match(/^'(.+)':/);
+          const unquotedMatch = choiceTrimmed.match(
+            /^([a-zA-Z_][a-zA-Z0-9_ ]*):$/
+          );
+          const quoteMatch =
+            doubleQuoteMatch || singleQuoteMatch || unquotedMatch;
+          if (quoteMatch) {
+            let choiceLabel = quoteMatch[1];
+            if (doubleQuoteMatch) {
+              choiceLabel = choiceLabel
+                .replace(/"+$/, "")
+                .replace(/\\"/g, '"')
+                .replace(/""/g, '"');
+            } else if (singleQuoteMatch) {
+              choiceLabel = choiceLabel
+                .replace(/'+$/, "")
+                .replace(/\\'/g, "'")
+                .replace(/''/g, "'");
+            }
             let target: string | null = null;
             const statEffects: Record<string, number> = {};
             const flags: string[] = [];
 
-            // Look ahead for jump and stat changes in this choice block
+            // Look ahead for jump and stat changes in this choice body
             const choiceBodyIndent = choiceIndent;
-            for (let k = j + 1; k < lines.length && k < j + 10; k++) {
+            for (let k = j + 1; k < lines.length; k++) {
               const bodyLine = lines[k];
               const bodyTrimmed = bodyLine.trim();
               const bodyIndent = bodyLine.search(/\S/);
@@ -1097,6 +1110,17 @@ export function parseRPYFileWithLabels(
 
               // Exit choice block if indentation decreased
               if (bodyIndent <= choiceBodyIndent) break;
+
+              // Exit if we hit another choice or dedent past menu level
+              // Exclude if/elif/else — those are valid choice body lines
+              if (
+                bodyIndent <= menuIndent ||
+                bodyTrimmed.match(/^["'][^"']+["']:/) ||
+                (bodyTrimmed.match(/^[a-zA-Z_][a-zA-Z0-9_ ]*:$/) &&
+                  !bodyTrimmed.match(/^(if|elif|else)\b/))
+              ) {
+                break;
+              }
 
               // Extract jump target
               const jumpInChoice = bodyTrimmed.match(
@@ -1959,6 +1983,35 @@ export function generateRpyFile(scene: BranchForgeScene): string {
         inMenu = false;
       }
       lines.push(`    "${entry.text}"`);
+    } else if (
+      entry.type === "MENU" &&
+      entry.menuOptions &&
+      entry.menuOptions.length > 0
+    ) {
+      const menuIndent = " ".repeat(
+        entry.indentLevel ? entry.indentLevel * 4 : 4
+      );
+      const choiceIndent = menuIndent + "    ";
+      const bodyIndent = choiceIndent + "    ";
+      lines.push(`${menuIndent}menu:`);
+      for (const opt of entry.menuOptions) {
+        lines.push(`${choiceIndent}"${opt.label}":`);
+        if (opt.targetLabelName) {
+          lines.push(`${bodyIndent}jump ${opt.targetLabelName}`);
+        }
+        if (opt.effects?.stats) {
+          for (const [stat, value] of Object.entries(opt.effects.stats)) {
+            const op = value >= 0 ? "+=" : "-=";
+            lines.push(`${bodyIndent}$ ${stat} ${op} ${Math.abs(value)}`);
+          }
+        }
+        if (opt.conditionFlags && opt.conditionFlags.length > 0) {
+          for (const flag of opt.conditionFlags) {
+            lines.push(`${bodyIndent}if ${flag}:`);
+          }
+        }
+      }
+      inMenu = false;
     } else if (entry.type === "FLAG" && entry.text && entry.target) {
       // Open menu if not already open
       if (!inMenu) {
@@ -1967,6 +2020,11 @@ export function generateRpyFile(scene: BranchForgeScene): string {
       }
       lines.push(`        "${entry.text}":`);
       lines.push(`            jump ${entry.target}`);
+    } else if (entry.type === "JUMP" && entry.target) {
+      if (inMenu) {
+        inMenu = false;
+      }
+      lines.push(`    jump ${entry.target}`);
     }
   }
 

--- a/apps/backend/src/services/rpy-parser.service.ts
+++ b/apps/backend/src/services/rpy-parser.service.ts
@@ -66,12 +66,21 @@ export interface RPYCharacter {
 export interface BranchForgeScene {
   name: string;
   entries: Array<{
-    type: "DIALOGUE" | "NARRATION" | "FLAG" | "JUMP";
+    type: "DIALOGUE" | "NARRATION" | "FLAG" | "JUMP" | "MENU";
     speaker?: string;
     text?: string;
     target?: string;
     lineNumber?: number; // RPY line number for accurate export
     indentLevel?: number; // Indent level for proper formatting
+    menuOptions?: Array<{
+      label: string;
+      targetLabelId: string;
+      targetLabelName: string;
+      conditionFlags?: string[];
+      effects?: {
+        stats?: Record<string, number>;
+      };
+    }>;
   }>;
   characters?: Array<{ tag: string; name: string }>;
 }
@@ -96,6 +105,17 @@ export interface LabeledDialogue {
   jumps: Array<{
     to: string;
     lineNumber: number;
+  }>;
+  // NEW: Grouped menu blocks with structured options
+  menus: Array<{
+    lineNumber: number;
+    options: Array<{
+      label: string;
+      target: string | null;
+      lineNumber: number;
+      effects?: Record<string, number>;
+      conditionFlags?: string[];
+    }>;
   }>;
 }
 
@@ -936,6 +956,7 @@ export function parseRPYFileWithLabels(
           dialogue: [],
           choices: [],
           jumps: [],
+          menus: [], // NEW
         };
         continue;
       }
@@ -1032,6 +1053,14 @@ export function parseRPYFileWithLabels(
       // Check for menu start
       if (trimmed === "menu:") {
         const menuIndent = line.search(/\S/);
+        const menuOptions: Array<{
+          label: string;
+          target: string | null;
+          lineNumber: number;
+          effects: Record<string, number>;
+          conditionFlags: string[];
+        }> = [];
+
         // Look ahead for choice labels inside this menu
         for (let j = i + 1; j < lines.length && j < i + 20; j++) {
           const choiceLine = lines[j];
@@ -1053,39 +1082,76 @@ export function parseRPYFileWithLabels(
               .replace(/\\"/g, '"')
               .replace(/""/g, '"');
             let target: string | null = null;
+            const statEffects: Record<string, number> = {};
+            const flags: string[] = [];
 
-            // Look ahead for jump statement in this choice block
+            // Look ahead for jump and stat changes in this choice block
+            const choiceBodyIndent = choiceIndent;
             for (let k = j + 1; k < lines.length && k < j + 10; k++) {
-              const jumpLine = lines[k];
-              const jumpTrimmed = jumpLine.trim();
-              const jumpIndent = jumpLine.search(/\S/);
+              const bodyLine = lines[k];
+              const bodyTrimmed = bodyLine.trim();
+              const bodyIndent = bodyLine.search(/\S/);
 
-              // Skip empty/whitespace-only lines
-              if (!jumpTrimmed) {
-                continue;
-              }
+              // Skip empty lines
+              if (!bodyTrimmed) continue;
 
-              // Check for jump statement before breaking on indentation
-              const jumpMatch = jumpTrimmed.match(
+              // Exit choice block if indentation decreased
+              if (bodyIndent <= choiceBodyIndent) break;
+
+              // Extract jump target
+              const jumpInChoice = bodyTrimmed.match(
                 /^jump\s+([a-zA-Z_][a-zA-Z0-9_]*)/
               );
-              if (jumpMatch) {
-                target = jumpMatch[1];
-                break;
+              if (jumpInChoice) {
+                target = jumpInChoice[1];
               }
 
-              // Exit choice block if indentation decreased to menu level or above
-              if (jumpIndent <= menuIndent) {
-                break;
+              // Extract stat changes (e.g., $ affection_luna += 10)
+              const statMatch = bodyTrimmed.match(
+                /\$\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*(\+=|-=)\s*(-?\d+)/
+              );
+              if (statMatch) {
+                const statName = statMatch[1];
+                const operator = statMatch[2];
+                const value = Number.parseInt(statMatch[3], 10);
+                if (operator === "+=") {
+                  statEffects[statName] = value;
+                } else if (operator === "-=") {
+                  statEffects[statName] = -value;
+                }
+              }
+
+              // Extract if conditions as flags
+              const ifMatch = bodyTrimmed.match(/^if\s+(\w+)\s*:/);
+              if (ifMatch) {
+                flags.push(ifMatch[1]);
               }
             }
 
+            // Push to flat choices (backward compatible)
             labelData.choices.push({
               label: choiceLabel,
               target,
               lineNumber: j + 1,
             });
+
+            // Push to structured menu options
+            menuOptions.push({
+              label: choiceLabel,
+              target,
+              lineNumber: j + 1,
+              effects: statEffects,
+              conditionFlags: flags,
+            });
           }
+        }
+
+        // Store the menu block with its options
+        if (menuOptions.length > 0) {
+          labelData.menus.push({
+            lineNumber: i + 1,
+            options: menuOptions,
+          });
         }
       }
 
@@ -1390,25 +1456,63 @@ export function convertToBranchForgeFormatFromLabels(
     });
   }
 
-  // Add choice entries (as flags) for THIS label only
-  for (const c of labelData.choices) {
-    entries.push({
-      type: "FLAG",
-      text: c.label,
-      target: c.target || undefined,
-      lineNumber: c.lineNumber,
-      indentLevel: getIndentLevel(c.lineNumber),
-    });
+  // Add menu entries (as MENU type with menuOptions) for THIS label
+  if (labelData.menus && labelData.menus.length > 0) {
+    for (const menu of labelData.menus) {
+      entries.push({
+        type: "MENU",
+        lineNumber: menu.lineNumber,
+        indentLevel: getIndentLevel(menu.lineNumber),
+        menuOptions: menu.options.map((o) => ({
+          label: o.label,
+          targetLabelId: o.target || "",
+          targetLabelName: o.target || "",
+          conditionFlags:
+            o.conditionFlags && o.conditionFlags.length > 0
+              ? o.conditionFlags
+              : undefined,
+          effects:
+            o.effects && Object.keys(o.effects).length > 0
+              ? { stats: o.effects }
+              : undefined,
+        })),
+      });
+    }
+  } else {
+    // Fallback to flat choices (backward compatible for old data)
+    for (const c of labelData.choices) {
+      entries.push({
+        type: "FLAG",
+        text: c.label,
+        target: c.target || undefined,
+        lineNumber: c.lineNumber,
+        indentLevel: getIndentLevel(c.lineNumber),
+      });
+    }
   }
 
-  // Add jump entries for THIS label only
+  // Collect all targets from menu options to avoid duplicate jump entries
+  // when menu choice bodies contain explicit jump statements
+  const menuTargets = new Set<string>();
+  if (labelData.menus) {
+    for (const menu of labelData.menus) {
+      for (const opt of menu.options) {
+        if (opt.target) menuTargets.add(opt.target);
+      }
+    }
+  }
+
+  // Add jump entries for THIS label only, excluding those already captured
+  // as menu choice targets (jumps inside menu bodies are redundant with menuOptions)
   for (const j of labelData.jumps) {
-    entries.push({
-      type: "JUMP",
-      target: j.to,
-      lineNumber: j.lineNumber,
-      indentLevel: getIndentLevel(j.lineNumber),
-    });
+    if (!menuTargets.has(j.to)) {
+      entries.push({
+        type: "JUMP",
+        target: j.to,
+        lineNumber: j.lineNumber,
+        indentLevel: getIndentLevel(j.lineNumber),
+      });
+    }
   }
 
   // Extract unique characters from this label's dialogue

--- a/apps/backend/src/services/rpy-parser.service.ts
+++ b/apps/backend/src/services/rpy-parser.service.ts
@@ -1964,6 +1964,9 @@ export function replaceLabelDialogue(
 export function generateRpyFile(scene: BranchForgeScene): string {
   const lines: string[] = [];
 
+  const escapeRenPyString = (s: string) =>
+    s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
   // Start with label
   lines.push(`label ${scene.name}:`);
   lines.push("");
@@ -1976,13 +1979,13 @@ export function generateRpyFile(scene: BranchForgeScene): string {
       if (inMenu) {
         inMenu = false;
       }
-      lines.push(`    ${entry.speaker} "${entry.text}"`);
+      lines.push(`    ${entry.speaker} "${escapeRenPyString(entry.text)}"`);
     } else if (entry.type === "NARRATION" && entry.text) {
       // Close any open menu before narration
       if (inMenu) {
         inMenu = false;
       }
-      lines.push(`    "${entry.text}"`);
+      lines.push(`    "${escapeRenPyString(entry.text)}"`);
     } else if (
       entry.type === "MENU" &&
       entry.menuOptions &&
@@ -1995,10 +1998,7 @@ export function generateRpyFile(scene: BranchForgeScene): string {
       const bodyIndent = choiceIndent + "    ";
       lines.push(`${menuIndent}menu:`);
       for (const opt of entry.menuOptions) {
-        lines.push(`${choiceIndent}"${opt.label}":`);
-        if (opt.targetLabelName) {
-          lines.push(`${bodyIndent}jump ${opt.targetLabelName}`);
-        }
+        lines.push(`${choiceIndent}"${escapeRenPyString(opt.label)}":`);
         if (opt.effects?.stats) {
           for (const [stat, value] of Object.entries(opt.effects.stats)) {
             const op = value >= 0 ? "+=" : "-=";
@@ -2010,6 +2010,9 @@ export function generateRpyFile(scene: BranchForgeScene): string {
             lines.push(`${bodyIndent}if ${flag}:`);
           }
         }
+        if (opt.targetLabelName) {
+          lines.push(`${bodyIndent}jump ${opt.targetLabelName}`);
+        }
       }
       inMenu = false;
     } else if (entry.type === "FLAG" && entry.text && entry.target) {
@@ -2018,7 +2021,7 @@ export function generateRpyFile(scene: BranchForgeScene): string {
         lines.push(`    menu:`);
         inMenu = true;
       }
-      lines.push(`        "${entry.text}":`);
+      lines.push(`        "${escapeRenPyString(entry.text)}":`);
       lines.push(`            jump ${entry.target}`);
     } else if (entry.type === "JUMP" && entry.target) {
       if (inMenu) {

--- a/apps/backend/src/services/zip-import.service.ts
+++ b/apps/backend/src/services/zip-import.service.ts
@@ -9,12 +9,16 @@
 import JSZip from "jszip";
 import { getDb } from "../db/index.js";
 import { projectFiles } from "../db/schema/index.js";
-import { eq, and, sql } from "drizzle-orm";
+import { eq, and, isNull, sql } from "drizzle-orm";
 import { calculateContentHash } from "../lib/hash.js";
 import { parseRPYFileWithLabels } from "./rpy-parser.service.js";
 import { logError, LogEventType } from "../lib/logger.js";
-import { syncLabelsFromFile } from "./labels.service.js";
+import {
+  syncLabelsFromFile,
+  updateIncomingJumpsForLabels,
+} from "./labels.service.js";
 import { createProject, deleteProject } from "./projects.service.js";
+import { labels } from "../db/schema/index.js";
 
 // ============================================================================
 // Import Guardrails
@@ -356,6 +360,22 @@ export async function importZipFile(
         fileIndex++;
       }
     });
+
+    // Compute incomingJumps for all project labels after import so
+    // cross-file jumps are captured regardless of file processing order.
+    // Skip if every file failed — no new labels were written.
+    if (filesImported + filesUpdated + filesSkipped > 0) {
+      await db.transaction(async (tx) => {
+        const allProjectLabels = await tx
+          .select({ id: labels.id })
+          .from(labels)
+          .where(
+            and(eq(labels.projectId, projectId), isNull(labels.deletedAt))
+          );
+        const allLabelIds = allProjectLabels.map((l) => l.id);
+        await updateIncomingJumpsForLabels(tx, allLabelIds, projectId);
+      });
+    }
 
     // Construct success result
     const success: ImportZipSuccess = {

--- a/apps/frontend/src/components/ide-shared/GitLabImportDialog.tsx
+++ b/apps/frontend/src/components/ide-shared/GitLabImportDialog.tsx
@@ -26,7 +26,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/contexts/ToastContext";
 import { useGitLab } from "@/hooks/useGitLab";
 import { gitlabApi } from "@/lib/api/gitlab";
-import { projectKeys, gitlabKeys } from "@/lib/query-keys";
+import { projectKeys, gitlabKeys, labelKeys } from "@/lib/query-keys";
 import { useQueryClient } from "@tanstack/react-query";
 import type { GitLabRepository } from "@/lib/api/gitlab";
 import { CharacterImportWizard } from "@/components/CharacterImportWizard";
@@ -275,6 +275,12 @@ export function GitLabImportDialog({
       await queryClient.invalidateQueries({ queryKey: projectKeys.lists() });
       await queryClient.invalidateQueries({
         queryKey: gitlabKeys.repositories(),
+      });
+
+      // Invalidate label queries for the new project to ensure fresh data
+      // (including incomingJumps computed during sync).
+      await queryClient.invalidateQueries({
+        queryKey: labelKeys.scoped(result.project.id),
       });
 
       const currentImportId = importIdRef.current;

--- a/apps/frontend/src/hooks/__tests__/useGitLabSync.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useGitLabSync.test.tsx
@@ -615,9 +615,9 @@ describe("useGitLabSync", () => {
         { timeout: 5000 }
       );
 
-      // Labels are immediately refetched after export to ensure data freshness
-      expect(refetchQueriesSpy).toHaveBeenCalledWith({
-        queryKey: labelKeys.lists("project-1"),
+      // Labels are invalidated after export to ensure data freshness
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: labelKeys.scoped("project-1"),
       });
       // Project files are also refetched to reflect any file changes from export
       expect(refetchQueriesSpy).toHaveBeenCalledWith({

--- a/apps/frontend/src/hooks/useGitLabSync.ts
+++ b/apps/frontend/src/hooks/useGitLabSync.ts
@@ -162,9 +162,11 @@ export function useGitLabSync(): UseGitLabSyncReturn {
 
   const invalidateProjectCaches = useCallback(
     (projectId: string) => {
-      // Invalidate and refetch list queries to ensure immediate data refresh
-      void queryClient.refetchQueries({
-        queryKey: labelKeys.lists(projectId),
+      // Invalidate all label queries for this project to ensure data refresh
+      // (e.g. incomingJumps recomputed after import). We use invalidateQueries
+      // to mark queries as stale so they refetch when next mounted/used.
+      queryClient.invalidateQueries({
+        queryKey: labelKeys.scoped(projectId),
       });
       void queryClient.refetchQueries({
         queryKey: gitlabKeys.importedFiles(projectId),

--- a/apps/frontend/src/hooks/useImportZipProject.ts
+++ b/apps/frontend/src/hooks/useImportZipProject.ts
@@ -6,7 +6,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { projectsApi } from "@/lib/api/projects";
-import { projectKeys } from "@/lib/query-keys";
+import { projectKeys, labelKeys } from "@/lib/query-keys";
 import type { ImportZipBody } from "@/lib/api/projects";
 
 export function useImportZipProject() {
@@ -16,9 +16,18 @@ export function useImportZipProject() {
     mutationFn: async (body: ImportZipBody) => {
       return projectsApi.importZip(body);
     },
-    onSuccess: async () => {
+    onSuccess: async (response) => {
       // Invalidate projects cache to refresh the list
       await queryClient.invalidateQueries({ queryKey: projectKeys.lists() });
+
+      // Invalidate label queries for the new project to ensure fresh data
+      // (including incomingJumps computed during sync). We use invalidateQueries
+      // to mark queries as stale so they refetch when next mounted/used.
+      if (response.success && response.project?.id) {
+        await queryClient.invalidateQueries({
+          queryKey: labelKeys.scoped(response.project.id),
+        });
+      }
     },
   });
 }

--- a/apps/frontend/src/hooks/useLabels.ts
+++ b/apps/frontend/src/hooks/useLabels.ts
@@ -307,25 +307,12 @@ export function useLabels(): UseLabelsReturn {
   // Invalidate labels method
   const invalidateLabels = useCallback(async () => {
     if (currentProject) {
-      // Refetch list queries to ensure immediate data refresh after import
-      // Also invalidate all detail queries for this project
-      // This ensures Write Mode gets fresh label data after import
-      await Promise.all([
-        queryClient.refetchQueries({
-          queryKey: labelKeys.lists(currentProject.id),
-        }),
-        queryClient.invalidateQueries({
-          predicate: (query) => {
-            const key = query.queryKey as unknown[];
-            return (
-              Array.isArray(key) &&
-              key[0] === "labels" &&
-              key[1] === currentProject.id &&
-              key[2] === "detail"
-            );
-          },
-        }),
-      ]);
+      // Invalidate all label queries for this project (list, detail, activeLabelId, etc.)
+      // using scoped prefix match. This marks queries as stale so they refetch
+      // when next mounted/used, ensuring fresh data including incomingJumps.
+      await queryClient.invalidateQueries({
+        queryKey: labelKeys.scoped(currentProject.id),
+      });
     }
   }, [currentProject, queryClient]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end support for interactive menu blocks with conditional options, stat-effect modifiers, and stable menu hashing

* **Improvements**
  * Dialogue saves now preserve menu/jump structures and append prose without overwriting structural lines
  * Import/sync flows and frontend cache invalidation updated to refresh label-related data and run incoming-jump recomputation after imports

* **Tests**
  * Added integration/unit tests covering menus, incoming-jumps, reconstruction, and related sync behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->