### PR TITLE
chore: version packages to v0.10.0 [skip-coderabbit]

### DIFF
--- a/.changeset/breezy-swans-hear.md
+++ b/.changeset/breezy-swans-hear.md
@@ -1,7 +1,0 @@
----
-"@branchforge/shared": patch
-"@branchforge/frontend": patch
-"@branchforge/backend": patch
----
-
-Fixed visual statement support, enhanced flow graph and tweaked UI

--- a/.changeset/brown-years-invent.md
+++ b/.changeset/brown-years-invent.md
@@ -1,7 +1,0 @@
----
-"@branchforge/shared": minor
-"@branchforge/frontend": minor
-"@branchforge/backend": minor
----
-
-Added flow graph visualization feature

--- a/.changeset/busy-cats-march.md
+++ b/.changeset/busy-cats-march.md
@@ -1,7 +1,0 @@
----
-"@branchforge/shared": patch
-"@branchforge/frontend": patch
-"@branchforge/backend": patch
----
-
-Renamed prerequisites to conditions, state variables to variables and meters to stats for clarity

--- a/.changeset/full-papers-wear.md
+++ b/.changeset/full-papers-wear.md
@@ -1,6 +1,0 @@
----
-"@branchforge/frontend": patch
-"@branchforge/backend": patch
----
-
-Added support for editing menu choice texts in write mode

--- a/.changeset/hot-roses-bake.md
+++ b/.changeset/hot-roses-bake.md
@@ -1,7 +1,0 @@
----
-"@branchforge/shared": patch
-"@branchforge/frontend": patch
-"@branchforge/backend": patch
----
-
-Replaced character reference panel with properties panel that displays detailed info about selected label

--- a/.changeset/purple-words-tie.md
+++ b/.changeset/purple-words-tie.md
@@ -1,7 +1,0 @@
----
-"@branchforge/backend": patch
-"@branchforge/frontend": patch
-"@branchforge/shared": patch
----
-
-Added line-level conditions and metadata badges to write mode

--- a/.changeset/sharp-ties-throw.md
+++ b/.changeset/sharp-ties-throw.md
@@ -1,7 +1,0 @@
----
-"@branchforge/shared": patch
-"@branchforge/frontend": patch
-"@branchforge/backend": patch
----
-
-Implemented incoming jumps section to write mode

--- a/.changeset/silent-zebras-clean.md
+++ b/.changeset/silent-zebras-clean.md
@@ -1,5 +1,0 @@
----
-"@branchforge/frontend": patch
----
-
-Added collapsible reference panel in script mode and simplified left sidebar and write mode

--- a/.changeset/six-cities-grab.md
+++ b/.changeset/six-cities-grab.md
@@ -1,6 +1,0 @@
----
-"@branchforge/frontend": minor
-"@branchforge/backend": minor
----
-
-Added Zip export feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to BranchForge will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.10.0 - 2026-06-13
+
+- Added flow graph visualization feature
+- Added Zip export feature
+- Fixed visual statement support, enhanced flow graph and tweaked UI
+- Renamed prerequisites to conditions, state variables to variables and meters to stats for clarity
+- Added support for editing menu choice texts in write mode
+- Replaced character reference panel with properties panel that displays detailed info about selected label
+- Added line-level conditions and metadata badges to write mode
+- Implemented incoming jumps section to write mode
+- Added collapsible reference panel in script mode and simplified left sidebar and write mode
+
 ## v0.9.2 - 2026-05-22
 
 - Fixed Docker builds by updating build permission configs

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/backend",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/frontend",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branchforge",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "description": "Visual Novel IDE for Ren'Py",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@branchforge/shared",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
<!-- release-automation:version-workflow -->
## Summary
- Consume pending changesets and bump package versions to v0.10.0.
- Run build, typecheck, and tests before opening this release PR.
- Merge this PR to trigger version tagging and release workflows.

## Notes
- Generated by .github/workflows/version.yml.
- Title includes [skip-coderabbit] to skip CodeRabbit on this automation PR.