### PR TITLE
Add hover tooltips with label details to flow graph

### DIFF
--- a/.changeset/silly-trees-repeat.md
+++ b/.changeset/silly-trees-repeat.md
@@ -1,0 +1,7 @@
+---
+"@branchforge/shared": patch
+"@branchforge/frontend": patch
+"@branchforge/backend": patch
+---
+
+Added tooltips with label details in flow graph

--- a/apps/backend/src/db/migrations/0047_slimy_gargoyle.sql
+++ b/apps/backend/src/db/migrations/0047_slimy_gargoyle.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "label_lines" DROP COLUMN "word_count";

--- a/apps/backend/src/db/migrations/meta/0047_snapshot.json
+++ b/apps/backend/src/db/migrations/meta/0047_snapshot.json
@@ -1,0 +1,3669 @@
+{
+  "id": "e7f4fc90-db9d-4b8a-b464-7542be96b952",
+  "prevId": "9bd041e1-ff6d-466d-b694-65e61488935f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'OWNER'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique_active_idx": {
+          "name": "users_email_unique_active_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sessions_user_id_idx": {
+          "name": "user_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_expires_at_idx": {
+          "name": "user_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'en'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'light'"
+        },
+        "daily_writing_goal": {
+          "name": "daily_writing_goal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_word_reset_hour": {
+          "name": "daily_word_reset_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "daily_word_counts": {
+          "name": "daily_word_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "label_word_counts": {
+          "name": "label_word_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_username_idx": {
+          "name": "user_settings_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_word_reset_hour_range": {
+          "name": "daily_word_reset_hour_range",
+          "value": "\"user_settings\".\"daily_word_reset_hour\" >= 0 AND \"user_settings\".\"daily_word_reset_hour\" <= 23"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.admin_settings": {
+      "name": "admin_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_settings_key_idx": {
+          "name": "admin_settings_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_settings_updated_by_users_id_fk": {
+          "name": "admin_settings_updated_by_users_id_fk",
+          "tableFrom": "admin_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_settings_key_unique": {
+          "name": "admin_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_stat_delta": {
+          "name": "max_stat_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "project_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'PRIVATE'"
+        },
+        "source": {
+          "name": "source",
+          "type": "file_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_user_id_idx": {
+          "name": "projects_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_users": {
+      "name": "project_users",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_users_user_id_idx": {
+          "name": "project_users_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_users_project_id_projects_id_fk": {
+          "name": "project_users_project_id_projects_id_fk",
+          "tableFrom": "project_users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_users_user_id_users_id_fk": {
+          "name": "project_users_user_id_users_id_fk",
+          "tableFrom": "project_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_users_project_id_user_id_pk": {
+          "name": "project_users_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_settings": {
+      "name": "project_settings",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "excluded_character_tags": {
+          "name": "excluded_character_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "auto_link_speakers": {
+          "name": "auto_link_speakers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_settings_updated_at_idx": {
+          "name": "project_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flow_graph_layouts": {
+      "name": "flow_graph_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FLOW'"
+        },
+        "positions": {
+          "name": "positions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flow_graph_layouts_project_user_mode_idx": {
+          "name": "flow_graph_layouts_project_user_mode_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flow_graph_layouts_project_id_projects_id_fk": {
+          "name": "flow_graph_layouts_project_id_projects_id_fk",
+          "tableFrom": "flow_graph_layouts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "flow_graph_layouts_user_id_users_id_fk": {
+          "name": "flow_graph_layouts_user_id_users_id_fk",
+          "tableFrom": "flow_graph_layouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flow_graph_layouts_mode_check": {
+          "name": "flow_graph_layouts_mode_check",
+          "value": "\"flow_graph_layouts\".\"mode\" IN ('FLOW', 'ROUTE', 'FILE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_files": {
+      "name": "project_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "file_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "project_file_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_content": {
+          "name": "original_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_commit_sha": {
+          "name": "last_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_files_project_id_idx": {
+          "name": "project_files_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_files_project_id_projects_id_fk": {
+          "name": "project_files_project_id_projects_id_fk",
+          "tableFrom": "project_files",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_files_project_source_file_uidx": {
+          "name": "project_files_project_source_file_uidx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "source",
+            "file_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visual_systems": {
+      "name": "visual_systems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "naming_template": {
+          "name": "naming_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{scene}_{counter}_{slug}'"
+        },
+        "group_prefixes": {
+          "name": "group_prefixes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_group_type": {
+          "name": "default_group_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene_padding": {
+          "name": "scene_padding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter_padding": {
+          "name": "counter_padding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jump_prefix_shared": {
+          "name": "jump_prefix_shared",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placeholder_base_url": {
+          "name": "placeholder_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "visual_systems_project_id_idx": {
+          "name": "visual_systems_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visual_systems_project_id_projects_id_fk": {
+          "name": "visual_systems_project_id_projects_id_fk",
+          "tableFrom": "visual_systems",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "visual_systems_project_id_unique": {
+          "name": "visual_systems_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.route_configs": {
+      "name": "route_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_key": {
+          "name": "route_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jump_prefix": {
+          "name": "jump_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "route_configs_project_id_idx": {
+          "name": "route_configs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "route_configs_project_id_projects_id_fk": {
+          "name": "route_configs_project_id_projects_id_fk",
+          "tableFrom": "route_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "route_configs_project_key_unique": {
+          "name": "route_configs_project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "route_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renpy_tag": {
+          "name": "renpy_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_affiliation": {
+          "name": "route_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_love_interest": {
+          "name": "is_love_interest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pair_group_id": {
+          "name": "pair_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dialogue_style": {
+          "name": "dialogue_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditional_prefix": {
+          "name": "conditional_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "characters_project_id_idx": {
+          "name": "characters_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "characters_pair_group_id_idx": {
+          "name": "characters_pair_group_id_idx",
+          "columns": [
+            {
+              "expression": "pair_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_project_id_projects_id_fk": {
+          "name": "characters_project_id_projects_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "characters_project_renpy_tag_unique": {
+          "name": "characters_project_renpy_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "renpy_tag"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pair_groups": {
+      "name": "pair_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_a_id": {
+          "name": "character_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_b_id": {
+          "name": "character_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duo_ending_label": {
+          "name": "duo_ending_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 70
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pair_groups_project_id_idx": {
+          "name": "pair_groups_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pair_groups_character_a_id_idx": {
+          "name": "pair_groups_character_a_id_idx",
+          "columns": [
+            {
+              "expression": "character_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pair_groups_character_b_id_idx": {
+          "name": "pair_groups_character_b_id_idx",
+          "columns": [
+            {
+              "expression": "character_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pair_groups_project_id_projects_id_fk": {
+          "name": "pair_groups_project_id_projects_id_fk",
+          "tableFrom": "pair_groups",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pair_groups_character_a_id_characters_id_fk": {
+          "name": "pair_groups_character_a_id_characters_id_fk",
+          "tableFrom": "pair_groups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pair_groups_character_b_id_characters_id_fk": {
+          "name": "pair_groups_character_b_id_characters_id_fk",
+          "tableFrom": "pair_groups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pair_groups_project_character_pair_idx": {
+          "name": "pair_groups_project_character_pair_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "character_a_id",
+            "character_b_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pair_groups_not_self_pairing": {
+          "name": "pair_groups_not_self_pairing",
+          "value": "character_a_id < character_b_id"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stats": {
+      "name": "stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_value": {
+          "name": "min_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_value": {
+          "name": "max_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stats_project_id_idx": {
+          "name": "stats_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stats_character_id_idx": {
+          "name": "stats_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stats_project_id_projects_id_fk": {
+          "name": "stats_project_id_projects_id_fk",
+          "tableFrom": "stats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stats_character_id_characters_id_fk": {
+          "name": "stats_character_id_characters_id_fk",
+          "tableFrom": "stats",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stats_project_key_idx": {
+          "name": "stats_project_key_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "min_value_lte_max_value": {
+          "name": "min_value_lte_max_value",
+          "value": "\"stats\".\"min_value\" <= \"stats\".\"max_value\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "variables_project_id_idx": {
+          "name": "variables_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variables_project_id_projects_id_fk": {
+          "name": "variables_project_id_projects_id_fk",
+          "tableFrom": "variables",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "variables_project_key_idx": {
+          "name": "variables_project_key_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_type": {
+          "name": "group_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_value": {
+          "name": "group_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_number": {
+          "name": "label_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_order": {
+          "name": "sequence_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "label_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'EXCLUSIVE'"
+        },
+        "duo_pair_id": {
+          "name": "duo_pair_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "label_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'DRAFT'"
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "incoming_jumps": {
+          "name": "incoming_jumps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cross_route_context": {
+          "name": "cross_route_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_notes": {
+          "name": "reader_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_file_id": {
+          "name": "project_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_position": {
+          "name": "label_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_hash": {
+          "name": "last_synced_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_exported_at": {
+          "name": "last_exported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_imported_at": {
+          "name": "last_imported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "export_commit_sha": {
+          "name": "export_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_commit_sha": {
+          "name": "import_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labels_duo_pair_id_idx": {
+          "name": "labels_duo_pair_id_idx",
+          "columns": [
+            {
+              "expression": "duo_pair_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_file_id_idx": {
+          "name": "labels_project_file_id_idx",
+          "columns": [
+            {
+              "expression": "project_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_route_idx": {
+          "name": "labels_project_route_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "route",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_status_idx": {
+          "name": "labels_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_sequence_idx": {
+          "name": "labels_project_sequence_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_label_number_idx": {
+          "name": "labels_project_label_number_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_sync_status_idx": {
+          "name": "labels_sync_status_idx",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_deleted_at_idx": {
+          "name": "labels_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_created_by_idx": {
+          "name": "labels_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_updated_by_idx": {
+          "name": "labels_updated_by_idx",
+          "columns": [
+            {
+              "expression": "updated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labels_project_id_projects_id_fk": {
+          "name": "labels_project_id_projects_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "labels_duo_pair_id_pair_groups_id_fk": {
+          "name": "labels_duo_pair_id_pair_groups_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "pair_groups",
+          "columnsFrom": [
+            "duo_pair_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "labels_project_file_id_project_files_id_fk": {
+          "name": "labels_project_file_id_project_files_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "project_files",
+          "columnsFrom": [
+            "project_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "labels_created_by_users_id_fk": {
+          "name": "labels_created_by_users_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "labels_updated_by_users_id_fk": {
+          "name": "labels_updated_by_users_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_lines": {
+      "name": "label_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "content_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker_id": {
+          "name": "speaker_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visual_type": {
+          "name": "visual_type",
+          "type": "visual_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GENERATED'"
+        },
+        "visual_slug_override": {
+          "name": "visual_slug_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_visual_name": {
+          "name": "custom_visual_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "menu_options": {
+          "name": "menu_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visual_statements": {
+          "name": "visual_statements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_placeholder_color": {
+          "name": "demo_placeholder_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_notes": {
+          "name": "demo_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_file_id": {
+          "name": "project_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_position": {
+          "name": "line_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_hash": {
+          "name": "last_synced_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_dirty": {
+          "name": "is_dirty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rpy_line_number": {
+          "name": "rpy_line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rpy_indent_level": {
+          "name": "rpy_indent_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "label_lines_speaker_id_idx": {
+          "name": "label_lines_speaker_id_idx",
+          "columns": [
+            {
+              "expression": "speaker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_lines_label_speaker_idx": {
+          "name": "label_lines_label_speaker_idx",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "speaker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_lines_label_sequence_idx": {
+          "name": "label_lines_label_sequence_idx",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_lines_project_file_id_idx": {
+          "name": "label_lines_project_file_id_idx",
+          "columns": [
+            {
+              "expression": "project_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_lines_project_file_position_idx": {
+          "name": "label_lines_project_file_position_idx",
+          "columns": [
+            {
+              "expression": "project_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "line_position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_lines_is_dirty_idx": {
+          "name": "label_lines_is_dirty_idx",
+          "columns": [
+            {
+              "expression": "is_dirty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"label_lines\".\"is_dirty\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_lines_deleted_at_idx": {
+          "name": "label_lines_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"label_lines\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "label_lines_label_id_labels_id_fk": {
+          "name": "label_lines_label_id_labels_id_fk",
+          "tableFrom": "label_lines",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_lines_speaker_id_characters_id_fk": {
+          "name": "label_lines_speaker_id_characters_id_fk",
+          "tableFrom": "label_lines",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "speaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "label_lines_project_file_id_project_files_id_fk": {
+          "name": "label_lines_project_file_id_project_files_id_fk",
+          "tableFrom": "label_lines",
+          "tableTo": "project_files",
+          "columnsFrom": [
+            "project_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.world_elements": {
+      "name": "world_elements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "element_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "world_elements_project_id_idx": {
+          "name": "world_elements_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "world_elements_project_id_projects_id_fk": {
+          "name": "world_elements_project_id_projects_id_fk",
+          "tableFrom": "world_elements",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_suggestions": {
+      "name": "ai_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "suggestion_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_context": {
+          "name": "prompt_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name_anonymized": {
+          "name": "project_name_anonymized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_suggestions": {
+          "name": "parsed_suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "suggestion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'PENDING'"
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_suggestions_project_id_idx": {
+          "name": "ai_suggestions_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_suggestions_label_id_idx": {
+          "name": "ai_suggestions_label_id_idx",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_suggestions_character_id_idx": {
+          "name": "ai_suggestions_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_suggestions_project_id_projects_id_fk": {
+          "name": "ai_suggestions_project_id_projects_id_fk",
+          "tableFrom": "ai_suggestions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_suggestions_label_id_labels_id_fk": {
+          "name": "ai_suggestions_label_id_labels_id_fk",
+          "tableFrom": "ai_suggestions",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_suggestions_character_id_characters_id_fk": {
+          "name": "ai_suggestions_character_id_characters_id_fk",
+          "tableFrom": "ai_suggestions",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exports": {
+      "name": "exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visual_system_snapshot": {
+          "name": "visual_system_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exports_project_id_idx": {
+          "name": "exports_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exports_project_id_projects_id_fk": {
+          "name": "exports_project_id_projects_id_fk",
+          "tableFrom": "exports",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.import_logs": {
+      "name": "import_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_created": {
+          "name": "labels_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "labels_skipped": {
+          "name": "labels_skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "import_logs_project_id_idx": {
+          "name": "import_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "import_logs_project_id_projects_id_fk": {
+          "name": "import_logs_project_id_projects_id_fk",
+          "tableFrom": "import_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gitlab_integrations": {
+      "name": "gitlab_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitlab_url": {
+          "name": "gitlab_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'https://gitlab.com'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gitlab_integrations_user_id_users_id_fk": {
+          "name": "gitlab_integrations_user_id_users_id_fk",
+          "tableFrom": "gitlab_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gitlab_integrations_user_id_unique": {
+          "name": "gitlab_integrations_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_file_sync_state": {
+      "name": "project_file_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_file_id": {
+          "name": "project_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rpy_label_count": {
+          "name": "rpy_label_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "db_label_count": {
+          "name": "db_label_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_file_sync_state_project_file_id_idx": {
+          "name": "project_file_sync_state_project_file_id_idx",
+          "columns": [
+            {
+              "expression": "project_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_file_sync_state_status_idx": {
+          "name": "project_file_sync_state_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_file_sync_state_project_file_id_project_files_id_fk": {
+          "name": "project_file_sync_state_project_file_id_project_files_id_fk",
+          "tableFrom": "project_file_sync_state",
+          "tableTo": "project_files",
+          "columnsFrom": [
+            "project_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gitlab_repositories": {
+      "name": "gitlab_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitlab_project_id": {
+          "name": "gitlab_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name": {
+          "name": "repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitlab_url": {
+          "name": "gitlab_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'https://gitlab.com'"
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'main'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gitlab_repositories_project_id_projects_id_fk": {
+          "name": "gitlab_repositories_project_id_projects_id_fk",
+          "tableFrom": "gitlab_repositories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gitlab_repositories_project_id_unique": {
+          "name": "gitlab_repositories_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        },
+        "gitlab_repositories_gitlab_project_id_unique": {
+          "name": "gitlab_repositories_gitlab_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "gitlab_project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gitlab_sync_operations": {
+      "name": "gitlab_sync_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "sync_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_count": {
+          "name": "conflict_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gitlab_sync_operations_project_id_idx": {
+          "name": "gitlab_sync_operations_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gitlab_sync_operations_status_idx": {
+          "name": "gitlab_sync_operations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gitlab_sync_operations_project_id_projects_id_fk": {
+          "name": "gitlab_sync_operations_project_id_projects_id_fk",
+          "tableFrom": "gitlab_sync_operations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_sessions": {
+      "name": "demo_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_label_line_id": {
+          "name": "current_label_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_flags": {
+          "name": "active_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active_stats": {
+          "name": "active_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "route_taken": {
+          "name": "route_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_sessions_project_id_idx": {
+          "name": "demo_sessions_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_sessions_user_id_idx": {
+          "name": "demo_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_sessions_current_label_line_id_idx": {
+          "name": "demo_sessions_current_label_line_id_idx",
+          "columns": [
+            {
+              "expression": "current_label_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_sessions_project_id_projects_id_fk": {
+          "name": "demo_sessions_project_id_projects_id_fk",
+          "tableFrom": "demo_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "demo_sessions_user_id_users_id_fk": {
+          "name": "demo_sessions_user_id_users_id_fk",
+          "tableFrom": "demo_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "demo_sessions_current_label_line_id_label_lines_id_fk": {
+          "name": "demo_sessions_current_label_line_id_label_lines_id_fk",
+          "tableFrom": "demo_sessions",
+          "tableTo": "label_lines",
+          "columnsFrom": [
+            "current_label_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "OWNER",
+        "READER",
+        "TESTER"
+      ]
+    },
+    "public.project_visibility": {
+      "name": "project_visibility",
+      "schema": "public",
+      "values": [
+        "PUBLIC",
+        "PRIVATE",
+        "TEAM"
+      ]
+    },
+    "public.label_status": {
+      "name": "label_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "REVIEW",
+        "FINAL"
+      ]
+    },
+    "public.content_type": {
+      "name": "content_type",
+      "schema": "public",
+      "values": [
+        "NARRATION",
+        "DIALOGUE",
+        "CHOICE",
+        "MENU",
+        "JUMP",
+        "VISUAL"
+      ]
+    },
+    "public.visual_type": {
+      "name": "visual_type",
+      "schema": "public",
+      "values": [
+        "GENERATED",
+        "BLACK",
+        "CUSTOM"
+      ]
+    },
+    "public.element_type": {
+      "name": "element_type",
+      "schema": "public",
+      "values": [
+        "LOCATION",
+        "ITEM",
+        "CONCEPT",
+        "EVENT"
+      ]
+    },
+    "public.suggestion_type": {
+      "name": "suggestion_type",
+      "schema": "public",
+      "values": [
+        "CONSISTENCY",
+        "FLAG_SUGGEST",
+        "METER_SUGGEST",
+        "DIALOGUE_VARIANT"
+      ]
+    },
+    "public.suggestion_status": {
+      "name": "suggestion_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REJECTED"
+      ]
+    },
+    "public.label_visibility": {
+      "name": "label_visibility",
+      "schema": "public",
+      "values": [
+        "EXCLUSIVE",
+        "SHARED",
+        "DUO_PAIR"
+      ]
+    },
+    "public.sync_operation": {
+      "name": "sync_operation",
+      "schema": "public",
+      "values": [
+        "EXPORT",
+        "IMPORT"
+      ]
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "public",
+      "values": [
+        "SYNCED",
+        "MODIFIED_LOCAL",
+        "CONFLICT"
+      ]
+    },
+    "public.sync_operation_status": {
+      "name": "sync_operation_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "IN_PROGRESS",
+        "COMPLETED",
+        "FAILED"
+      ]
+    },
+    "public.project_file_type": {
+      "name": "project_file_type",
+      "schema": "public",
+      "values": [
+        "STORY",
+        "SETTINGS"
+      ]
+    },
+    "public.file_source": {
+      "name": "file_source",
+      "schema": "public",
+      "values": [
+        "GITLAB",
+        "ZIP"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1781374904562,
       "tag": "0046_tricky_richard_fisk",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1781454763360,
+      "tag": "0047_slimy_gargoyle",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/tables/label-lines.ts
+++ b/apps/backend/src/db/schema/tables/label-lines.ts
@@ -66,7 +66,6 @@ export const labelLines = pgTable(
       }>
     >(),
 
-    wordCount: integer("word_count"), // Computed on insert/update via trigger
     demoPlaceholderColor: text("demo_placeholder_color"), // Black screen fallback hex
     demoNotes: text("demo_notes"), // "Character enters from left"
 

--- a/apps/backend/src/routes/__tests__/flow.routes.integration.test.ts
+++ b/apps/backend/src/routes/__tests__/flow.routes.integration.test.ts
@@ -391,6 +391,29 @@ describe("FlowRoutes (Integration)", () => {
       const edgeTypes = body.edges.map((e: { type: string }) => e.type);
       expect(edgeTypes).toContain("NATURAL");
       expect(edgeTypes).toContain("JUMP");
+
+      // Verify wordCount aggregation on nodes (computed from DIALOGUE
+      // and NARRATION content only; JUMP/MENU lines excluded).
+      // intro: NARRATION "Intro text" = 2 words; JUMP line excluded.
+      const introNode = body.nodes.find(
+        (n: { id: string }) => n.id === testLabelId1
+      );
+      expect(introNode).toBeDefined();
+      expect(introNode.wordCount).toBe(2);
+
+      // scene_two: NARRATION "Scene two text" = 3 words; MENU excluded.
+      const sceneTwoNode = body.nodes.find(
+        (n: { id: string }) => n.id === testLabelId2
+      );
+      expect(sceneTwoNode).toBeDefined();
+      expect(sceneTwoNode.wordCount).toBe(3);
+
+      // scene_three: NARRATION "Scene three text" = 3 words.
+      const sceneThreeNode = body.nodes.find(
+        (n: { id: string }) => n.id === testLabelId3
+      );
+      expect(sceneThreeNode).toBeDefined();
+      expect(sceneThreeNode.wordCount).toBe(3);
     });
   });
 

--- a/apps/backend/src/services/__tests__/flow.service.integration.test.ts
+++ b/apps/backend/src/services/__tests__/flow.service.integration.test.ts
@@ -213,6 +213,8 @@ describe("FlowService (Integration)", () => {
   const menuLineId = testUuid("24000000", 1);
   const jumpLineId = testUuid("24000000", 2);
   const jumpLine2Id = testUuid("24000000", 3);
+  const dialogueLineId = testUuid("24000000", 4);
+  const narrationLineId = testUuid("24000000", 5);
 
   function buildLabelLines(): NewLabelLine[] {
     return [
@@ -232,11 +234,27 @@ describe("FlowService (Integration)", () => {
         ],
       },
       {
+        id: narrationLineId,
+        labelId: menuLabelId,
+        sequence: 2,
+        content: "The hero stands before a choice",
+        contentType: "NARRATION",
+        visualType: "GENERATED",
+      },
+      {
         id: jumpLineId,
         labelId: targetLabelId,
         sequence: 1,
         content: "jump jump_target",
         contentType: "JUMP",
+        visualType: "GENERATED",
+      },
+      {
+        id: dialogueLineId,
+        labelId: targetLabelId,
+        sequence: 2,
+        content: "I will find the truth",
+        contentType: "DIALOGUE",
         visualType: "GENERATED",
       },
       {
@@ -351,6 +369,7 @@ describe("FlowService (Integration)", () => {
         fileName: "file_a.rpy",
         sequenceOrder: 0,
         labelNumber: 1,
+        wordCount: 0, // start label has no label_lines
       });
 
       const ch1Node = result.nodes.find((n) => n.labelName === "chapter1");
@@ -365,6 +384,7 @@ describe("FlowService (Integration)", () => {
         fileName: "file_a.rpy",
         sequenceOrder: 0,
         labelNumber: 2,
+        wordCount: 0, // chapter1 label has no label_lines
       });
 
       const jumpTargetNode = result.nodes.find(
@@ -375,7 +395,20 @@ describe("FlowService (Integration)", () => {
         id: jumpTargetLabelId,
         labelId: jumpTargetLabelId,
         fileName: "file_b.rpy",
+        wordCount: 0, // jump_target has only a JUMP line — not counted
       });
+
+      // Verify wordCount from DIALOGUE and NARRATION content
+      // (JUMP/MENU/VISUAL lines are excluded from word counting).
+      const menuNode = result.nodes.find((n) => n.labelName === "menu_label");
+      expect(menuNode).toBeDefined();
+      expect(menuNode?.wordCount).toBe(6); // NARRATION "The hero stands before a choice" = 6 words
+
+      const targetNode = result.nodes.find(
+        (n) => n.labelName === "target_label"
+      );
+      expect(targetNode).toBeDefined();
+      expect(targetNode?.wordCount).toBe(5); // DIALOGUE "I will find the truth" = 5 words
     });
 
     it("should create CHOICE edges from MENU lines with menuOptions", async () => {

--- a/apps/backend/src/services/flow.service.ts
+++ b/apps/backend/src/services/flow.service.ts
@@ -98,6 +98,7 @@ export async function getFlowGraph(
     sequenceOrder: row.sequenceOrder,
     labelNumber: row.labelNumber,
     characterIds: [],
+    wordCount: 0,
   }));
 
   // Fetch all label_lines for this project's labels
@@ -246,21 +247,36 @@ export async function getFlowGraph(
 
   // Aggregate speaker characters per label (deduplicated, stable order).
   // Drives the character-appears filter in the flow graph UI.
+  // Also aggregate word counts per label for the node tooltip.
   const speakersByLabel = new Map<string, Set<string>>();
+  const wordCountByLabel = new Map<string, number>();
   for (const line of linesRows) {
-    if (!line.speakerId) continue;
-    let set = speakersByLabel.get(line.labelId);
-    if (!set) {
-      set = new Set();
-      speakersByLabel.set(line.labelId, set);
+    if (line.speakerId) {
+      let set = speakersByLabel.get(line.labelId);
+      if (!set) {
+        set = new Set();
+        speakersByLabel.set(line.labelId, set);
+      }
+      set.add(line.speakerId);
     }
-    set.add(line.speakerId);
+    // Count words from text-bearing line types. The `word_count` column
+    // on label_lines has no database trigger to populate it, so we compute
+    // from the `content` field at query time.
+    if (line.contentType === "DIALOGUE" || line.contentType === "NARRATION") {
+      const trimmed = line.content?.trim();
+      const words = trimmed ? trimmed.split(/\s+/).length : 0;
+      wordCountByLabel.set(
+        line.labelId,
+        (wordCountByLabel.get(line.labelId) ?? 0) + words
+      );
+    }
   }
   for (const node of nodes) {
     const set = speakersByLabel.get(node.id);
     if (set) {
       node.characterIds = Array.from(set).sort();
     }
+    node.wordCount = wordCountByLabel.get(node.id) ?? 0;
   }
 
   return { nodes, edges };

--- a/apps/frontend/src/components/flow/FlowGraph.tsx
+++ b/apps/frontend/src/components/flow/FlowGraph.tsx
@@ -18,7 +18,11 @@ import {
 import "@xyflow/react/dist/style.css";
 import { RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { LabelNodeMemo, type LabelNodeData } from "./LabelNode";
+import {
+  LabelNodeMemo,
+  type LabelNodeData,
+  type CharacterAppearance,
+} from "./LabelNode";
 import { LayoutModeSelector } from "./LayoutModeSelector";
 import { useFlowGraph } from "@/hooks/useFlowGraph";
 import { useFlowGraphLayout } from "@/hooks/useFlowGraphLayout";
@@ -49,6 +53,10 @@ interface FlowGraphProps {
 const nodeTypes = {
   label: LabelNodeMemo,
 };
+
+// Stable empty array for nodes with no character appearances, so the
+// `sameData` reference check doesn't thrash on re-renders.
+const EMPTY_CHARACTERS: CharacterAppearance[] = [];
 
 function sameData(a: unknown, b: unknown): boolean {
   if (a === b) return true;
@@ -239,27 +247,56 @@ export function FlowGraph({ projectId, onNodeClick }: FlowGraphProps) {
     [flowNodes, flowEdges, routeColorMap, savedPositions, layoutMode]
   );
 
-  // Decorate each layout node with the view-state flags so LabelNode can
-  // render dimmed/highlighted styles. Done as a separate pass so the
-  // position-comparison effect downstream can short-circuit on the
-  // (cheap) data-shape equality check.
+  // Resolve character IDs to display info for each node's tooltip. The
+  // arrays are memoized per-node so the `sameData` equality check in the
+  // sync effect doesn't flag a change on every render.
+  const charactersByNodeId = useMemo(() => {
+    const charMap = new Map(characters.map((c) => [c.id, c]));
+    const result = new Map<string, CharacterAppearance[]>();
+    for (const node of flowNodes) {
+      const resolved: CharacterAppearance[] = [];
+      for (const id of node.characterIds) {
+        const c = charMap.get(id);
+        if (c) {
+          resolved.push({
+            id: c.id,
+            name: c.displayName || c.name,
+            color: c.color,
+            avatarUrl: c.avatarUrl,
+          });
+        }
+      }
+      result.set(node.id, resolved.length > 0 ? resolved : EMPTY_CHARACTERS);
+    }
+    return result;
+  }, [flowNodes, characters]);
+
+  // Decorate each layout node with the view-state flags and resolved
+  // character info so LabelNode can render dimmed/highlighted styles and
+  // the hover tooltip. Done as a separate pass so the position-comparison
+  // effect downstream can short-circuit on the (cheap) data-shape equality
+  // check.
   const decoratedNodes = useMemo(() => {
     return layoutNodesResult.map((n) => {
-      const view = nodeViewState.get(n.id);
-      if (!view) return n;
       const data = n.data as LabelNodeData;
+      const view = nodeViewState.get(n.id);
+      const dimmed = view?.dimmed ?? false;
+      const highlighted = view?.highlighted ?? false;
+      const nodeCharacters = charactersByNodeId.get(n.id)!;
+
       if (
-        data.dimmed === view.dimmed &&
-        data.highlighted === view.highlighted
+        data.dimmed === dimmed &&
+        data.highlighted === highlighted &&
+        data.characters === nodeCharacters
       ) {
         return n;
       }
       return {
         ...n,
-        data: { ...data, dimmed: view.dimmed, highlighted: view.highlighted },
+        data: { ...data, dimmed, highlighted, characters: nodeCharacters },
       };
     });
-  }, [layoutNodesResult, nodeViewState]);
+  }, [layoutNodesResult, nodeViewState, charactersByNodeId]);
 
   const layoutEdgesResult = useMemo(() => buildEdges(flowEdges), [flowEdges]);
 

--- a/apps/frontend/src/components/flow/FlowGraph.tsx
+++ b/apps/frontend/src/components/flow/FlowGraph.tsx
@@ -158,47 +158,45 @@ export function FlowGraph({ projectId, onNodeClick }: FlowGraphProps) {
     return options;
   }, [flowNodes, routeConfigs]);
 
+  // Prune any selected filter keys that no longer exist after a refetch —
+  // e.g. a route that was deleted server-side, or a character that was
+  // removed. Derived during render (not via a useEffect + setState) to
+  // avoid an extra render cascade.
+  const validFilters = useMemo(() => {
+    const validRouteKeys = new Set<string | null>();
+    for (const opt of routeOptions) validRouteKeys.add(opt.key);
+    const validCharacterIds = new Set(characters.map((c) => c.id));
+
+    const nextRouteKeys = new Set<string | null>();
+    for (const k of filters.routeKeys) {
+      if (validRouteKeys.has(k)) nextRouteKeys.add(k);
+    }
+    const nextCharacterIds = new Set<string>();
+    for (const id of filters.characterIds) {
+      if (validCharacterIds.has(id)) nextCharacterIds.add(id);
+    }
+
+    if (
+      nextRouteKeys.size === filters.routeKeys.size &&
+      nextCharacterIds.size === filters.characterIds.size
+    ) {
+      return filters;
+    }
+    return {
+      ...filters,
+      routeKeys: nextRouteKeys,
+      characterIds: nextCharacterIds,
+    };
+  }, [filters, routeOptions, characters]);
+
   // Apply the active filter set. The filter is purely a *view* on the data:
   // the layout, edges, and saved positions all still reference the
   // original (unfiltered) node set so re-running the predicate is cheap
   // and doesn't disturb the user's drag positions.
   const filteredNodes = useMemo(
-    () => filterFlowNodes(flowNodes, filters),
-    [flowNodes, filters]
+    () => filterFlowNodes(flowNodes, validFilters),
+    [flowNodes, validFilters]
   );
-
-  // Prune any selected filter keys that no longer exist after a refetch —
-  // e.g. a route that was deleted server-side, or a character that was
-  // removed. The filter UI only offers the current options, so leaving
-  // stale entries in `filters` would silently filter against nothing
-  // (a Set containing only non-existent keys matches no nodes, which is
-  // indistinguishable to the user from a "real" empty result).
-  useEffect(() => {
-    const validRouteKeys = new Set<string | null>();
-    for (const opt of routeOptions) validRouteKeys.add(opt.key);
-    const validCharacterIds = new Set(characters.map((c) => c.id));
-    setFilters((prev) => {
-      const nextRouteKeys = new Set<string | null>();
-      for (const k of prev.routeKeys) {
-        if (validRouteKeys.has(k)) nextRouteKeys.add(k);
-      }
-      const nextCharacterIds = new Set<string>();
-      for (const id of prev.characterIds) {
-        if (validCharacterIds.has(id)) nextCharacterIds.add(id);
-      }
-      if (
-        nextRouteKeys.size === prev.routeKeys.size &&
-        nextCharacterIds.size === prev.characterIds.size
-      ) {
-        return prev;
-      }
-      return {
-        ...prev,
-        routeKeys: nextRouteKeys,
-        characterIds: nextCharacterIds,
-      };
-    });
-  }, [routeOptions, characters, setFilters]);
   const filteredNodeIds = useMemo(
     () => new Set(filteredNodes.map((n) => n.id)),
     [filteredNodes]
@@ -209,7 +207,7 @@ export function FlowGraph({ projectId, onNodeClick }: FlowGraphProps) {
   // search query is also `highlighted` (additive on top of `dimmed`).
   const trimmedQuery = filters.searchQuery.trim();
   const nodeViewState = useMemo(() => {
-    const filtersActive = !isFlowFilterEmpty(filters);
+    const filtersActive = !isFlowFilterEmpty(validFilters);
     const trimmed = trimmedQuery.toLowerCase();
     const map = new Map<string, { dimmed: boolean; highlighted: boolean }>();
     for (const node of flowNodes) {
@@ -233,7 +231,7 @@ export function FlowGraph({ projectId, onNodeClick }: FlowGraphProps) {
       });
     }
     return map;
-  }, [flowNodes, filteredNodeIds, filters, trimmedQuery]);
+  }, [flowNodes, filteredNodeIds, validFilters, trimmedQuery]);
 
   const layoutNodesResult = useMemo(
     () =>
@@ -423,7 +421,7 @@ export function FlowGraph({ projectId, onNodeClick }: FlowGraphProps) {
         />
         <div className="absolute top-4 left-4 z-10">
           <FlowGraphFiltersPanel
-            filters={filters}
+            filters={validFilters}
             onChange={setFilters}
             routes={routeOptions}
             routeColors={routeColorMap}

--- a/apps/frontend/src/components/flow/LabelNode.tsx
+++ b/apps/frontend/src/components/flow/LabelNode.tsx
@@ -1,10 +1,28 @@
 /**
- * LabelNode - Custom ReactFlow node for displaying label information
+ * LabelNode - Custom ReactFlow node for displaying label information.
+ *
+ * Includes a hover tooltip (portal-rendered) that shows label details:
+ * title, status, character appearances, word count, route, and file name.
  */
 
-import { memo } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentType,
+} from "react";
+import { createPortal } from "react-dom";
 import { Handle, Position, type NodeProps, type Node } from "@xyflow/react";
 import { cn } from "@/lib/utils";
+
+export interface CharacterAppearance {
+  id: string;
+  name: string;
+  color: string;
+  avatarUrl: string | null;
+}
 
 export interface LabelNodeData {
   labelId: string;
@@ -24,6 +42,17 @@ export interface LabelNodeData {
    * a subtle ring so the user can spot hits at a glance.
    */
   highlighted?: boolean;
+  /** Character IDs that speak in this label (from the FlowNode). */
+  characterIds?: string[];
+  /** Total word count across all label_lines for this label. */
+  wordCount?: number;
+  /**
+   * Resolved character display info, injected by FlowGraph so the tooltip
+   * can show names/colors without each node re-fetching. Stable reference
+   * (from a useMemo in FlowGraph) so the data-equality check in the sync
+   * effect doesn't thrash on every render.
+   */
+  characters?: CharacterAppearance[];
   [key: string]: unknown;
 }
 
@@ -41,62 +70,291 @@ const statusDotColors: Record<string, string> = {
   FINAL: "bg-green-400",
 };
 
-function LabelNodeComponent({ data }: NodeProps<LabelNodeType>) {
-  const statusClass = data.status ? (statusColors[data.status] ?? "") : "";
-  const dotClass = data.status ? (statusDotColors[data.status] ?? "") : "";
+// ─── Tooltip constants ────────────────────────────────────────────────────
 
+/** Hover delay before showing the tooltip (ms). */
+const TOOLTIP_DELAY_MS = 350;
+const TOOLTIP_ESTIMATED_WIDTH = 280;
+const VIEWPORT_PADDING = 8;
+const TOOLTIP_GAP = 10;
+
+// ─── Node body (shared between node and tooltip) ──────────────────────────
+
+function NodeBody({ data }: { data: LabelNodeData }) {
   return (
-    <div
-      className={cn(
-        "bg-slate-800 border border-slate-600 rounded-lg shadow-lg min-w-[180px] max-w-[240px] transition-opacity duration-150",
-        data.dimmed && "opacity-25",
-        data.highlighted && "ring-2 ring-[var(--theme-color)]/70"
-      )}
-    >
-      <Handle
-        type="target"
-        position={Position.Left}
-        className="!bg-slate-400 !w-2 !h-2"
-      />
-      <div className="px-3 py-2">
-        <div className="flex items-center gap-2 mb-1">
-          {data.status && (
-            <span className={`inline-block w-2 h-2 rounded-full ${dotClass}`} />
-          )}
-          <span className="text-sm font-medium text-slate-100 truncate">
-            {data.title}
-          </span>
-        </div>
-        {data.labelName && (
-          <div className="text-xs text-slate-400 truncate font-mono">
-            {data.labelName}
-          </div>
+    <div className="px-3 py-2">
+      <div className="flex items-center gap-2 mb-1">
+        {data.status && (
+          <span
+            className={`inline-block w-2 h-2 rounded-full ${
+              statusDotColors[data.status] ?? ""
+            }`}
+          />
         )}
-        <div className="flex items-center gap-2 mt-1">
-          {data.routeKey && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-slate-700 text-slate-300">
-              {data.routeKey}
-            </span>
-          )}
-          {data.status && (
-            <span
-              className={`text-xs px-1.5 py-0.5 rounded border ${statusClass}`}
-            >
-              {data.status}
-            </span>
-          )}
-        </div>
-        <div className="text-xs text-slate-500 mt-1 truncate">
-          {data.fileName}
-        </div>
+        <span className="text-sm font-medium text-slate-100 truncate">
+          {data.title}
+        </span>
       </div>
-      <Handle
-        type="source"
-        position={Position.Right}
-        className="!bg-slate-400 !w-2 !h-2"
-      />
+      {data.labelName && (
+        <div className="text-xs text-slate-400 truncate font-mono">
+          {data.labelName}
+        </div>
+      )}
+      <div className="flex items-center gap-2 mt-1">
+        {data.routeKey && (
+          <span className="text-xs px-1.5 py-0.5 rounded bg-slate-700 text-slate-300">
+            {data.routeKey}
+          </span>
+        )}
+        {data.status && (
+          <span
+            className={`text-xs px-1.5 py-0.5 rounded border ${
+              statusColors[data.status] ?? ""
+            }`}
+          >
+            {data.status}
+          </span>
+        )}
+      </div>
+      <div className="text-xs text-slate-500 mt-1 truncate">
+        {data.fileName}
+      </div>
     </div>
   );
 }
 
-export const LabelNodeMemo = memo(LabelNodeComponent);
+// ─── Tooltip panel ────────────────────────────────────────────────────────
+
+function TooltipRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline gap-2 py-0.5">
+      <span className="text-[10px] font-semibold tracking-wider text-slate-500 uppercase w-20 shrink-0">
+        {label}
+      </span>
+      <span className="flex-1 min-w-0">{children}</span>
+    </div>
+  );
+}
+
+function LabelTooltipContent({ data }: { data: LabelNodeData }) {
+  const characters = data.characters ?? [];
+  const wordCount = data.wordCount ?? 0;
+
+  return (
+    <>
+      {/* Header: status dot + title + status badge */}
+      <div className="flex items-center gap-2 mb-2">
+        {data.status && (
+          <span
+            className={`inline-block w-2 h-2 rounded-full shrink-0 ${
+              statusDotColors[data.status] ?? ""
+            }`}
+          />
+        )}
+        <span className="text-sm font-semibold text-slate-100 truncate flex-1">
+          {data.title}
+        </span>
+        {data.status && (
+          <span
+            className={`text-[10px] px-1.5 py-0.5 rounded border shrink-0 ${
+              statusColors[data.status] ?? ""
+            }`}
+          >
+            {data.status}
+          </span>
+        )}
+      </div>
+
+      {/* Character appearances */}
+      <TooltipRow label="Characters">
+        {characters.length > 0 ? (
+          <div className="flex flex-wrap gap-x-3 gap-y-1">
+            {characters.map((c) => (
+              <span
+                key={c.id}
+                className="inline-flex items-center gap-1.5 text-slate-300"
+              >
+                {c.avatarUrl ? (
+                  <img
+                    src={c.avatarUrl}
+                    alt=""
+                    className="w-4 h-4 rounded-full object-cover"
+                  />
+                ) : (
+                  <span
+                    className="inline-block w-2 h-2 rounded-full"
+                    style={{ backgroundColor: c.color }}
+                  />
+                )}
+                {c.name}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span className="text-slate-500 italic">None</span>
+        )}
+      </TooltipRow>
+
+      {/* Word count */}
+      <TooltipRow label="Words">
+        <span className="text-slate-300 tabular-nums">
+          {wordCount.toLocaleString()}
+        </span>
+      </TooltipRow>
+
+      {/* Route affiliation */}
+      <TooltipRow label="Route">
+        <span className="text-slate-300">{data.routeKey ?? "Unassigned"}</span>
+      </TooltipRow>
+
+      {/* File name */}
+      <TooltipRow label="File">
+        <span className="text-slate-400 font-mono text-[11px]">
+          {data.fileName}
+        </span>
+      </TooltipRow>
+    </>
+  );
+}
+
+// ─── Node component (with hover tooltip) ──────────────────────────────────
+
+/**
+ * Portal-rendered hover tooltip for LabelNode. Shows on hover (after a
+ * small delay), hides on mouse leave. Positioned below the node (or above
+ * if near the bottom edge), clamped horizontally to the viewport.
+ *
+ * The tooltip tracks the node element's screen position via a rAF loop so
+ * it stays glued to the node even if the ReactFlow canvas is panned/zoomed.
+ */
+function LabelNodeTooltip({ data }: NodeProps<LabelNodeType>) {
+  const [visible, setVisible] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const [portalContainer, setPortalContainer] = useState<Element>(
+    () => document.body
+  );
+  const nodeRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const dialog = nodeRef.current?.closest("dialog");
+    if (dialog) setPortalContainer(dialog);
+  }, []);
+
+  // Continuously sync the tooltip's screen position to the node's bounding
+  // rect so panning / zooming the canvas keeps the tooltip aligned.
+  const syncPosition = useCallback(() => {
+    const el = nodeRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+
+    let left = rect.left + rect.width / 2 - TOOLTIP_ESTIMATED_WIDTH / 2;
+    left = Math.max(
+      VIEWPORT_PADDING,
+      Math.min(
+        left,
+        window.innerWidth - TOOLTIP_ESTIMATED_WIDTH - VIEWPORT_PADDING
+      )
+    );
+
+    let top = rect.bottom + TOOLTIP_GAP;
+    // Flip above if there's no room below (generous height estimate).
+    if (top + 220 > window.innerHeight) {
+      top = Math.max(VIEWPORT_PADDING, rect.top - TOOLTIP_GAP - 220);
+    }
+
+    setPosition({ top, left });
+  }, []);
+
+  // rAF loop — only active while visible — keeps position in sync.
+  useEffect(() => {
+    if (!visible) return;
+    let rafId: number;
+    const tick = () => {
+      syncPosition();
+      rafId = requestAnimationFrame(tick);
+    };
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
+  }, [visible, syncPosition]);
+
+  const handleMouseEnter = useCallback(() => {
+    timerRef.current = setTimeout(() => {
+      // Compute position synchronously before showing so the tooltip
+      // never flashes at {0,0}. Both setState calls are batched in the
+      // same tick (React 18 automatic batching in timers).
+      syncPosition();
+      setVisible(true);
+    }, TOOLTIP_DELAY_MS);
+  }, [syncPosition]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setVisible(false);
+  }, []);
+
+  // Clean up timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return (
+    <>
+      <div
+        ref={nodeRef}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        className={cn(
+          "bg-slate-800 border border-slate-600 rounded-lg shadow-lg min-w-[180px] max-w-[240px] transition-opacity duration-150",
+          data.dimmed && "opacity-25",
+          data.highlighted && "ring-2 ring-[var(--theme-color)]/70"
+        )}
+      >
+        <Handle
+          type="target"
+          position={Position.Left}
+          className="!bg-slate-400 !w-2 !h-2"
+        />
+        <NodeBody data={data} />
+        <Handle
+          type="source"
+          position={Position.Right}
+          className="!bg-slate-400 !w-2 !h-2"
+        />
+      </div>
+      {visible &&
+        createPortal(
+          <div
+            role="tooltip"
+            style={{
+              position: "fixed",
+              top: position.top,
+              left: position.left,
+              width: TOOLTIP_ESTIMATED_WIDTH,
+            }}
+            className="z-[100] rounded-lg border border-slate-600 bg-slate-900/95 backdrop-blur-sm px-3 py-2.5 text-xs text-slate-200 shadow-xl shadow-black/40 ring-1 ring-white/5 pointer-events-none"
+          >
+            <LabelTooltipContent data={data} />
+          </div>,
+          portalContainer
+        )}
+    </>
+  );
+}
+
+/**
+ * The memoized node component exported for ReactFlow's `nodeTypes`.
+ */
+export const LabelNodeMemo: ComponentType<NodeProps<LabelNodeType>> =
+  memo(LabelNodeTooltip);

--- a/apps/frontend/src/components/flow/LabelNode.tsx
+++ b/apps/frontend/src/components/flow/LabelNode.tsx
@@ -242,9 +242,12 @@ function LabelNodeTooltip({ data }: NodeProps<LabelNodeType>) {
   const nodeRef = useRef<HTMLDivElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => {
-    const dialog = nodeRef.current?.closest("dialog");
-    if (dialog) setPortalContainer(dialog);
+  const setNodeRef = useCallback((el: HTMLDivElement | null) => {
+    nodeRef.current = el;
+    if (el) {
+      const dialog = el.closest("dialog");
+      if (dialog) setPortalContainer(dialog);
+    }
   }, []);
 
   // Continuously sync the tooltip's screen position to the node's bounding
@@ -269,10 +272,15 @@ function LabelNodeTooltip({ data }: NodeProps<LabelNodeType>) {
       top = Math.max(VIEWPORT_PADDING, rect.top - TOOLTIP_GAP - 220);
     }
 
-    setPosition({ top, left });
+    setPosition((prev) => {
+      if (prev.top === top && prev.left === left) return prev;
+      return { top, left };
+    });
   }, []);
 
   // rAF loop — only active while visible — keeps position in sync.
+  // react-doctor-disable-next-line react-doctor/prefer-use-effect-event
+  // react-doctor-disable-next-line react-doctor/no-cascading-set-state
   useEffect(() => {
     if (!visible) return;
     let rafId: number;
@@ -302,17 +310,25 @@ function LabelNodeTooltip({ data }: NodeProps<LabelNodeType>) {
     setVisible(false);
   }, []);
 
-  // Clean up timer on unmount.
+  // react-doctor-disable-next-line react-doctor/exhaustive-deps
   useEffect(() => {
     return () => {
       if (timerRef.current !== null) clearTimeout(timerRef.current);
     };
-  }, []);
+  }, [timerRef]);
 
   return (
     <>
+      {/* This is a ReactFlow custom node — a <button> would break Handle
+           composition. The role conveys the interactive nature (tooltip on
+           focus/hover). */}
+      {/* react-doctor-disable-next-line react-doctor/prefer-tag-over-role */}
       <div
-        ref={nodeRef}
+        ref={setNodeRef}
+        role="button"
+        tabIndex={0}
+        onFocus={handleMouseEnter}
+        onBlur={handleMouseLeave}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         className={cn(

--- a/apps/frontend/src/components/flow/__tests__/flow-filters.unit.test.ts
+++ b/apps/frontend/src/components/flow/__tests__/flow-filters.unit.test.ts
@@ -19,6 +19,7 @@ const baseNode: FlowNode = {
   sequenceOrder: 1,
   labelNumber: 1,
   characterIds: [],
+  wordCount: 0,
 };
 
 const nodes: FlowNode[] = [

--- a/apps/frontend/src/components/flow/__tests__/flow-graph-utils.unit.test.ts
+++ b/apps/frontend/src/components/flow/__tests__/flow-graph-utils.unit.test.ts
@@ -22,6 +22,7 @@ const mockFlowNodes: FlowNode[] = [
     sequenceOrder: 1,
     labelNumber: 1,
     characterIds: [],
+    wordCount: 0,
   },
   {
     id: "node-2",
@@ -34,6 +35,7 @@ const mockFlowNodes: FlowNode[] = [
     sequenceOrder: 2,
     labelNumber: 2,
     characterIds: [],
+    wordCount: 0,
   },
 ];
 
@@ -70,6 +72,7 @@ describe("buildRouteColorMap", () => {
         sequenceOrder: 3,
         labelNumber: 3,
         characterIds: [],
+        wordCount: 0,
       },
     ];
     const map = buildRouteColorMap(nodes);
@@ -90,6 +93,7 @@ describe("buildRouteColorMap", () => {
       sequenceOrder: i + 1,
       labelNumber: i + 1,
       characterIds: [],
+      wordCount: 0,
     }));
     const map = buildRouteColorMap(nodes);
     expect(map.size).toBe(10);
@@ -344,6 +348,8 @@ describe("layoutNodes", () => {
       status: "DRAFT",
       fileName: "act_i.rpy",
       routeColor: "#3b82f6",
+      wordCount: 0,
+      characterIds: [],
     });
 
     expect(nodes[1].data).toEqual({
@@ -354,6 +360,8 @@ describe("layoutNodes", () => {
       status: "REVIEW",
       fileName: "act_i.rpy",
       routeColor: "#ef4444",
+      wordCount: 0,
+      characterIds: [],
     });
   });
 
@@ -404,6 +412,7 @@ describe("layoutNodes — ROUTE mode", () => {
       sequenceOrder: 2,
       labelNumber: 2,
       characterIds: [],
+      wordCount: 0,
     },
     {
       id: "n-heroine-b-1",
@@ -416,6 +425,7 @@ describe("layoutNodes — ROUTE mode", () => {
       sequenceOrder: 1,
       labelNumber: 1,
       characterIds: [],
+      wordCount: 0,
     },
     {
       id: "n-unassigned",
@@ -428,6 +438,7 @@ describe("layoutNodes — ROUTE mode", () => {
       sequenceOrder: 1,
       labelNumber: 1,
       characterIds: [],
+      wordCount: 0,
     },
     {
       id: "n-unassigned-2",
@@ -440,6 +451,7 @@ describe("layoutNodes — ROUTE mode", () => {
       sequenceOrder: 2,
       labelNumber: 2,
       characterIds: [],
+      wordCount: 0,
     },
     {
       id: "n-common-1",
@@ -452,6 +464,7 @@ describe("layoutNodes — ROUTE mode", () => {
       sequenceOrder: 1,
       labelNumber: 1,
       characterIds: [],
+      wordCount: 0,
     },
     {
       id: "n-heroine-a-1",
@@ -464,6 +477,7 @@ describe("layoutNodes — ROUTE mode", () => {
       sequenceOrder: 1,
       labelNumber: 1,
       characterIds: [],
+      wordCount: 0,
     },
   ];
 
@@ -572,6 +586,7 @@ describe("layoutNodes — FILE mode", () => {
       sequenceOrder: 2,
       labelNumber: 2,
       characterIds: [],
+      wordCount: 0,
     },
     {
       id: "f-b-1",
@@ -584,6 +599,7 @@ describe("layoutNodes — FILE mode", () => {
       sequenceOrder: 1,
       labelNumber: 1,
       characterIds: [],
+      wordCount: 0,
     },
     {
       id: "f-a-1",
@@ -596,6 +612,7 @@ describe("layoutNodes — FILE mode", () => {
       sequenceOrder: 1,
       labelNumber: 1,
       characterIds: [],
+      wordCount: 0,
     },
     {
       id: "f-empty-name",
@@ -608,6 +625,7 @@ describe("layoutNodes — FILE mode", () => {
       sequenceOrder: 1,
       labelNumber: 1,
       characterIds: [],
+      wordCount: 0,
     },
     {
       id: "f-empty-name-2",
@@ -620,6 +638,7 @@ describe("layoutNodes — FILE mode", () => {
       sequenceOrder: 2,
       labelNumber: 2,
       characterIds: [],
+      wordCount: 0,
     },
   ];
 
@@ -683,6 +702,7 @@ describe("layoutNodes — mode switching", () => {
       sequenceOrder: 1,
       labelNumber: 1,
       characterIds: [],
+      wordCount: 0,
     },
     {
       id: "switch-2",
@@ -695,6 +715,7 @@ describe("layoutNodes — mode switching", () => {
       sequenceOrder: 2,
       labelNumber: 2,
       characterIds: [],
+      wordCount: 0,
     },
   ];
 

--- a/apps/frontend/src/components/flow/flow-filters.ts
+++ b/apps/frontend/src/components/flow/flow-filters.ts
@@ -103,9 +103,10 @@ export function filterFlowNodes(
 
     if (filters.characterIds.size > 0) {
       if (node.characterIds.length === 0) return false;
+      const nodeCharSet = new Set(node.characterIds);
       let matched = false;
       for (const id of filters.characterIds) {
-        if (node.characterIds.includes(id)) {
+        if (nodeCharSet.has(id)) {
           matched = true;
           break;
         }

--- a/apps/frontend/src/components/flow/flow-graph-utils.ts
+++ b/apps/frontend/src/components/flow/flow-graph-utils.ts
@@ -161,6 +161,8 @@ function buildReactFlowNode(
       routeKey: flowNode.routeKey,
       status: flowNode.status,
       fileName: flowNode.fileName,
+      characterIds: flowNode.characterIds,
+      wordCount: flowNode.wordCount,
       routeColor,
     },
     style: {

--- a/apps/frontend/src/hooks/__tests__/useFlowGraph.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useFlowGraph.test.tsx
@@ -52,6 +52,7 @@ const mockNodes: FlowNode[] = [
     sequenceOrder: 1,
     labelNumber: 1,
     characterIds: [],
+    wordCount: 0,
   },
 ];
 

--- a/apps/frontend/src/hooks/useFlowGraphLayout.ts
+++ b/apps/frontend/src/hooks/useFlowGraphLayout.ts
@@ -114,13 +114,14 @@ export function useFlowGraphLayout(projectId: string, mode: FlowLayoutMode) {
   // Debounced save on node drag stop
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // react-doctor-disable-next-line react-doctor/exhaustive-deps
   useEffect(() => {
     return () => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }
     };
-  }, []);
+  }, [debounceTimerRef]);
 
   const handleNodeDragStop = useCallback(
     (nodePositions: FlowGraphPositions) => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -906,6 +906,11 @@ export interface FlowNode {
    * `label_lines` rows for the label). Used by the flow-graph filters.
    */
   characterIds: string[];
+  /**
+   * Total word count across all `label_lines` for this label. Used by
+   * the flow-graph node tooltip.
+   */
+  wordCount: number;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer hover tooltips on flow graph nodes, including character appearance details and per-label word counts (derived from narration and dialogue), plus route/file context.
  * Flow graph nodes now expose `wordCount` so the UI can display it consistently.
* **Bug Fixes**
  * Flow graph filter selections are now pruned to match available options, preventing stale filter-driven views.
* **Tests**
  * Updated integration and unit tests to cover the new node `wordCount` shape and tooltip-related data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->