### PR TITLE
Add end-to-end support for editing menu texts in write mode

### DIFF
--- a/.changeset/full-papers-wear.md
+++ b/.changeset/full-papers-wear.md
@@ -1,0 +1,6 @@
+---
+"@branchforge/frontend": patch
+"@branchforge/backend": patch
+---
+
+Added support for editing menu choice texts in write mode

--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -412,20 +412,38 @@ export const updateLabelSchema = z
 /**
  * Update label dialogue request validation
  */
+const menuOptionSchema = z.object({
+  label: z.string().min(1, "Choice label cannot be empty"),
+  targetLabelId: z.string().uuid(),
+  targetLabelName: z.string(),
+  conditionFlags: z.array(z.string()).optional(),
+  effects: z.object({ stats: z.record(z.string(), z.number()) }).optional(),
+});
+
+const menuBlockSchema = z.object({
+  lineId: z.string().uuid(),
+  menuOptions: z.array(menuOptionSchema),
+});
+
 export const updateLabelDialogueBodySchema = z
   .object({
-    dialogue: z
-      .array(
-        z.object({
-          speakerId: z.string().uuid().nullable(),
-          text: z.string().min(1, "Dialogue text cannot be empty"),
-        })
-      )
-      .min(1, "At least one dialogue entry is required"),
+    dialogue: z.array(
+      z.object({
+        speakerId: z.string().uuid().nullable(),
+        text: z.string().min(1, "Dialogue text cannot be empty"),
+      })
+    ),
+    menuBlocks: z.array(menuBlockSchema).optional(),
     expectedVersion: z.number().int().min(1).optional(),
     expectedContentHash: expectedContentHashSchema,
   })
-  .strict();
+  .refine(
+    (data) =>
+      (data.dialogue?.length ?? 0) > 0 || (data.menuBlocks?.length ?? 0) > 0,
+    {
+      message: "At least one dialogue entry or menu block is required",
+    }
+  );
 
 // ============================================================================
 // Route Configuration Schemas

--- a/apps/backend/src/routes/labels.routes.ts
+++ b/apps/backend/src/routes/labels.routes.ts
@@ -412,10 +412,14 @@ async function updateLabelDialogueHandler(
       // 3.5. Process menu blocks - update MENU lines' menuOptions
       if (menuBlocks && menuBlocks.length > 0) {
         for (const block of menuBlocks) {
-          await tx
+          const menuContentHash = calculateContentHash(
+            JSON.stringify(block.menuOptions)
+          );
+          const result = await tx
             .update(labelLines)
             .set({
               menuOptions: block.menuOptions,
+              contentHash: menuContentHash,
               isDirty: true,
               lastSyncedHash: null,
             })
@@ -423,9 +427,15 @@ async function updateLabelDialogueHandler(
               and(
                 eq(labelLines.id, block.lineId),
                 eq(labelLines.labelId, labelId),
+                eq(labelLines.contentType, "MENU"),
                 isNull(labelLines.deletedAt)
               )
             );
+          if (result.rowCount === 0) {
+            throw new NotFoundError(
+              `Menu line ${block.lineId} not found in label ${labelId}`
+            );
+          }
         }
       }
 

--- a/apps/backend/src/routes/labels.routes.ts
+++ b/apps/backend/src/routes/labels.routes.ts
@@ -176,7 +176,8 @@ async function updateLabelDialogueHandler(
   reply: FastifyReply
 ): Promise<void> {
   const { labelId } = request.params;
-  const { dialogue, expectedVersion, expectedContentHash } = request.body;
+  const { dialogue, menuBlocks, expectedVersion, expectedContentHash } =
+    request.body;
   const user = request.user!;
 
   try {
@@ -406,6 +407,26 @@ async function updateLabelDialogueHandler(
 
       if (idsToDelete.length > 0) {
         await tx.delete(labelLines).where(inArray(labelLines.id, idsToDelete));
+      }
+
+      // 3.5. Process menu blocks - update MENU lines' menuOptions
+      if (menuBlocks && menuBlocks.length > 0) {
+        for (const block of menuBlocks) {
+          await tx
+            .update(labelLines)
+            .set({
+              menuOptions: block.menuOptions,
+              isDirty: true,
+              lastSyncedHash: null,
+            })
+            .where(
+              and(
+                eq(labelLines.id, block.lineId),
+                eq(labelLines.labelId, labelId),
+                isNull(labelLines.deletedAt)
+              )
+            );
+        }
       }
 
       // 4. Compute content hash from the actual persisted label_lines

--- a/apps/backend/src/services/labels.service.ts
+++ b/apps/backend/src/services/labels.service.ts
@@ -1603,6 +1603,7 @@ export async function reconstructFileForLabel(
       contentType: labelLines.contentType,
       content: labelLines.content,
       sequence: labelLines.sequence,
+      menuOptions: labelLines.menuOptions,
     })
     .from(labelLines)
     .leftJoin(characters, eq(labelLines.speakerId, characters.id))
@@ -1643,6 +1644,11 @@ export async function reconstructFileForLabel(
   // structural keywords already present in the original file (handled via menuStack
   // and other mechanisms) and must not be emitted as quoted text, otherwise they
   // appear duplicated (e.g. "jump end" + jump end).
+  //
+  // Also build a menu choices map from MENU lines' menuOptions, so that
+  // reconstructRPYFile can update choice text in the RPY file.
+  const updatedMenuChoices = new Map<string, string[][]>();
+
   for (const l of allLabels) {
     // Skip labels without a labelName (UI-created labels that don't exist in RPY files)
     if (l.labelName === null) {
@@ -1661,12 +1667,29 @@ export async function reconstructFileForLabel(
         text: line.content,
       }));
     updatedDialogue.set(l.labelName, labelDialogue);
+
+    // Build menu choices from MENU lines' menuOptions
+    const menuBlocks = allLabelLines
+      .filter(
+        (line) =>
+          line.labelId === l.id &&
+          line.contentType === "MENU" &&
+          line.menuOptions &&
+          line.menuOptions.length > 0
+      )
+      .sort((a, b) => a.sequence - b.sequence)
+      .map((line) => line.menuOptions!.map((opt) => opt.label));
+
+    if (menuBlocks.length > 0) {
+      updatedMenuChoices.set(l.labelName, menuBlocks);
+    }
   }
 
   // Reconstruct and return file content using current file content as base
   return reconstructRPYFile({
     originalContent: reconstructionBaseContent,
     updatedDialogue,
+    updatedMenuChoices,
   });
 }
 

--- a/apps/backend/src/services/labels.service.ts
+++ b/apps/backend/src/services/labels.service.ts
@@ -1647,7 +1647,18 @@ export async function reconstructFileForLabel(
   //
   // Also build a menu choices map from MENU lines' menuOptions, so that
   // reconstructRPYFile can update choice text in the RPY file.
-  const updatedMenuChoices = new Map<string, string[][]>();
+  const updatedMenuChoices = new Map<
+    string,
+    Array<
+      Array<{
+        label: string;
+        targetLabelId?: string;
+        targetLabelName?: string;
+        conditionFlags?: string[];
+        effects?: { stats?: Record<string, number> };
+      }>
+    >
+  >();
 
   for (const l of allLabels) {
     // Skip labels without a labelName (UI-created labels that don't exist in RPY files)
@@ -1678,7 +1689,15 @@ export async function reconstructFileForLabel(
           line.menuOptions.length > 0
       )
       .sort((a, b) => a.sequence - b.sequence)
-      .map((line) => line.menuOptions!.map((opt) => opt.label));
+      .map((line) =>
+        line.menuOptions!.map((opt) => ({
+          label: opt.label,
+          targetLabelId: opt.targetLabelId,
+          targetLabelName: opt.targetLabelName,
+          conditionFlags: opt.conditionFlags,
+          effects: opt.effects,
+        }))
+      );
 
     if (menuBlocks.length > 0) {
       updatedMenuChoices.set(l.labelName, menuBlocks);

--- a/apps/backend/src/services/rpy-parser.service.ts
+++ b/apps/backend/src/services/rpy-parser.service.ts
@@ -256,6 +256,7 @@ function trackBlocks(
 export interface ReconstructedFileOptions {
   originalContent: string;
   updatedDialogue: Map<string, Array<{ speaker: string | null; text: string }>>; // label -> dialogue
+  updatedMenuChoices?: Map<string, string[][]>; // label -> [menuBlock1Choices, menuBlock2Choices, ...]
 }
 
 /**
@@ -1205,7 +1206,7 @@ export function parseRPYFileWithLabels(
  * @returns Reconstructed RPY file content
  */
 export function reconstructRPYFile(options: ReconstructedFileOptions): string {
-  const { originalContent, updatedDialogue } = options;
+  const { originalContent, updatedDialogue, updatedMenuChoices } = options;
   const lines = originalContent.split("\n");
   const result: string[] = [];
 
@@ -1222,6 +1223,11 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
   // menu choice bodies should NOT trigger dialogue insertion — they're part of
   // the menu structure, not the label's main dialogue flow.
   const menuStack: number[] = [];
+
+  // Track menu choice replacement: per label, track which menu block index
+  // we're in and which choice index within that block.
+  const menuBlockIndices = new Map<string, number>(); // label -> current menu block index
+  const menuChoiceIndices = new Map<string, number>(); // label -> current choice index
 
   // Keywords that signal the end of a label's dialogue block.
   // The `menuStack.length === 0` guard below prevents premature insertion at
@@ -1285,6 +1291,12 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
     // Track menu block nesting: push on menu:, pop on dedent
     if (trimmed === "menu:") {
       menuStack.push(line.search(/\S/));
+      // Track menu block index for choice text replacement
+      if (currentLabel) {
+        const blockIdx = menuBlockIndices.get(currentLabel) ?? 0;
+        menuBlockIndices.set(currentLabel, blockIdx + 1);
+        menuChoiceIndices.set(currentLabel, 0);
+      }
     } else if (menuStack.length > 0 && trimmed) {
       const lineIndent = line.search(/\S/);
       while (
@@ -1292,6 +1304,42 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
         lineIndent <= menuStack[menuStack.length - 1]
       ) {
         menuStack.pop();
+      }
+    }
+
+    // Replace menu choice text inside menu blocks.
+    // Choice lines in RPY look like: "Choice text":
+    // or with conditions: "Choice text" if condition:
+    if (
+      menuStack.length > 0 &&
+      currentLabel &&
+      updatedMenuChoices?.has(currentLabel)
+    ) {
+      // Match a choice line: "text": or "text" if condition:
+      const choiceMatch = trimmed.match(/^"(.+?)"(?:\s+(if\s+.+))?:(?:\s*)?$/);
+      if (choiceMatch) {
+        const labelBlocks = updatedMenuChoices.get(currentLabel)!;
+        const blockIdx = (menuBlockIndices.get(currentLabel) ?? 1) - 1;
+        const choiceIdx = menuChoiceIndices.get(currentLabel) ?? 0;
+
+        if (
+          blockIdx < labelBlocks.length &&
+          choiceIdx < labelBlocks[blockIdx].length
+        ) {
+          const newChoiceText = labelBlocks[blockIdx][choiceIdx];
+          menuChoiceIndices.set(currentLabel, choiceIdx + 1);
+
+          // Reconstruct the line preserving indentation and any trailing syntax
+          const indent = line.match(/^(\s*)/)?.[1] || "";
+          // Preserve condition suffix if present: "text" if condition:
+          const conditionPart = choiceMatch[2];
+          if (conditionPart) {
+            result.push(`${indent}"${newChoiceText}" ${conditionPart}:`);
+          } else {
+            result.push(`${indent}"${newChoiceText}":`);
+          }
+          continue;
+        }
       }
     }
 
@@ -1481,11 +1529,17 @@ export function convertToBranchForgeFormatFromLabels(
   }
 
   // Add menu entries (as MENU type with menuOptions) for THIS label
+  // Use the first choice option's line number so the MENU entry sorts AFTER
+  // any caption text (narration lines between `menu:` and the first choice)
   if (labelData.menus && labelData.menus.length > 0) {
     for (const menu of labelData.menus) {
+      // Use first option's line number for sort ordering; fall back to
+      // the menu keyword's line if there are no options (shouldn't happen)
+      const sortLineNumber =
+        menu.options.length > 0 ? menu.options[0].lineNumber : menu.lineNumber;
       entries.push({
         type: "MENU",
-        lineNumber: menu.lineNumber,
+        lineNumber: sortLineNumber,
         indentLevel: getIndentLevel(menu.lineNumber),
         menuOptions: menu.options.map((o) => ({
           label: o.label,
@@ -1557,7 +1611,7 @@ export function convertToBranchForgeFormatFromLabels(
 
   return {
     name: labelName,
-    entries,
+    entries: entries.sort((a, b) => (a.lineNumber ?? 0) - (b.lineNumber ?? 0)),
     characters: characters.length > 0 ? characters : undefined,
   };
 }

--- a/apps/backend/src/services/rpy-parser.service.ts
+++ b/apps/backend/src/services/rpy-parser.service.ts
@@ -253,10 +253,19 @@ function trackBlocks(
  * Options for reconstructing RPY file with updated dialogue
  * Used for Write Mode saves to merge dialogue changes with original keywords
  */
+/** A single menu option carried through RPY reconstruction */
+export interface MenuOptionForReconstruction {
+  label: string;
+  targetLabelId?: string;
+  targetLabelName?: string;
+  conditionFlags?: string[];
+  effects?: { stats?: Record<string, number> };
+}
+
 export interface ReconstructedFileOptions {
   originalContent: string;
   updatedDialogue: Map<string, Array<{ speaker: string | null; text: string }>>; // label -> dialogue
-  updatedMenuChoices?: Map<string, string[][]>; // label -> [menuBlock1Choices, menuBlock2Choices, ...]
+  updatedMenuChoices?: Map<string, MenuOptionForReconstruction[][]>; // label -> [menuBlock1, menuBlock2, ...]
 }
 
 /**
@@ -1315,8 +1324,13 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
       currentLabel &&
       updatedMenuChoices?.has(currentLabel)
     ) {
-      // Match a choice line: "text": or "text" if condition:
-      const choiceMatch = trimmed.match(/^"(.+?)"(?:\s+(if\s+.+))?:(?:\s*)?$/);
+      // Match a choice line with any quoting style: "text", 'text', or unquoted
+      // Also captures optional "if ..." condition
+      // Negative lookahead excludes Ren'Py control-flow keywords (if/elif/else/jump/etc.)
+      // that appear inside menu blocks at the same indent level as choices.
+      const choiceMatch = trimmed.match(
+        /^(?:"(.+?)"|'(.+?)'|(?!(?:if|elif|else|pass|jump|call|return|python|while|for|default|define|label|menu|init)\s*:)([a-zA-Z_][a-zA-Z0-9_ ]*?))(?:\s+(if\s+.+))?:(?:\s*)?$/
+      );
       if (choiceMatch) {
         const labelBlocks = updatedMenuChoices.get(currentLabel)!;
         const blockIdx = (menuBlockIndices.get(currentLabel) ?? 1) - 1;
@@ -1326,17 +1340,21 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
           blockIdx < labelBlocks.length &&
           choiceIdx < labelBlocks[blockIdx].length
         ) {
-          const newChoiceText = labelBlocks[blockIdx][choiceIdx];
+          const newChoiceText = labelBlocks[blockIdx][choiceIdx].label;
           menuChoiceIndices.set(currentLabel, choiceIdx + 1);
 
           // Reconstruct the line preserving indentation and any trailing syntax
           const indent = line.match(/^(\s*)/)?.[1] || "";
           // Preserve condition suffix if present: "text" if condition:
-          const conditionPart = choiceMatch[2];
+          const conditionPart = choiceMatch[4];
+          // Determine quote style from the original match
+          const quote = choiceMatch[1] ? '"' : choiceMatch[2] ? "'" : "";
           if (conditionPart) {
-            result.push(`${indent}"${newChoiceText}" ${conditionPart}:`);
+            result.push(
+              `${indent}${quote}${newChoiceText}${quote} ${conditionPart}:`
+            );
           } else {
-            result.push(`${indent}"${newChoiceText}":`);
+            result.push(`${indent}${quote}${newChoiceText}${quote}:`);
           }
           continue;
         }

--- a/apps/frontend/src/components/write-mode/DialogueLine.tsx
+++ b/apps/frontend/src/components/write-mode/DialogueLine.tsx
@@ -29,6 +29,17 @@ interface DialogueLineProps {
   showBadges?: boolean;
 }
 
+/**
+ * Structural equality check for memo comparison.
+ * Handles nested objects (e.g. effects.stats) and arrays (e.g. conditionFlags)
+ * correctly via JSON.stringify, unlike shallow reference comparison.
+ */
+function isEqualJson(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return a === b;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
 function areDialogueLinePropsEqual(
   prev: DialogueLineProps,
   next: DialogueLineProps
@@ -41,10 +52,14 @@ function areDialogueLinePropsEqual(
     prev.entry.choiceData?.targetLabelId ===
       next.entry.choiceData?.targetLabelId &&
     prev.entry.choiceData?.optionIndex === next.entry.choiceData?.optionIndex &&
-    JSON.stringify(prev.entry.choiceData?.conditionFlags) ===
-      JSON.stringify(next.entry.choiceData?.conditionFlags) &&
-    JSON.stringify(prev.entry.choiceData?.effects) ===
-      JSON.stringify(next.entry.choiceData?.effects) &&
+    isEqualJson(
+      prev.entry.choiceData?.conditionFlags,
+      next.entry.choiceData?.conditionFlags
+    ) &&
+    isEqualJson(
+      prev.entry.choiceData?.effects,
+      next.entry.choiceData?.effects
+    ) &&
     prev.entry.contentType === next.entry.contentType &&
     prev.index === next.index &&
     prev.totalEntries === next.totalEntries &&

--- a/apps/frontend/src/components/write-mode/DialogueLine.tsx
+++ b/apps/frontend/src/components/write-mode/DialogueLine.tsx
@@ -6,7 +6,7 @@
  */
 
 import { memo, useState, useCallback, useRef, useEffect, useId } from "react";
-import { X, ChevronDown } from "lucide-react";
+import { X, ChevronDown, Split, ArrowUpRight } from "lucide-react";
 import type { DialogueEntry } from "@/lib/prose-types";
 import type { Character } from "@branchforge/shared";
 import { withAlpha } from "@/lib/utils";
@@ -37,6 +37,14 @@ function areDialogueLinePropsEqual(
     prev.entry.id === next.entry.id &&
     prev.entry.speakerId === next.entry.speakerId &&
     prev.entry.text === next.entry.text &&
+    prev.entry.choiceData?.lineId === next.entry.choiceData?.lineId &&
+    prev.entry.choiceData?.targetLabelId ===
+      next.entry.choiceData?.targetLabelId &&
+    prev.entry.choiceData?.optionIndex === next.entry.choiceData?.optionIndex &&
+    JSON.stringify(prev.entry.choiceData?.conditionFlags) ===
+      JSON.stringify(next.entry.choiceData?.conditionFlags) &&
+    JSON.stringify(prev.entry.choiceData?.effects) ===
+      JSON.stringify(next.entry.choiceData?.effects) &&
     prev.entry.contentType === next.entry.contentType &&
     prev.index === next.index &&
     prev.totalEntries === next.totalEntries &&
@@ -290,11 +298,12 @@ export const DialogueLine = memo(function DialogueLine({
         speakerId,
         text: entry.text,
         contentType: entry.contentType,
+        choiceData: entry.choiceData,
       });
       setIsDropdownOpen(false);
       setFocusedOptionIndex(-1);
     },
-    [entry.id, entry.text, onChange]
+    [onChange, entry.id, entry.text, entry.contentType, entry.choiceData]
   );
 
   const handleTextChange = useCallback(
@@ -307,11 +316,18 @@ export const DialogueLine = memo(function DialogueLine({
         speakerId: entry.speakerId,
         text: e.target.value,
         contentType: entry.contentType,
+        choiceData: entry.choiceData,
       });
       // Resize immediately for smooth typing experience
       resizeTextarea();
     },
-    [entry.id, entry.speakerId, resizeTextarea]
+    [
+      entry.id,
+      entry.speakerId,
+      entry.contentType,
+      entry.choiceData,
+      resizeTextarea,
+    ]
   );
 
   const handleKeyDown = useCallback(
@@ -420,13 +436,22 @@ export const DialogueLine = memo(function DialogueLine({
   const isStacked = layoutMode === "stacked";
   const isSpeakerInteractive = isHovered || isDropdownOpen;
   const hasSpeaker = Boolean(entry.speakerId);
-  const showDelete = (isHovered || entry.text === "") && totalEntries > 1;
+  const isChoice = entry.contentType === "CHOICE";
+  const choiceTargetName = entry.choiceData?.targetLabelName;
+  const showDelete =
+    (isHovered || entry.text === "") && totalEntries > 1 && !isChoice;
+
+  const wrapperClass = isChoice
+    ? `group relative transition-colors pl-3 ${
+        isStacked ? "flex flex-col gap-1.5 py-2" : "flex flex-col gap-1 py-1.5"
+      }`
+    : `group relative transition-colors ${
+        isStacked ? "flex flex-col gap-1.5 py-2" : "flex flex-col gap-1 py-1.5"
+      }`;
 
   return (
     <div
-      className={`group relative transition-colors ${
-        isStacked ? "flex flex-col gap-1.5 py-2" : "flex flex-col gap-1 py-1.5"
-      }`}
+      className={wrapperClass}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
@@ -434,130 +459,149 @@ export const DialogueLine = memo(function DialogueLine({
       <div
         className={`flex ${isStacked ? "flex-col gap-1.5" : "items-start gap-3"}`}
       >
-        {/* Speaker Name / Dropdown */}
-        <div
-          className={`relative ${isStacked ? "w-full" : "shrink-0 w-40"}`}
-          ref={dropdownRef}
-          onBlur={handleDropdownBlur}
-        >
-          <button
-            ref={speakerButtonRef}
-            type="button"
-            onClick={handleSpeakerToggle}
-            aria-haspopup="listbox"
-            aria-expanded={isDropdownOpen}
-            aria-controls={dropdownId}
-            aria-label={`Change speaker: ${
-              character?.displayName || "Narration"
-            }`}
-            className={`flex items-center gap-1.5 rounded-md transition-all border tracking-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
-              isStacked
-                ? "inline-flex max-w-full h-8 py-1.5 px-2.5 -ml-2.5"
-                : "inline-flex max-w-full items-start h-auto py-1.5 px-2.5 overflow-hidden"
-            }`}
-            style={{
-              fontSize: "var(--prose-editor-font-size, 14px)",
-              backgroundColor: isSpeakerInteractive
-                ? hasSpeaker && speakerColor
-                  ? withAlpha(speakerColor, 8)
-                  : "hsl(var(--muted) / 0.5)"
-                : "transparent",
-              borderColor: isSpeakerInteractive
-                ? hasSpeaker && speakerColor
-                  ? withAlpha(speakerColor, 25)
-                  : "hsl(var(--border))"
-                : "transparent",
-              color:
-                hasSpeaker && speakerColor
-                  ? speakerColor
-                  : "hsl(var(--muted-foreground))",
-              fontStyle: hasSpeaker ? "normal" : "italic",
-            }}
-            title={
-              hasSpeaker
-                ? character?.displayName || "Character dialogue"
-                : "Narration"
-            }
-          >
-            <span className="truncate">
-              {character?.displayName || "Narration"}
-            </span>
-            <ChevronDown
-              className={`size-3 transition-transform duration-200 flex-shrink-0 ${
-                isDropdownOpen ? "rotate-180" : ""
-              }`}
-              style={{ opacity: isSpeakerInteractive ? 0.5 : 0 }}
-            />
-          </button>
-
-          {isDropdownOpen && (
+        {isChoice ? (
+          <div className={`relative ${isStacked ? "w-full" : "shrink-0 w-40"}`}>
             <div
-              ref={dropdownMenuRef}
-              id={dropdownId}
-              role="listbox"
-              aria-label="Select speaker"
-              aria-activedescendant={
-                focusedOptionIndex >= 0
-                  ? `${dropdownId}-option-${focusedOptionIndex}`
-                  : undefined
-              }
-              onKeyDown={handleDropdownKeyDown}
-              tabIndex={0}
-              className={`absolute z-50 bg-popover border border-border rounded-md shadow-lg shadow-black/10 py-1 min-w-[160px] max-h-[280px] overflow-y-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color)] animate-in fade-in-0 zoom-in-95 duration-200 ease-out ${
-                openUpward ? "bottom-full mb-1" : "top-full mt-1"
-              } ${
-                openUpward ? "slide-in-from-bottom-1" : "slide-in-from-top-1"
-              } ${isStacked ? "-left-2.5" : "left-0"}`}
+              className={`flex items-center gap-1.5 rounded-md transition-all h-8 py-1.5 px-2.5 ${
+                isStacked ? "-ml-2.5" : ""
+              }`}
+              style={{
+                fontSize: "var(--prose-editor-font-size, 14px)",
+                color: "hsl(var(--muted-foreground))",
+                fontStyle: "italic",
+              }}
             >
-              <button
-                id={`${dropdownId}-option-0`}
-                type="button"
-                role="option"
-                aria-selected={!entry.speakerId}
-                onClick={() => handleSpeakerSelect(null)}
-                tabIndex={-1}
-                className={`w-full text-left px-3 py-2 text-sm transition-colors duration-150 ${
-                  focusedOptionIndex === 0 ? "bg-muted" : "hover:bg-muted"
+              <Split className="size-3 opacity-50" />
+              <span className="truncate text-xs">Choice</span>
+            </div>
+          </div>
+        ) : (
+          <div
+            className={`relative ${isStacked ? "w-full" : "shrink-0 w-40"}`}
+            ref={dropdownRef}
+            onBlur={handleDropdownBlur}
+          >
+            <button
+              ref={speakerButtonRef}
+              type="button"
+              onClick={handleSpeakerToggle}
+              aria-haspopup="listbox"
+              aria-expanded={isDropdownOpen}
+              aria-controls={dropdownId}
+              aria-label={`Change speaker: ${
+                character?.displayName || "Narration"
+              }`}
+              className={`flex items-center gap-1.5 rounded-md transition-all border tracking-normal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+                isStacked
+                  ? "inline-flex max-w-full h-8 py-1.5 px-2.5 -ml-2.5"
+                  : "inline-flex max-w-full items-start h-auto py-1.5 px-2.5 overflow-hidden"
+              }`}
+              style={{
+                fontSize: "var(--prose-editor-font-size, 14px)",
+                backgroundColor: isSpeakerInteractive
+                  ? hasSpeaker && speakerColor
+                    ? withAlpha(speakerColor, 8)
+                    : "hsl(var(--muted) / 0.5)"
+                  : "transparent",
+                borderColor: isSpeakerInteractive
+                  ? hasSpeaker && speakerColor
+                    ? withAlpha(speakerColor, 25)
+                    : "hsl(var(--border))"
+                  : "transparent",
+                color:
+                  hasSpeaker && speakerColor
+                    ? speakerColor
+                    : "hsl(var(--muted-foreground))",
+                fontStyle: hasSpeaker ? "normal" : "italic",
+              }}
+              title={
+                hasSpeaker
+                  ? character?.displayName || "Character dialogue"
+                  : "Narration"
+              }
+            >
+              <span className="truncate">
+                {character?.displayName || "Narration"}
+              </span>
+              <ChevronDown
+                className={`size-3 transition-transform duration-200 flex-shrink-0 ${
+                  isDropdownOpen ? "rotate-180" : ""
                 }`}
-                style={{
-                  fontStyle: "italic",
-                  fontWeight: !entry.speakerId ? "600" : "normal",
-                }}
+                style={{ opacity: isSpeakerInteractive ? 0.5 : 0 }}
+              />
+            </button>
+
+            {isDropdownOpen && (
+              <div
+                ref={dropdownMenuRef}
+                id={dropdownId}
+                role="listbox"
+                aria-label="Select speaker"
+                aria-activedescendant={
+                  focusedOptionIndex >= 0
+                    ? `${dropdownId}-option-${focusedOptionIndex}`
+                    : undefined
+                }
+                onKeyDown={handleDropdownKeyDown}
+                tabIndex={0}
+                className={`absolute z-50 bg-popover border border-border rounded-md shadow-lg shadow-black/10 py-1 min-w-[160px] max-h-[280px] overflow-y-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color)] animate-in fade-in-0 zoom-in-95 duration-200 ease-out ${
+                  openUpward ? "bottom-full mb-1" : "top-full mt-1"
+                } ${
+                  openUpward ? "slide-in-from-bottom-1" : "slide-in-from-top-1"
+                } ${isStacked ? "-left-2.5" : "left-0"}`}
               >
-                Narration
-              </button>
-
-              <div className="my-1 border-t border-border" role="separator" />
-
-              {characters.map((char, idx) => (
                 <button
-                  key={char.id}
-                  id={`${dropdownId}-option-${idx + 1}`}
+                  id={`${dropdownId}-option-0`}
                   type="button"
                   role="option"
-                  aria-selected={entry.speakerId === char.id}
-                  onClick={() => handleSpeakerSelect(char.id)}
+                  aria-selected={!entry.speakerId}
+                  onClick={() => handleSpeakerSelect(null)}
                   tabIndex={-1}
-                  className={`w-full text-left px-3 py-2 text-sm transition-colors duration-150 flex items-center gap-2 ${
-                    focusedOptionIndex === idx + 1
-                      ? "bg-muted"
-                      : "hover:bg-muted"
+                  className={`w-full text-left px-3 py-2 text-sm transition-colors duration-150 ${
+                    focusedOptionIndex === 0 ? "bg-muted" : "hover:bg-muted"
                   }`}
                   style={{
-                    color: entry.speakerId === char.id ? char.color : undefined,
-                    fontWeight: entry.speakerId === char.id ? "600" : "normal",
+                    fontStyle: "italic",
+                    fontWeight: !entry.speakerId ? "600" : "normal",
                   }}
                 >
-                  <span
-                    className="size-2 rounded-full shrink-0"
-                    style={{ backgroundColor: char.color }}
-                  />
-                  <span>{char.displayName}</span>
+                  Narration
                 </button>
-              ))}
-            </div>
-          )}
-        </div>
+
+                <div className="my-1 border-t border-border" role="separator" />
+
+                {characters.map((char, idx) => (
+                  <button
+                    key={char.id}
+                    id={`${dropdownId}-option-${idx + 1}`}
+                    type="button"
+                    role="option"
+                    aria-selected={entry.speakerId === char.id}
+                    onClick={() => handleSpeakerSelect(char.id)}
+                    tabIndex={-1}
+                    className={`w-full text-left px-3 py-2 text-sm transition-colors duration-150 flex items-center gap-2 ${
+                      focusedOptionIndex === idx + 1
+                        ? "bg-muted"
+                        : "hover:bg-muted"
+                    }`}
+                    style={{
+                      color:
+                        entry.speakerId === char.id ? char.color : undefined,
+                      fontWeight:
+                        entry.speakerId === char.id ? "600" : "normal",
+                    }}
+                  >
+                    <span
+                      className="size-2 rounded-full shrink-0"
+                      style={{ backgroundColor: char.color }}
+                    />
+                    <span>{char.displayName}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Text Content */}
         <textarea
@@ -568,7 +612,13 @@ export const DialogueLine = memo(function DialogueLine({
           defaultValue={entry.text}
           onChange={handleTextChange}
           onKeyDown={handleKeyDown}
-          placeholder={entry.speakerId ? "Dialogue..." : "Narration..."}
+          placeholder={
+            isChoice
+              ? "Choice text..."
+              : entry.speakerId
+                ? "Dialogue..."
+                : "Narration..."
+          }
           className={`relative min-h-[2.5rem] p-0 pr-7 resize-none overflow-hidden bg-transparent border-0 outline-none focus-visible:outline-none focus-visible:ring-0 font-light tracking-normal leading-8 placeholder:text-muted-foreground/50 ${
             isStacked ? "w-full" : "flex-1"
           }`}
@@ -591,6 +641,18 @@ export const DialogueLine = memo(function DialogueLine({
           </button>
         )}
       </div>
+
+      {/* Destination indicator for CHOICE entries — placed below the text row */}
+      {isChoice && choiceTargetName && (
+        <span
+          className={`text-xs text-muted-foreground/50 flex items-center gap-1 ${
+            isStacked ? "" : "ml-[172px]"
+          }`}
+        >
+          <ArrowUpRight className="size-3" />
+          {choiceTargetName}
+        </span>
+      )}
 
       {/* Technical Badges - pill container anchored to parent line */}
       {showBadges &&

--- a/apps/frontend/src/components/write-mode/ProseEditor.tsx
+++ b/apps/frontend/src/components/write-mode/ProseEditor.tsx
@@ -17,7 +17,10 @@ import {
 } from "react";
 import type React from "react";
 import { DialogueLine } from "./DialogueLine";
-import { areDialogueEntriesEqual } from "@/lib/prose-converter";
+import {
+  areDialogueEntriesEqual,
+  menuLineToChoiceEntries,
+} from "@/lib/prose-converter";
 import { WritingGoalPill } from "./WritingGoalPill";
 const WritingStatsDialog = lazy(() =>
   import("./WritingStatsDialog").then((m) => ({
@@ -82,24 +85,7 @@ function convertLabelLinesToEntries(
       line.menuOptions &&
       line.menuOptions.length > 0
     ) {
-      // Expand each menu option into a CHOICE entry
-      for (let i = 0; i < line.menuOptions.length; i++) {
-        const option = line.menuOptions[i];
-        result.push({
-          id: `${line.id}-choice-${i}`,
-          speakerId: null,
-          text: option.label,
-          contentType: "CHOICE",
-          choiceData: {
-            lineId: line.id,
-            optionIndex: i,
-            targetLabelId: option.targetLabelId,
-            targetLabelName: option.targetLabelName,
-            conditionFlags: option.conditionFlags,
-            effects: option.effects,
-          },
-        });
-      }
+      result.push(...menuLineToChoiceEntries(line));
     }
   }
   return result;

--- a/apps/frontend/src/components/write-mode/ProseEditor.tsx
+++ b/apps/frontend/src/components/write-mode/ProseEditor.tsx
@@ -77,6 +77,29 @@ function convertLabelLinesToEntries(
         speakerId: line.speakerId,
         text: line.content,
       });
+    } else if (
+      line.contentType === "MENU" &&
+      line.menuOptions &&
+      line.menuOptions.length > 0
+    ) {
+      // Expand each menu option into a CHOICE entry
+      for (let i = 0; i < line.menuOptions.length; i++) {
+        const option = line.menuOptions[i];
+        result.push({
+          id: `${line.id}-choice-${i}`,
+          speakerId: null,
+          text: option.label,
+          contentType: "CHOICE",
+          choiceData: {
+            lineId: line.id,
+            optionIndex: i,
+            targetLabelId: option.targetLabelId,
+            targetLabelName: option.targetLabelName,
+            conditionFlags: option.conditionFlags,
+            effects: option.effects,
+          },
+        });
+      }
     }
   }
   return result;
@@ -496,12 +519,34 @@ export const ProseEditor = function ProseEditor({
     (index: number) => {
       setEntries((prev) => {
         const newEntries = [...prev];
-        const newEntry: DialogueEntry = {
-          id: crypto.randomUUID(),
-          speakerId: prev[index]?.speakerId || null,
-          text: "",
-        };
-        newEntries.splice(index + 1, 0, newEntry);
+        const currentEntry = prev[index];
+
+        // If adding from a CHOICE entry, create another CHOICE entry
+        if (currentEntry?.contentType === "CHOICE" && currentEntry.choiceData) {
+          const { lineId, targetLabelId, targetLabelName } =
+            currentEntry.choiceData;
+          const newEntry: DialogueEntry = {
+            id: crypto.randomUUID(),
+            speakerId: null,
+            text: "",
+            contentType: "CHOICE",
+            choiceData: {
+              lineId,
+              optionIndex: index + 1, // Will be recalculated on save
+              targetLabelId,
+              targetLabelName,
+            },
+          };
+          newEntries.splice(index + 1, 0, newEntry);
+        } else {
+          // Default: create a dialogue/narration entry
+          const newEntry: DialogueEntry = {
+            id: crypto.randomUUID(),
+            speakerId: prev[index]?.speakerId || null,
+            text: "",
+          };
+          newEntries.splice(index + 1, 0, newEntry);
+        }
 
         // Record history snapshot
         recordImmediateHistorySnapshot(newEntries);

--- a/apps/frontend/src/hooks/useLabels.ts
+++ b/apps/frontend/src/hooks/useLabels.ts
@@ -65,6 +65,16 @@ export interface UseLabelsReturn {
     options?: {
       expectedVersion?: number;
       expectedContentHash?: string;
+      menuBlocks?: Array<{
+        lineId: string;
+        menuOptions: Array<{
+          label: string;
+          targetLabelId: string;
+          targetLabelName: string;
+          conditionFlags?: string[];
+          effects?: { stats?: Record<string, number> };
+        }>;
+      }>;
     }
   ) => Promise<UpdateDialogueResponse>;
   isUpdatingDialogue: boolean;
@@ -151,15 +161,27 @@ export function useLabels(): UseLabelsReturn {
       dialogue,
       expectedVersion,
       expectedContentHash,
+      menuBlocks,
     }: {
       labelId: string;
       dialogue: Array<{ speakerId: string | null; text: string }>;
       expectedVersion?: number;
       expectedContentHash?: string;
+      menuBlocks?: Array<{
+        lineId: string;
+        menuOptions: Array<{
+          label: string;
+          targetLabelId: string;
+          targetLabelName: string;
+          conditionFlags?: string[];
+          effects?: { stats?: Record<string, number> };
+        }>;
+      }>;
     }) =>
       labelsApi.updateDialogue(labelId, dialogue, {
         expectedVersion,
         expectedContentHash,
+        menuBlocks,
       }),
     onSuccess: async (_data, variables) => {
       clearHistoryCursor(variables.labelId);
@@ -324,6 +346,16 @@ export function useLabels(): UseLabelsReturn {
       options?: {
         expectedVersion?: number;
         expectedContentHash?: string;
+        menuBlocks?: Array<{
+          lineId: string;
+          menuOptions: Array<{
+            label: string;
+            targetLabelId: string;
+            targetLabelName: string;
+            conditionFlags?: string[];
+            effects?: { stats?: Record<string, number> };
+          }>;
+        }>;
       }
     ) => {
       return updateDialogueMutation.mutateAsync({
@@ -331,6 +363,7 @@ export function useLabels(): UseLabelsReturn {
         dialogue,
         expectedVersion: options?.expectedVersion,
         expectedContentHash: options?.expectedContentHash,
+        menuBlocks: options?.menuBlocks,
       });
     },
     [updateDialogueMutation]

--- a/apps/frontend/src/hooks/useTechnicalInfo.ts
+++ b/apps/frontend/src/hooks/useTechnicalInfo.ts
@@ -34,13 +34,18 @@ function normalizeConditions(
 
 /**
  * Build technical info from a single line into the info accumulator.
+ * @param line - The label line to process
+ * @param info - The accumulator for technical info
+ * @param skipMenuChoices - When true, skip aggregating menuOptions into choices
+ *   (used when choices are rendered as inline entries in the prose editor)
  */
 function buildLineInfo(
   line: LabelLine,
-  info: NonNullable<DialogueEntry["technicalInfo"]>
+  info: NonNullable<DialogueEntry["technicalInfo"]>,
+  skipMenuChoices = false
 ) {
-  // Parse menu choices
-  if (line.menuOptions && line.menuOptions.length > 0) {
+  // Parse menu choices — skip when choices are shown as inline entries
+  if (!skipMenuChoices && line.menuOptions && line.menuOptions.length > 0) {
     info.choices = [
       ...(info.choices || []),
       ...line.menuOptions.map((choice) => ({
@@ -126,7 +131,7 @@ export function useTechnicalInfo(
   const lines = activeLabel?.lines;
 
   // Map is stable across renders — useMemo ensures identity for the same lines array
-   
+
   const labelById = useMemo(() => {
     if (!lines) return new Map<string, LabelLine>();
 
@@ -193,11 +198,13 @@ export function useTechnicalInfo(
       const info: NonNullable<DialogueEntry["technicalInfo"]> = {};
 
       // Parse technical info from the dialogue/narration line itself
-      buildLineInfo(line, info);
+      // Skip menu choices since they are now rendered as inline CHOICE entries
+      buildLineInfo(line, info, true);
 
       // Aggregate from adjacent structural lines (MENU, JUMP, CHOICE, etc.)
+      // Skip menu choices here too since they're inline entries
       for (const adjLine of adjacentStructural) {
-        buildLineInfo(adjLine, info);
+        buildLineInfo(adjLine, info, true);
       }
 
       const result = Object.keys(info).length > 0 ? info : undefined;

--- a/apps/frontend/src/hooks/useWriteAutosave.ts
+++ b/apps/frontend/src/hooks/useWriteAutosave.ts
@@ -7,6 +7,7 @@ import {
   dialogueToPayload,
   hashDialogueEntries,
   extractMenuBlocks,
+  menuLineToChoiceEntries,
 } from "@/lib/prose-converter";
 import type { DialogueEntry } from "@/lib/prose-types";
 import type { UpdateDialogueResponse } from "@/lib/api/labels";
@@ -239,23 +240,7 @@ export function getPersistedDialogueFromLabel(
       line.menuOptions &&
       line.menuOptions.length > 0
     ) {
-      for (let i = 0; i < line.menuOptions.length; i++) {
-        const option = line.menuOptions[i];
-        result.push({
-          id: `${line.id}-choice-${i}`,
-          speakerId: null,
-          text: option.label,
-          contentType: "CHOICE",
-          choiceData: {
-            lineId: line.id,
-            optionIndex: i,
-            targetLabelId: option.targetLabelId,
-            targetLabelName: option.targetLabelName,
-            conditionFlags: option.conditionFlags,
-            effects: option.effects,
-          },
-        });
-      }
+      result.push(...menuLineToChoiceEntries(line));
     }
   }
   return result;

--- a/apps/frontend/src/hooks/useWriteAutosave.ts
+++ b/apps/frontend/src/hooks/useWriteAutosave.ts
@@ -3,7 +3,11 @@ import type { RefObject } from "react";
 import type { PublicLabel, LabelDetail } from "@branchforge/shared";
 import { useAutosave, type SaveStatus } from "@/hooks/useAutosave";
 import { registerModeFlushHandler } from "@/lib/editor-sync-coordinator";
-import { dialogueToPayload, hashDialogueEntries } from "@/lib/prose-converter";
+import {
+  dialogueToPayload,
+  hashDialogueEntries,
+  extractMenuBlocks,
+} from "@/lib/prose-converter";
 import type { DialogueEntry } from "@/lib/prose-types";
 import type { UpdateDialogueResponse } from "@/lib/api/labels";
 
@@ -20,7 +24,18 @@ interface UpdateDialogueOptions {
 type UpdateDialogue = (
   labelId: string,
   dialogue: Array<{ speakerId: string | null; text: string }>,
-  options?: UpdateDialogueOptions
+  options?: UpdateDialogueOptions & {
+    menuBlocks?: Array<{
+      lineId: string;
+      menuOptions: Array<{
+        label: string;
+        targetLabelId: string;
+        targetLabelName: string;
+        conditionFlags?: string[];
+        effects?: { stats?: Record<string, number> };
+      }>;
+    }>;
+  }
 ) => Promise<UpdateDialogueResponse>;
 
 interface UseWriteAutosaveProps {
@@ -219,6 +234,28 @@ export function getPersistedDialogueFromLabel(
         speakerId: line.speakerId,
         text: line.content,
       });
+    } else if (
+      line.contentType === "MENU" &&
+      line.menuOptions &&
+      line.menuOptions.length > 0
+    ) {
+      for (let i = 0; i < line.menuOptions.length; i++) {
+        const option = line.menuOptions[i];
+        result.push({
+          id: `${line.id}-choice-${i}`,
+          speakerId: null,
+          text: option.label,
+          contentType: "CHOICE",
+          choiceData: {
+            lineId: line.id,
+            optionIndex: i,
+            targetLabelId: option.targetLabelId,
+            targetLabelName: option.targetLabelName,
+            conditionFlags: option.conditionFlags,
+            effects: option.effects,
+          },
+        });
+      }
     }
   }
   return result;
@@ -285,9 +322,10 @@ export function useWriteAutosave({
           }
 
           const payload = dialogueToPayload(draftToSave.entries);
+          const menuBlocks = extractMenuBlocks(draftToSave.entries);
 
-          // Skip saving if all entries are empty — backend requires at least 1 entry
-          if (payload.length === 0) {
+          // Skip saving if all entries are empty and no menu blocks to update
+          if (payload.length === 0 && menuBlocks.length === 0) {
             return;
           }
 
@@ -301,6 +339,7 @@ export function useWriteAutosave({
           const result = await onUpdateDialogue(draftToSave.labelId, payload, {
             expectedVersion,
             expectedContentHash,
+            menuBlocks: menuBlocks.length > 0 ? menuBlocks : undefined,
           });
 
           if (result.success) {

--- a/apps/frontend/src/lib/api/labels.ts
+++ b/apps/frontend/src/lib/api/labels.ts
@@ -121,6 +121,16 @@ export const labelsApi = {
     options?: {
       expectedVersion?: number;
       expectedContentHash?: string;
+      menuBlocks?: Array<{
+        lineId: string;
+        menuOptions: Array<{
+          label: string;
+          targetLabelId: string;
+          targetLabelName: string;
+          conditionFlags?: string[];
+          effects?: { stats?: Record<string, number> };
+        }>;
+      }>;
     }
   ): Promise<UpdateDialogueResponse> {
     return await request<UpdateDialogueResponse>(
@@ -129,6 +139,7 @@ export const labelsApi = {
         method: "PUT",
         body: JSON.stringify({
           dialogue,
+          menuBlocks: options?.menuBlocks,
           expectedVersion: options?.expectedVersion,
           expectedContentHash: options?.expectedContentHash,
         }),

--- a/apps/frontend/src/lib/prose-converter.ts
+++ b/apps/frontend/src/lib/prose-converter.ts
@@ -131,7 +131,13 @@ export function extractMenuBlocks(
     }>
   >();
 
-  for (const entry of entries) {
+  const indexMap = new Map<
+    string,
+    { min: number; max: number; count: number }
+  >();
+
+  for (let idx = 0; idx < entries.length; idx++) {
+    const entry = entries[idx];
     if (entry.contentType !== "CHOICE" || !entry.choiceData) continue;
 
     const { lineId, targetLabelId, targetLabelName, conditionFlags, effects } =
@@ -139,7 +145,13 @@ export function extractMenuBlocks(
 
     if (!blockMap.has(lineId)) {
       blockMap.set(lineId, []);
+      indexMap.set(lineId, { min: idx, max: idx, count: 0 });
     }
+
+    const meta = indexMap.get(lineId)!;
+    meta.min = Math.min(meta.min, idx);
+    meta.max = Math.max(meta.max, idx);
+    meta.count += 1;
 
     blockMap.get(lineId)!.push({
       label: entry.text,
@@ -150,9 +162,58 @@ export function extractMenuBlocks(
     });
   }
 
+  // Validate contiguity: for each lineId, all CHOICE entries must be adjacent
+  for (const [lineId, meta] of indexMap) {
+    if (meta.max - meta.min + 1 !== meta.count) {
+      throw new Error(
+        `[extractMenuBlocks] Non-contiguous CHOICE entries for lineId ${lineId}: ` +
+          `indices ${meta.min}-${meta.max} span ${meta.max - meta.min + 1} slots but only ${meta.count} CHOICE entries found`
+      );
+    }
+  }
+
   const result: MenuBlockPayload[] = [];
   for (const [lineId, menuOptions] of blockMap) {
     result.push({ lineId, menuOptions });
+  }
+  return result;
+}
+
+/**
+ * Converts a MENU label line's menuOptions into CHOICE dialogue entries.
+ * Used to expand menu lines into editable choice entries in the prose editor.
+ *
+ * @param line - A label line with menuOptions
+ * @returns Array of CHOICE DialogueEntry items
+ */
+export function menuLineToChoiceEntries(line: {
+  id: string;
+  menuOptions?: Array<{
+    label: string;
+    targetLabelId: string;
+    targetLabelName: string;
+    conditionFlags?: string[];
+    effects?: { stats?: Record<string, number> };
+  }> | null;
+}): DialogueEntry[] {
+  if (!line.menuOptions || line.menuOptions.length === 0) return [];
+  const result: DialogueEntry[] = [];
+  for (let i = 0; i < line.menuOptions.length; i++) {
+    const option = line.menuOptions[i];
+    result.push({
+      id: `${line.id}-choice-${i}`,
+      speakerId: null,
+      text: option.label,
+      contentType: "CHOICE",
+      choiceData: {
+        lineId: line.id,
+        optionIndex: i,
+        targetLabelId: option.targetLabelId,
+        targetLabelName: option.targetLabelName,
+        conditionFlags: option.conditionFlags,
+        effects: option.effects,
+      },
+    });
   }
   return result;
 }

--- a/apps/frontend/src/lib/prose-converter.ts
+++ b/apps/frontend/src/lib/prose-converter.ts
@@ -59,7 +59,7 @@ export function areDialogueEntriesEqual(
  * Converts DialogueEntry[] to backend dialogue payload format
  * This converts prose editor entries to the format expected by the backend API
  * Filters out entries with empty or whitespace-only text
- * Skips structural entries (MENU, JUMP, CHOICE) which are not editable dialogue
+ * Skips structural entries (MENU, JUMP, CHOICE) which are handled separately
  *
  * @param entries - Dialogue entries from the prose editor
  * @returns Backend dialogue payload
@@ -73,7 +73,7 @@ export function dialogueToPayload(entries: DialogueEntry[]): Array<{
     text: string;
   }> = [];
   for (const entry of entries) {
-    // Skip structural entries (MENU, JUMP, CHOICE) - they are read-only
+    // Skip structural entries (MENU, JUMP, CHOICE) - they are handled via menuBlocks
     if (
       entry.contentType !== undefined &&
       entry.contentType !== "DIALOGUE" &&
@@ -87,6 +87,72 @@ export function dialogueToPayload(entries: DialogueEntry[]): Array<{
         text: entry.text,
       });
     }
+  }
+  return result;
+}
+
+/**
+ * Menu block payload for backend save
+ * Groups adjacent CHOICE entries by their parent MENU line ID
+ * and reconstructs the menuOptions arrays.
+ */
+export interface MenuBlockPayload {
+  lineId: string;
+  menuOptions: Array<{
+    label: string;
+    targetLabelId: string;
+    targetLabelName: string;
+    conditionFlags?: string[];
+    effects?: {
+      stats?: Record<string, number>;
+    };
+  }>;
+}
+
+/**
+ * Extracts menu blocks from DialogueEntry[] for backend save.
+ * Groups adjacent CHOICE entries by their parent MENU line ID (choiceData.lineId)
+ * and reconstructs menuOptions arrays with updated labels.
+ *
+ * @param entries - Dialogue entries from the prose editor
+ * @returns Menu block payloads for the backend
+ */
+export function extractMenuBlocks(
+  entries: DialogueEntry[]
+): MenuBlockPayload[] {
+  const blockMap = new Map<
+    string,
+    Array<{
+      label: string;
+      targetLabelId: string;
+      targetLabelName: string;
+      conditionFlags?: string[];
+      effects?: { stats?: Record<string, number> };
+    }>
+  >();
+
+  for (const entry of entries) {
+    if (entry.contentType !== "CHOICE" || !entry.choiceData) continue;
+
+    const { lineId, targetLabelId, targetLabelName, conditionFlags, effects } =
+      entry.choiceData;
+
+    if (!blockMap.has(lineId)) {
+      blockMap.set(lineId, []);
+    }
+
+    blockMap.get(lineId)!.push({
+      label: entry.text,
+      targetLabelId,
+      targetLabelName,
+      conditionFlags,
+      effects,
+    });
+  }
+
+  const result: MenuBlockPayload[] = [];
+  for (const [lineId, menuOptions] of blockMap) {
+    result.push({ lineId, menuOptions });
   }
   return result;
 }

--- a/apps/frontend/src/lib/prose-types.ts
+++ b/apps/frontend/src/lib/prose-types.ts
@@ -26,6 +26,18 @@ export interface DialogueEntry {
   contentType?: string;
   speakerTag?: string | null;
 
+  // For structural CHOICE entries: link back to parent MENU line and choice data
+  choiceData?: {
+    lineId: string; // parent MENU label line ID
+    optionIndex: number; // index in menuOptions array
+    targetLabelId: string;
+    targetLabelName: string;
+    conditionFlags?: string[];
+    effects?: {
+      stats?: Record<string, number>;
+    };
+  };
+
   // Technical info for badges
   technicalInfo?: {
     choices?: Array<{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit and persist interactive menu choices directly in the dialogue editor, including conditional flags and stat effects.
  * Choice lines render distinctly (labeled “Choice”), show destination indicators, and use a context-sensitive placeholder.
  * Adding lines supports inserting additional choices; menu data is saved alongside dialogue so empty dialogue + menu choices still persist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->