### PR TITLE
Add Ren'Py tokenizer and text formatting display

### DIFF
--- a/apps/frontend/src/components/write-mode/DialogueLine.tsx
+++ b/apps/frontend/src/components/write-mode/DialogueLine.tsx
@@ -554,7 +554,7 @@ export const DialogueLine = memo(function DialogueLine({
   // the data-raw-start / data-raw-len attributes on each rendered span.
 
   const handleRenderedLineClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: React.MouseEvent<HTMLElement>) => {
       const textarea = internalTextareaRef.current;
       if (!textarea) return;
 
@@ -566,16 +566,6 @@ export const DialogueLine = memo(function DialogueLine({
 
       if (rawPos !== null) {
         textarea.setSelectionRange(rawPos, rawPos);
-      }
-    },
-    []
-  );
-
-  const handleRenderedLineKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        internalTextareaRef.current?.focus();
       }
     },
     []
@@ -811,6 +801,11 @@ export const DialogueLine = memo(function DialogueLine({
                   ? "Dialogue text"
                   : "Narration text"
             }
+            // aria-hidden and tabIndex are coordinated: when not focused the
+            // textarea is hidden from AT AND removed from tab order (tabIndex=-1),
+            // yet must stay programmatically focusable so the rendered-line
+            // overlay's click handler can call .focus() to enter edit mode.
+            // react-doctor-disable-next-line react-doctor/no-aria-hidden-on-focusable
             aria-hidden={!isFocused}
             tabIndex={isFocused ? 0 : -1}
             style={{
@@ -821,11 +816,9 @@ export const DialogueLine = memo(function DialogueLine({
             }}
           />
           {!isFocused && (
-            <div
-              role="button"
-              tabIndex={0}
+            <button
+              type="button"
               onClick={handleRenderedLineClick}
-              onKeyDown={handleRenderedLineKeyDown}
               data-rendered-line-wrapper="true"
               aria-label={
                 isChoice
@@ -834,7 +827,7 @@ export const DialogueLine = memo(function DialogueLine({
                     ? "Edit dialogue text"
                     : "Edit narration text"
               }
-              className="absolute inset-0 pr-7 cursor-text leading-8 outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm overflow-hidden"
+              className="absolute inset-0 pr-7 cursor-text leading-8 text-left bg-transparent border-0 p-0 outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm overflow-hidden"
               style={{
                 fontSize: "var(--prose-editor-font-size, 16px)",
                 fontFamily: "var(--prose-editor-font-family, var(--font-sans))",
@@ -846,7 +839,7 @@ export const DialogueLine = memo(function DialogueLine({
                 tokens={renderedTokens}
                 className="font-light tracking-normal leading-8"
               />
-            </div>
+            </button>
           )}
         </div>
 

--- a/apps/frontend/src/components/write-mode/DialogueLine.tsx
+++ b/apps/frontend/src/components/write-mode/DialogueLine.tsx
@@ -5,13 +5,97 @@
  * Matches app design system with theme colors and simple styling.
  */
 
-import { memo, useState, useCallback, useRef, useEffect, useId } from "react";
+import {
+  memo,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  useId,
+  useMemo,
+} from "react";
 import { X, ChevronDown, Split, ArrowUpRight } from "lucide-react";
 import type { DialogueEntry } from "@/lib/prose-types";
 import type { Character } from "@branchforge/shared";
 import { withAlpha } from "@/lib/utils";
 import { TechnicalBadge } from "./TechnicalBadge";
 import { TechnicalPopover } from "./TechnicalPopover";
+import { RenderedLine } from "./RenderedLine";
+import { tokenize } from "@/lib/renpy-tags";
+
+// ---------------------------------------------------------------------------
+// Click → raw-text offset mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Given pixel coordinates (e.g. from a mouse click on the rendered overlay),
+ * find the equivalent character offset in the RAW textarea text.
+ *
+ * Uses `caretRangeFromPoint` / `caretPositionFromPoint` to locate the text
+ * node under the cursor, then reads `data-raw-start` and `data-raw-len` from
+ * the enclosing rendered span to map back to raw-text coordinates.
+ *
+ * Returns `null` if the position can't be determined (e.g. clicked on empty
+ * space, or the API is unavailable). Caller should fall back to default focus.
+ */
+function getRawOffsetFromPoint(x: number, y: number): number | null {
+  let container: Node | null = null;
+  let offset = 0;
+
+  // Firefox: caretPositionFromPoint (standard)
+  const doc = document as Document & {
+    caretPositionFromPoint?: (
+      x: number,
+      y: number
+    ) => { offsetNode: Node; offset: number } | null;
+  };
+  if (typeof doc.caretPositionFromPoint === "function") {
+    const pos = doc.caretPositionFromPoint(x, y);
+    if (pos) {
+      container = pos.offsetNode;
+      offset = pos.offset;
+    }
+  }
+
+  // Chrome / Safari / Edge: caretRangeFromPoint (de-facto standard)
+  if (
+    container === null &&
+    typeof document.caretRangeFromPoint === "function"
+  ) {
+    const range = document.caretRangeFromPoint(x, y);
+    if (range) {
+      container = range.startContainer;
+      offset = range.startOffset;
+    }
+  }
+
+  if (container === null) return null;
+
+  // When the click lands on padding or an element node (rather than a text
+  // node), `startOffset` is a *child index*, not a character offset. There's
+  // no reliable way to map that back to a raw-text caret position, so bail
+  // out and let the caller fall back to default focus.
+  if (container.nodeType !== Node.TEXT_NODE) return null;
+
+  // Walk up to the nearest rendered span with position metadata.
+  const element = container.parentElement;
+  const span = element?.closest("[data-raw-start]");
+  if (!span) return null;
+
+  const rawStart = parseInt(span.getAttribute("data-raw-start") || "0", 10);
+  const rawLen = parseInt(span.getAttribute("data-raw-len") || "0", 10);
+  const renderedLen = span.textContent?.length ?? 0;
+
+  if (renderedLen === 0 || rawLen === renderedLen) {
+    // Normal tokens (text, interpolation, malformed): 1:1 mapping.
+    return rawStart + offset;
+  }
+
+  // Newline tokens: raw is 2 chars ("\n"), rendered is 1 char.
+  // Scale proportionally and clamp to [rawStart, rawStart + rawLen].
+  const scaled = Math.round((offset / renderedLen) * rawLen);
+  return rawStart + Math.min(scaled, rawLen);
+}
 
 interface DialogueLineProps {
   entry: DialogueEntry;
@@ -99,12 +183,14 @@ export const DialogueLine = memo(function DialogueLine({
     "conditions" | "jump" | "visuals" | "menu" | null
   >(null);
   const [showRemoveHint, setShowRemoveHint] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
   const removeHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const internalTextareaRef = useRef<HTMLTextAreaElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const dropdownMenuRef = useRef<HTMLDivElement>(null);
   const speakerButtonRef = useRef<HTMLButtonElement>(null);
   const wasDropdownOpenRef = useRef(false);
+
   const dropdownId = useId();
   const textOnChangeRef = useRef(onChange);
   const previousTextRef = useRef(entry.text);
@@ -460,6 +546,41 @@ export const DialogueLine = memo(function DialogueLine({
     [characters, focusedOptionIndex, handleSpeakerSelect]
   );
 
+  // -- Rendered-line click → caret position mapping -------------------------
+  // The rendered overlay hides formatting tags ({b}, {/b}, etc.), so its text
+  // layout differs from the textarea's raw text. When the user clicks the
+  // overlay, we use caretRangeFromPoint to find WHERE in the rendered text they
+  // clicked, then map that to the equivalent position in the RAW text using
+  // the data-raw-start / data-raw-len attributes on each rendered span.
+
+  const handleRenderedLineClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const textarea = internalTextareaRef.current;
+      if (!textarea) return;
+
+      // Find the rendered text node at the click point.
+      const rawPos = getRawOffsetFromPoint(e.clientX, e.clientY);
+
+      // Focus first so the textarea is ready, then position the caret.
+      textarea.focus();
+
+      if (rawPos !== null) {
+        textarea.setSelectionRange(rawPos, rawPos);
+      }
+    },
+    []
+  );
+
+  const handleRenderedLineKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        internalTextareaRef.current?.focus();
+      }
+    },
+    []
+  );
+
   const handleDropdownBlur = useCallback(
     (e: React.FocusEvent<HTMLDivElement>) => {
       if (!e.currentTarget.contains(e.relatedTarget)) {
@@ -492,6 +613,12 @@ export const DialogueLine = memo(function DialogueLine({
     : `group relative transition-colors ${
         isStacked ? "flex flex-col gap-1.5 py-2" : "flex flex-col gap-1 py-1.5"
       }`;
+
+  // Tokenize the raw text once per change. The tokenizer is O(n) and the
+  // overlay is only mounted when the textarea is blurred, but we still
+  // memoize to avoid re-tokenizing on every keystroke when the parent
+  // re-renders for unrelated reasons (e.g. speaker hover state).
+  const renderedTokens = useMemo(() => tokenize(entry.text), [entry.text]);
 
   return (
     <div
@@ -648,39 +775,80 @@ export const DialogueLine = memo(function DialogueLine({
           </div>
         )}
 
-        {/* Text Content */}
-        <textarea
-          ref={(el) => {
-            internalTextareaRef.current = el;
-            if (textareaRef) textareaRef(el);
-          }}
-          defaultValue={entry.text}
-          onChange={handleTextChange}
-          onKeyDown={handleKeyDown}
-          placeholder={
-            isChoice
-              ? "Choice text..."
-              : entry.speakerId
-                ? "Dialogue..."
-                : "Narration..."
-          }
-          className={`relative min-h-[2.5rem] p-0 pr-7 resize-none overflow-hidden bg-transparent border-0 outline-none focus-visible:outline-none focus-visible:ring-0 font-light tracking-normal leading-8 placeholder:text-muted-foreground/50 ${
-            isStacked ? "w-full" : "flex-1"
-          }`}
-          aria-label={
-            isChoice
-              ? "Choice text"
-              : entry.speakerId
-                ? "Dialogue text"
-                : "Narration text"
-          }
-          style={{
-            fontSize: "var(--prose-editor-font-size, 16px)",
-            fontFamily: "var(--prose-editor-font-family, var(--font-sans))",
-            fontStyle: !entry.speakerId ? "italic" : "normal",
-            color: "hsl(var(--foreground))",
-          }}
-        />
+        {/* Text Content — textarea is always mounted to prevent height shift.
+            When blurred: textarea is opacity-0 + pointer-events-none (invisible,
+            not clickable). The rendered overlay sits on top with
+            pointer-events-auto, intercepting clicks. On click, we map the
+            rendered position to the raw-text position via caretRangeFromPoint,
+            then focus the textarea and set the caret precisely. */}
+        <div className={`relative ${isStacked ? "w-full" : "flex-1"}`}>
+          <textarea
+            ref={(el) => {
+              internalTextareaRef.current = el;
+              if (textareaRef) textareaRef(el);
+            }}
+            defaultValue={entry.text}
+            onChange={handleTextChange}
+            onKeyDown={handleKeyDown}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            placeholder={
+              isChoice
+                ? "Choice text..."
+                : entry.speakerId
+                  ? "Dialogue..."
+                  : "Narration..."
+            }
+            className={`min-h-[2.5rem] w-full p-0 pr-7 resize-none overflow-hidden bg-transparent border-0 outline-none focus-visible:outline-none focus-visible:ring-0 font-light tracking-normal leading-8 placeholder:text-muted-foreground/50 ${
+              isFocused
+                ? "opacity-100 pointer-events-auto"
+                : "opacity-0 pointer-events-none"
+            }`}
+            aria-label={
+              isChoice
+                ? "Choice text"
+                : entry.speakerId
+                  ? "Dialogue text"
+                  : "Narration text"
+            }
+            aria-hidden={!isFocused}
+            tabIndex={isFocused ? 0 : -1}
+            style={{
+              fontSize: "var(--prose-editor-font-size, 16px)",
+              fontFamily: "var(--prose-editor-font-family, var(--font-sans))",
+              fontStyle: !entry.speakerId ? "italic" : "normal",
+              color: "hsl(var(--foreground))",
+            }}
+          />
+          {!isFocused && (
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={handleRenderedLineClick}
+              onKeyDown={handleRenderedLineKeyDown}
+              data-rendered-line-wrapper="true"
+              aria-label={
+                isChoice
+                  ? "Edit choice text"
+                  : entry.speakerId
+                    ? "Edit dialogue text"
+                    : "Edit narration text"
+              }
+              className="absolute inset-0 pr-7 cursor-text leading-8 outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm overflow-hidden"
+              style={{
+                fontSize: "var(--prose-editor-font-size, 16px)",
+                fontFamily: "var(--prose-editor-font-family, var(--font-sans))",
+                fontStyle: !entry.speakerId ? "italic" : "normal",
+                color: "hsl(var(--foreground))",
+              }}
+            >
+              <RenderedLine
+                tokens={renderedTokens}
+                className="font-light tracking-normal leading-8"
+              />
+            </div>
+          )}
+        </div>
 
         {/* Delete Button */}
         {showDelete && (

--- a/apps/frontend/src/components/write-mode/RenderedLine.tsx
+++ b/apps/frontend/src/components/write-mode/RenderedLine.tsx
@@ -1,0 +1,266 @@
+/**
+ * RenderedLine Component
+ *
+ * Pure presentational component that renders a Ren'Py dialogue line with
+ * visual formatting. Formatting tags ({b}, {i}, {color=...}, etc.) are
+ * hidden — only the styled content is shown. This gives a clean reading
+ * experience at the cost of a minor layout shift when switching to the
+ * raw textarea on focus.
+ *
+ * What's visible in the rendered output:
+ * - Text content with formatting applied (bold, italic, color, etc.)
+ * - Variable interpolation [name] — shown in the theme's variable color
+ *   (it's content, not formatting)
+ * - Malformed tags — shown in the theme's destructive color (errors the
+ *   writer needs to see)
+ *
+ * What's hidden:
+ * - Open/close tags: {b}, {/b}, {color=#f00}, {/color}, etc.
+ * - Self-closing tags: {w}, {p}, {nw}, etc.
+ * - Newline escapes: \n (rendered as actual line break via whitespace-pre-wrap)
+ *
+ * **Coupling note:** Each rendered span carries `data-raw-start` and
+ * `data-raw-len` attributes so `DialogueLine.getRawOffsetFromPoint` can map
+ * a click on the rendered overlay to a caret position in the raw textarea.
+ * This is a deliberate inter-component contract — keep the attribute names
+ * and semantics in sync if either side changes.
+ */
+
+import React from "react";
+import type { RenpyToken, RenpyTag } from "@/lib/renpy-tags";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface RenderedLineProps {
+  /** Token stream from `tokenize()`. */
+  tokens: RenpyToken[];
+  /** Optional CSS class for the outermost container. */
+  className?: string;
+}
+
+/**
+ * Render a Ren'Py token stream as formatted text with tags hidden.
+ *
+ * @example
+ *   <RenderedLine tokens={tokenize('{b}Hello{/b} world')} />
+ *   // Renders: <b>Hello</b> world  (bold styled, no visible {b} tags)
+ */
+export function RenderedLine({ tokens, className }: RenderedLineProps) {
+  const nodes = renderTokens(tokens);
+  return (
+    <div
+      className={`whitespace-pre-wrap ${className ?? ""}`}
+      data-rendered-line="true"
+    >
+      {nodes}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+interface ActiveTag {
+  tag: RenpyTag;
+  value?: string;
+}
+
+/**
+ * Single-pass flat rendering. Formatting tags are consumed silently (only
+ * their style effect is applied to subsequent text). Non-formatting tokens
+ * (interpolation, malformed, newline) are rendered visibly.
+ *
+ * Each rendered span carries `data-raw-start` and `data-raw-len` attributes
+ * recording where the span's text sits in the original raw string. This
+ * enables click-position mapping: when the user clicks on the rendered
+ * overlay, we can find the exact character offset in the raw textarea text
+ * (which includes hidden tags), so the caret lands in the right place.
+ *
+ * Span keys are derived from the raw-text position so unchanged spans keep
+ * their DOM nodes across re-renders, reducing flicker on keystroke.
+ */
+function renderTokens(tokens: RenpyToken[]): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  const stack: ActiveTag[] = [];
+  let rawStart = 0;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i]!;
+    const rawLen = t.kind === "text" ? t.value.length : t.raw.length;
+    // Stable across re-renders: a token's raw position + kind is unique
+    // within a single tokenization. When the user types, the regenerated
+    // tokens only shift suffixes, so prefix spans keep their identity.
+    const key = `${rawStart}-${t.kind}`;
+
+    switch (t.kind) {
+      case "text":
+        nodes.push(
+          <span
+            key={key}
+            style={computeStyle(stack)}
+            data-raw-start={rawStart}
+            data-raw-len={rawLen}
+          >
+            {t.value}
+          </span>
+        );
+        break;
+
+      case "open":
+        // Hidden — just push the style onto the stack.
+        stack.push({ tag: t.tag, value: t.value });
+        break;
+
+      case "close":
+        // Hidden — pop the style from the stack.
+        popMatchingTag(stack, t.tag);
+        break;
+
+      case "self":
+        // Hidden — self-closing tags have no visible content.
+        break;
+
+      case "newline":
+        // Render as actual whitespace — whitespace-pre-wrap displays it.
+        // Wrapped in a span for position mapping. Note: raw is 2 chars
+        // (e.g. "\n") but rendered as 1 char (actual newline).
+        nodes.push(
+          <span key={key} data-raw-start={rawStart} data-raw-len={rawLen}>
+            {t.raw === "\\t" ? "\t" : "\n"}
+          </span>
+        );
+        break;
+
+      case "interpolation":
+        // Visible — variable references are content, not formatting.
+        // Uses the theme's --muted-foreground color (darker than the body
+        // text) so it reads as a subdued reference rather than syntax noise.
+        nodes.push(
+          <span
+            key={key}
+            style={{
+              ...computeStyle(stack),
+              color: "hsl(var(--muted-foreground))",
+            }}
+            title={`Variable: ${t.name}`}
+            data-raw-start={rawStart}
+            data-raw-len={rawLen}
+          >
+            {t.raw}
+          </span>
+        );
+        break;
+
+      case "malformed":
+        // Visible — errors need attention. Uses the theme's `--destructive`
+        // so it respects light/dark themes.
+        nodes.push(
+          <span
+            key={key}
+            style={{ color: "hsl(var(--destructive))" }}
+            title={`Malformed: ${t.raw}`}
+            data-raw-start={rawStart}
+            data-raw-len={rawLen}
+          >
+            {t.raw}
+          </span>
+        );
+        break;
+    }
+
+    rawStart += rawLen;
+  }
+
+  return nodes;
+}
+
+// ---------------------------------------------------------------------------
+// Style computation
+// ---------------------------------------------------------------------------
+
+function computeStyle(stack: ActiveTag[]): React.CSSProperties {
+  const style: React.CSSProperties = {};
+  const decorations: string[] = [];
+
+  for (const { tag, value } of stack) {
+    switch (tag) {
+      case "b":
+        style.fontWeight = "bold";
+        break;
+      case "i":
+        style.fontStyle = "italic";
+        break;
+      case "u":
+        decorations.push("underline");
+        break;
+      case "s":
+        decorations.push("line-through");
+        break;
+      case "color":
+        if (value) style.color = value;
+        break;
+      case "size": {
+        const fontSize = sizeToFontSize(value);
+        if (fontSize) style.fontSize = fontSize;
+        break;
+      }
+      case "alpha": {
+        const opacity = alphaToOpacity(value);
+        if (opacity !== null) style.opacity = opacity;
+        break;
+      }
+      // `font` references a font file (e.g. "arial.ttf") we can't load in the
+      // browser without a font-face declaration, so we leave it as a no-op
+      // for now. `cps` and the self-closing timing tags (`w`/`p`/`nw`/`fast`/
+      // `clear`/`done`) have no static visual equivalent in Ren'Py and are
+      // also intentionally ignored.
+    }
+  }
+
+  if (decorations.length > 0) {
+    style.textDecorationLine = decorations.join(" ");
+  }
+
+  return style;
+}
+
+/**
+ * Convert a Ren'Py size value to a CSS `font-size`.
+ *
+ * Ren'Py sizes are pixels: `+5`/`-2` are relative to the inherited size,
+ * `24` is absolute. We translate that to a CSS `calc()` so the inherited
+ * font size still drives the base.
+ */
+function sizeToFontSize(value: string | undefined): string | null {
+  if (!value) return null;
+  const n = parseInt(value, 10);
+  if (Number.isNaN(n)) return null;
+  if (value.startsWith("+") || value.startsWith("-")) {
+    const abs = Math.abs(n);
+    const op = n >= 0 ? "+" : "-";
+    return `calc(1em ${op} ${abs}px)`;
+  }
+  return `${n}px`;
+}
+
+/**
+ * Convert a Ren'Py alpha value (0.0..1.0) to a CSS opacity.
+ */
+function alphaToOpacity(value: string | undefined): number | null {
+  if (!value) return null;
+  const a = parseFloat(value);
+  if (Number.isNaN(a)) return null;
+  return Math.max(0, Math.min(1, a));
+}
+
+function popMatchingTag(stack: ActiveTag[], tag: RenpyTag): void {
+  for (let i = stack.length - 1; i >= 0; i--) {
+    if (stack[i]!.tag === tag) {
+      stack.splice(i, 1);
+      return;
+    }
+  }
+}

--- a/apps/frontend/src/components/write-mode/__tests__/DialogueLine.test.tsx
+++ b/apps/frontend/src/components/write-mode/__tests__/DialogueLine.test.tsx
@@ -106,12 +106,22 @@ describe("DialogueLine", () => {
     await user.click(container.querySelector("[data-rendered-line-wrapper]")!);
 
     // Textarea is now visible and accessible.
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea).toBeInTheDocument();
 
     // Rendered line overlay is gone.
     expect(
       container.querySelector("[data-rendered-line]")
     ).not.toBeInTheDocument();
+
+    // The polyfill in test/setup.ts makes caretPositionFromPoint return the
+    // end of the first text node under the rendered-line overlay. For the
+    // 11-char "Hello world" text token (rawLen === renderedLen), the
+    // 1:1 mapping in getRawOffsetFromPoint translates that to raw offset 11,
+    // which handleRenderedLineClick then sets as a collapsed caret via
+    // setSelectionRange(11, 11).
+    expect(textarea.selectionStart).toBe(11);
+    expect(textarea.selectionEnd).toBe(11);
   });
 
   it("hides the textarea visually when blurred again", async () => {

--- a/apps/frontend/src/components/write-mode/__tests__/DialogueLine.test.tsx
+++ b/apps/frontend/src/components/write-mode/__tests__/DialogueLine.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Character } from "@branchforge/shared";
 import type { DialogueEntry } from "@/lib/prose-types";
@@ -22,6 +22,21 @@ const characters: Character[] = [
     updatedAt: "2024-01-01T00:00:00.000Z",
   },
 ];
+
+const renderDialogueLine = (entry: DialogueEntry) =>
+  render(
+    <DialogueLine
+      entry={entry}
+      characters={characters}
+      layoutMode="stacked"
+      index={0}
+      totalEntries={1}
+      onChange={vi.fn()}
+      onDelete={vi.fn()}
+      onMoveUp={vi.fn()}
+      onMoveDown={vi.fn()}
+    />
+  );
 
 describe("DialogueLine", () => {
   it("speaker dropdown options have tabindex=-1 to prevent direct tab navigation", async () => {
@@ -59,5 +74,89 @@ describe("DialogueLine", () => {
     for (const option of screen.getAllByRole("option")) {
       expect(option).toHaveAttribute("tabindex", "-1");
     }
+  });
+
+  it("hides the textarea visually when blurred (default)", () => {
+    const entry: DialogueEntry = {
+      id: "entry-1",
+      speakerId: null,
+      text: "Hello world",
+    };
+
+    const { container } = renderDialogueLine(entry);
+
+    // Textarea is aria-hidden when blurred (excluded from role queries).
+    expect(screen.queryByRole("textbox")).toBeNull();
+
+    // Rendered line overlay is present and keyboard-accessible.
+    expect(container.querySelector("[data-rendered-line]")).toBeInTheDocument();
+  });
+
+  it("focuses the textarea when the rendered line is clicked", async () => {
+    const user = userEvent.setup();
+    const entry: DialogueEntry = {
+      id: "entry-1",
+      speakerId: null,
+      text: "Hello world",
+    };
+
+    const { container } = renderDialogueLine(entry);
+
+    // Click the rendered line overlay to enter edit mode.
+    await user.click(container.querySelector("[data-rendered-line-wrapper]")!);
+
+    // Textarea is now visible and accessible.
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+
+    // Rendered line overlay is gone.
+    expect(
+      container.querySelector("[data-rendered-line]")
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the textarea visually when blurred again", async () => {
+    const user = userEvent.setup();
+    const entry: DialogueEntry = {
+      id: "entry-1",
+      speakerId: null,
+      text: "Hello world",
+    };
+
+    const { container } = renderDialogueLine(entry);
+
+    // Enter edit mode by clicking the overlay.
+    await user.click(container.querySelector("[data-rendered-line-wrapper]")!);
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toBeInTheDocument();
+
+    // Blur the textarea.
+    fireEvent.blur(textarea);
+
+    // Textarea is aria-hidden again, rendered line is back.
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(container.querySelector("[data-rendered-line]")).toBeInTheDocument();
+  });
+
+  it("renders tokenized content in the blurred state", () => {
+    const entry: DialogueEntry = {
+      id: "entry-1",
+      speakerId: null,
+      text: "{b}hello{/b}",
+    };
+
+    const { container } = renderDialogueLine(entry);
+
+    // Tags are hidden — only the styled content "hello" is visible.
+    const renderedLine = container.querySelector("[data-rendered-line]");
+    expect(renderedLine).toBeInTheDocument();
+    expect(renderedLine?.textContent).toBe("hello");
+
+    // The content span has bold styling.
+    const spans = renderedLine?.querySelectorAll(":scope > span");
+    const helloSpan = Array.from(spans ?? []).find(
+      (s) => s.textContent === "hello"
+    );
+    expect(helloSpan).toBeDefined();
+    expect((helloSpan as HTMLElement)?.style.fontWeight).toBe("bold");
   });
 });

--- a/apps/frontend/src/components/write-mode/__tests__/RenderedLine.test.tsx
+++ b/apps/frontend/src/components/write-mode/__tests__/RenderedLine.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * RenderedLine component tests
+ *
+ * Tests the presentational layer with formatting tags HIDDEN.
+ * Only styled content, interpolation, and malformed markers are visible.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { tokenize } from "@/lib/renpy-tags";
+import { RenderedLine } from "../RenderedLine";
+
+function renderTokens(text: string) {
+  const tokens = tokenize(text);
+  return render(<RenderedLine tokens={tokens} />);
+}
+
+/** Get all <span> children of the rendered-line container. */
+function getSpans(container: HTMLElement): HTMLSpanElement[] {
+  const root = container.querySelector("[data-rendered-line]");
+  return Array.from(root?.querySelectorAll(":scope > span") ?? []);
+}
+
+describe("RenderedLine", () => {
+  describe("basic rendering", () => {
+    it("renders empty div for empty tokens", () => {
+      const { container } = render(<RenderedLine tokens={[]} />);
+      const root = container.querySelector("[data-rendered-line]");
+      expect(root).toBeInTheDocument();
+      expect(root?.textContent).toBe("");
+    });
+
+    it("renders plain text", () => {
+      const { container } = renderTokens("Hello, world.");
+      expect(container.querySelector("[data-rendered-line]")?.textContent).toBe(
+        "Hello, world."
+      );
+    });
+
+    it("has whitespace-pre-wrap on container", () => {
+      const { container } = renderTokens("hi");
+      const root = container.querySelector("[data-rendered-line]");
+      expect(root?.className).toMatch(/whitespace-pre-wrap/);
+    });
+
+    it("renders literal \\n escape as a visual line break", () => {
+      const { container } = renderTokens("line1\\nline2");
+      const root = container.querySelector("[data-rendered-line]");
+      // Newline token renders as actual \n (not literal backslash-n)
+      expect(root?.textContent).toBe("line1\nline2");
+    });
+
+    it("renders actual newlines in text", () => {
+      const { container } = renderTokens("line1\nline2");
+      expect(container.textContent).toBe("line1\nline2");
+    });
+
+    it("accepts custom className alongside whitespace-pre-wrap", () => {
+      const { container } = render(
+        <RenderedLine tokens={tokenize("hi")} className="custom-test" />
+      );
+      const root = container.querySelector("[data-rendered-line]");
+      expect(root).toHaveClass("custom-test");
+      expect(root).toHaveClass("whitespace-pre-wrap");
+    });
+  });
+
+  describe("formatting tags are hidden", () => {
+    it("{b}bold{/b} renders just 'bold' (no tag markers)", () => {
+      const { container } = renderTokens("{b}bold{/b}");
+      expect(container.textContent).toBe("bold");
+    });
+
+    it("{i}italic{/i} renders just 'italic'", () => {
+      const { container } = renderTokens("{i}italic{/i}");
+      expect(container.textContent).toBe("italic");
+    });
+
+    it("{color=#f00}red{/color} renders just 'red'", () => {
+      const { container } = renderTokens("{color=#f00}red{/color}");
+      expect(container.textContent).toBe("red");
+    });
+
+    it("self-closing {w} is hidden", () => {
+      const { container } = renderTokens("wait{w}now");
+      expect(container.textContent).toBe("waitnow");
+    });
+
+    it("{size=+5} tags are hidden but content shows", () => {
+      const { container } = renderTokens("{size=+5}big{/size}");
+      expect(container.textContent).toBe("big");
+    });
+
+    it("mixed tags and text: only text is visible", () => {
+      const { container } = renderTokens(
+        "Hello {b}world{/b} and {i}stuff{/i}!"
+      );
+      expect(container.textContent).toBe("Hello world and stuff!");
+    });
+  });
+
+  describe("visual formatting applied to content", () => {
+    it("{b} applies font-weight: bold", () => {
+      const { container } = renderTokens("{b}bold{/b}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "bold");
+      expect(content?.style.fontWeight).toBe("bold");
+    });
+
+    it("{i} applies font-style: italic", () => {
+      const { container } = renderTokens("{i}italic{/i}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "italic");
+      expect(content?.style.fontStyle).toBe("italic");
+    });
+
+    it("{u} applies underline", () => {
+      const { container } = renderTokens("{u}under{/u}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "under");
+      expect(content?.style.textDecorationLine).toContain("underline");
+    });
+
+    it("{s} applies line-through", () => {
+      const { container } = renderTokens("{s}struck{/s}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "struck");
+      expect(content?.style.textDecorationLine).toContain("line-through");
+    });
+
+    it("{color=#f00} applies color", () => {
+      const { container } = renderTokens("{color=#f00}red{/color}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "red");
+      expect(content?.style.color).toBeTruthy();
+    });
+  });
+
+  describe("nested tags", () => {
+    it("applies both styles to inner content", () => {
+      const { container } = renderTokens("{i}{b}text{/b}{/i}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "text");
+      expect(content?.style.fontWeight).toBe("bold");
+      expect(content?.style.fontStyle).toBe("italic");
+    });
+
+    it("hides all tag markers in nested structure", () => {
+      const { container } = renderTokens("{i}hello {b}world{/b}!{/i}");
+      expect(container.textContent).toBe("hello world!");
+    });
+  });
+
+  describe("u + s combined", () => {
+    it("applies both underline and line-through", () => {
+      const { container } = renderTokens("{u}{s}both{/s}{/u}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "both");
+      expect(content?.style.textDecorationLine).toContain("underline");
+      expect(content?.style.textDecorationLine).toContain("line-through");
+    });
+  });
+
+  describe("interpolation (visible)", () => {
+    it("renders [name] with muted foreground color", () => {
+      const { container } = renderTokens("Hello [name]!");
+      expect(container.textContent).toBe("Hello [name]!");
+      const spans = getSpans(container);
+      const interp = spans.find((s) => s.textContent === "[name]");
+      // Uses the design-system --muted-foreground token so it reads as
+      // a subdued reference (darker than body text) and adapts to the
+      // active theme. Assert on the token name rather than a literal
+      // value so the test doesn't break when the palette changes.
+      expect(interp?.style.color).toContain("--muted-foreground");
+    });
+
+    it("interpolation inside formatting tags inherits style", () => {
+      const { container } = renderTokens("{b}[var]{/b}");
+      const spans = getSpans(container);
+      const interp = spans.find((s) => s.textContent === "[var]");
+      expect(interp?.style.fontWeight).toBe("bold");
+    });
+  });
+
+  describe("malformed tags (visible)", () => {
+    it("renders malformed {} using the destructive theme color", () => {
+      const { container } = renderTokens("a{}b");
+      expect(container.textContent).toBe("a{}b");
+      const spans = getSpans(container);
+      const malformed = spans.find((s) => s.textContent === "{}");
+      // Uses the design-system --destructive token so the color adapts to
+      // the active theme (light/dark). We assert on the token name rather
+      // than a literal RGB so the test doesn't break when the palette
+      // changes.
+      expect(malformed?.style.color).toContain("--destructive");
+    });
+  });
+
+  describe("size and alpha tags", () => {
+    it("{size=+5} applies a relative font-size offset", () => {
+      const { container } = renderTokens("{size=+5}big{/size}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "big");
+      expect(content?.style.fontSize).toBe("calc(1em + 5px)");
+    });
+
+    it("{size=-2} applies a negative relative font-size offset", () => {
+      const { container } = renderTokens("{size=-2}small{/size}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "small");
+      expect(content?.style.fontSize).toBe("calc(1em - 2px)");
+    });
+
+    it("{size=24} applies an absolute pixel size", () => {
+      const { container } = renderTokens("{size=24}abs{/size}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "abs");
+      expect(content?.style.fontSize).toBe("24px");
+    });
+
+    it("{alpha=0.5} sets opacity to 0.5", () => {
+      const { container } = renderTokens("{alpha=0.5}ghost{/alpha}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "ghost");
+      expect(content?.style.opacity).toBe("0.5");
+    });
+
+    it("{alpha=2.0} clamps to opacity 1", () => {
+      const { container } = renderTokens("{alpha=2.0}bright{/alpha}");
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "bright");
+      expect(content?.style.opacity).toBe("1");
+    });
+  });
+
+  describe("newline rendering", () => {
+    it("\\n creates a visual line break", () => {
+      const { container } = renderTokens("a\\nb");
+      expect(container.textContent).toBe("a\nb");
+    });
+
+    it("\\n inside tags still breaks", () => {
+      const { container } = renderTokens("{b}line1\\nline2{/b}");
+      expect(container.textContent).toBe("line1\nline2");
+    });
+
+    it("multiple \\n create multiple breaks", () => {
+      const { container } = renderTokens("a\\nb\\nc");
+      expect(container.textContent).toBe("a\nb\nc");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("renders content when open tag is never closed", () => {
+      const { container } = renderTokens("{b}never closed");
+      expect(container.textContent).toBe("never closed");
+      // Content should still be bold
+      const spans = getSpans(container);
+      const content = spans.find((s) => s.textContent === "never closed");
+      expect(content?.style.fontWeight).toBe("bold");
+    });
+
+    it("unmatched close is silently ignored", () => {
+      const { container } = renderTokens("text {/b}");
+      // Just the text is shown, close tag is hidden
+      expect(container.textContent).toBe("text ");
+    });
+
+    it("handles the canonical issue #137 example", () => {
+      const input =
+        '"This is {b}very important{/b} and {color=#f00}red text{/color}."';
+      const { container } = renderTokens(input);
+      // Tags hidden, only text + quote marks visible
+      expect(container.textContent).toBe(
+        '"This is very important and red text."'
+      );
+      // Bold content styled
+      const spans = getSpans(container);
+      const boldContent = spans.find((s) => s.textContent === "very important");
+      expect(boldContent?.style.fontWeight).toBe("bold");
+    });
+
+    it("handles mixed content: tags, interpolation, and self-closing", () => {
+      const { container } = renderTokens("{b}[name]{/b}{w}!");
+      // Tags and {w} hidden, interpolation and ! visible
+      expect(container.textContent).toBe("[name]!");
+    });
+  });
+});

--- a/apps/frontend/src/lib/renpy-tags.ts
+++ b/apps/frontend/src/lib/renpy-tags.ts
@@ -1,0 +1,393 @@
+/**
+ * Ren'Py text tag tokenizer.
+ *
+ * Ren'Py dialogue text can contain inline tags in curly braces that control
+ * styling, timing, and flow. Examples:
+ *   {b}bold{/b}            - bold
+ *   {color=#f00}red{/color} - red text
+ *   {size=+5}big{/size}    - larger text
+ *   {w}                    - pause (self-closing)
+ *   [variable]             - interpolation (handled separately)
+ *
+ * This module produces a flat stream of tokens that the UI can render. It is
+ * deliberately **lossless** with respect to the source string: re-stringifying
+ * the tokens yields the original input byte-for-byte. Anything we cannot
+ * recognize round-trips as `text` (the literal characters) plus a `malformed`
+ * marker on the enclosing token so the UI can show a warning.
+ *
+ * Variable interpolation (`[name]`) is **not** treated as a tag — it is its own
+ * token type so the UI can render it as a variable reference.
+ *
+ * Reference (v1 scope): b, i, u, s, color, size, font, alpha, cps, w, p, nw,
+ * fast, clear, done. Self-closing tags have no `/` form.
+ */
+
+export type RenpyToken =
+  | { kind: "text"; value: string }
+  | { kind: "open"; tag: RenpyTag; raw: string; value?: string }
+  | { kind: "close"; tag: RenpyTag; raw: string }
+  | { kind: "self"; tag: RenpySelfTag; raw: string }
+  | { kind: "interpolation"; name: string; raw: string }
+  | { kind: "newline"; raw: string }
+  | { kind: "malformed"; raw: string };
+
+/** Tags that have a matching close tag (`{/tag}`). */
+export type RenpyTag =
+  | "b"
+  | "i"
+  | "u"
+  | "s"
+  | "color"
+  | "size"
+  | "font"
+  | "alpha"
+  | "cps";
+
+/** Tags that stand alone (no close form). */
+export type RenpySelfTag = "w" | "p" | "nw" | "fast" | "clear" | "done";
+
+const CLOSEABLE_TAGS: ReadonlySet<RenpyTag> = new Set<RenpyTag>([
+  "b",
+  "i",
+  "u",
+  "s",
+  "color",
+  "size",
+  "font",
+  "alpha",
+  "cps",
+]);
+
+const SELF_TAGS: ReadonlySet<RenpySelfTag> = new Set<RenpySelfTag>([
+  "w",
+  "p",
+  "nw",
+  "fast",
+  "clear",
+  "done",
+]);
+
+/**
+ * Tokenize a single line of Ren'Py dialogue text.
+ *
+ * The tokenizer is single-pass and character-based. It does not validate
+ * nesting balance — a missing close is just a raw `text` span followed by the
+ * remaining text. Unknown tags are emitted as `open` tokens with `tag` set to
+ * a synthetic `unknown` value... actually, to preserve losslessness, unknown
+ * tags are emitted as `text` for the `{...}` and the consumer can show them
+ * verbatim. To keep the type surface small, we treat unknown braces as
+ * `malformed` and include the literal characters in `raw`.
+ *
+ * @example
+ *   tokenize("Hi {b}there{/b}!")
+ *   // [
+ *   //   { kind: "text", value: "Hi " },
+ *   //   { kind: "open", tag: "b", raw: "{b}" },
+ *   //   { kind: "text", value: "there" },
+ *   //   { kind: "close", tag: "b", raw: "{/b}" },
+ *   //   { kind: "text", value: "!" },
+ *   // ]
+ */
+export function tokenize(input: string): RenpyToken[] {
+  const tokens: RenpyToken[] = [];
+  let i = 0;
+  let textStart = 0;
+  const flushText = (end: number): void => {
+    if (end > textStart) {
+      tokens.push({ kind: "text", value: input.slice(textStart, end) });
+    }
+  };
+
+  while (i < input.length) {
+    const ch = input[i]!;
+
+    // Escape sequences: \n (newline), \t (tab).
+    // These are literal two-character sequences in the source text that
+    // should render as actual whitespace in the prose editor.
+    if (ch === "\\" && i + 1 < input.length) {
+      const next = input[i + 1]!;
+      if (next === "n") {
+        flushText(i);
+        tokens.push({ kind: "newline", raw: "\\n" });
+        i += 2;
+        textStart = i;
+        continue;
+      }
+      if (next === "t") {
+        flushText(i);
+        tokens.push({ kind: "newline", raw: "\\t" });
+        i += 2;
+        textStart = i;
+        continue;
+      }
+      // Other backslash sequences: treat as literal text.
+    }
+
+    // Variable interpolation: [name] — letters, digits, underscore, dot.
+    if (ch === "[") {
+      const close = findInterpolationClose(input, i + 1);
+      if (close !== -1) {
+        const name = input.slice(i + 1, close);
+        if (isValidInterpolationName(name)) {
+          flushText(i);
+          tokens.push({
+            kind: "interpolation",
+            name,
+            raw: input.slice(i, close + 1),
+          });
+          i = close + 1;
+          textStart = i;
+          continue;
+        }
+      }
+      // Fall through — treat as literal '['.
+    }
+
+    // Tag: { ... }
+    if (ch === "{") {
+      const close = findTagClose(input, i + 1);
+      if (close !== -1) {
+        const raw = input.slice(i, close + 1);
+        const inner = input.slice(i + 1, close);
+
+        if (isWellFormedTagInner(inner)) {
+          flushText(i);
+          const token = parseTag(inner, raw);
+          if (token) {
+            tokens.push(token);
+          } else {
+            // Well-formed shape but unrecognized tag name (e.g. `{whatever}`).
+            // Keep as text so the user sees the literal characters — this
+            // preserves losslessness and lets unknown-but-valid Ren'Py tags
+            // render neutrally in the prose editor.
+            tokens.push({ kind: "text", value: raw });
+          }
+          i = close + 1;
+          textStart = i;
+          continue;
+        }
+
+        // Malformed: braces present but inner is not a valid tag shape.
+        flushText(i);
+        tokens.push({ kind: "malformed", raw });
+        i = close + 1;
+        textStart = i;
+        continue;
+      }
+
+      // Unterminated `{` — treat the rest of the line as literal text.
+      break;
+    }
+
+    i++;
+  }
+
+  flushText(input.length);
+  return coalesceAdjacentText(tokens);
+}
+
+/**
+ * Re-stringify tokens back into the original source. Used by tests to assert
+ * losslessness and by future export logic if a consumer ever mutates tokens
+ * (e.g. a hover preview that strips styling).
+ */
+export function stringify(tokens: RenpyToken[]): string {
+  return tokens
+    .map((t) => {
+      switch (t.kind) {
+        case "text":
+          return t.value;
+        case "malformed":
+        case "open":
+        case "close":
+        case "self":
+        case "interpolation":
+        case "newline":
+          return t.raw;
+      }
+    })
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the matching `}` for a tag starting after position `start`. Returns the
+ * index of the `}` or -1 if no valid terminator is found before end-of-string
+ * or before a stray `{` (Ren'Py does not allow nesting braces inside a tag).
+ */
+function findTagClose(input: string, start: number): number {
+  for (let j = start; j < input.length; j++) {
+    const c = input[j]!;
+    if (c === "}") return j;
+    if (c === "{") return -1;
+    if (c === "\n" || c === "\r") return -1;
+  }
+  return -1;
+}
+
+/**
+ * Find the matching `]` for a `[name]` interpolation. Returns the index of
+ * the `]` or -1. Allows alphanumerics, underscore, and dot inside the name.
+ */
+function findInterpolationClose(input: string, start: number): number {
+  if (start >= input.length) return -1;
+  for (let j = start; j < input.length; j++) {
+    const c = input[j]!;
+    if (c === "]") {
+      // Must have at least one char of name and not be empty `[]`.
+      return j > start ? j : -1;
+    }
+    if (
+      !(
+        (c >= "a" && c <= "z") ||
+        (c >= "A" && c <= "Z") ||
+        (c >= "0" && c <= "9") ||
+        c === "_" ||
+        c === "."
+      )
+    ) {
+      return -1;
+    }
+  }
+  return -1;
+}
+
+function isValidInterpolationName(name: string): boolean {
+  if (name.length === 0) return false;
+  // First char must be a letter or underscore (matches Python identifier rules
+  // for what Ren'Py authors typically use).
+  const first = name[0]!;
+  if (
+    !(
+      (first >= "a" && first <= "z") ||
+      (first >= "A" && first <= "Z") ||
+      first === "_"
+    )
+  ) {
+    return false;
+  }
+  for (let k = 1; k < name.length; k++) {
+    const c = name[k]!;
+    if (
+      !(
+        (c >= "a" && c <= "z") ||
+        (c >= "A" && c <= "Z") ||
+        (c >= "0" && c <= "9") ||
+        c === "_" ||
+        c === "."
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Classify a tag name string into the typed union, or null if it isn't a
+ * recognized tag. We do this in one place so `isValidTagInner` and
+ * `parseTag` don't fight over a `string` vs `RenpyTag` boundary.
+ */
+function classifyTagName(name: string): RenpyTag | RenpySelfTag | null {
+  if (CLOSEABLE_TAGS.has(name as RenpyTag)) return name as RenpyTag;
+  if (SELF_TAGS.has(name as RenpySelfTag)) return name as RenpySelfTag;
+  return null;
+}
+
+/**
+ * A tag's interior is well-formed if it matches one of:
+ *   - a bare tag name (e.g. `b`, `w`, `whatever`)
+ *   - a tag name with `=value` (e.g. `color=#f00`, `size=+5`, `font=arial.ttf`)
+ *   - a closing tag (`/b`, `/color`)
+ *
+ * Note: this only checks *shape*, not whether the tag name is recognized.
+ * Unknown-but-well-formed tags (e.g. `{whatever}`) round-trip as a `text`
+ * token so the user sees the literal characters — they may be using a
+ * Ren'Py feature outside our known set, or pasting from elsewhere.
+ * Truly malformed input (empty `{}`, `{b=}`, unterminated) becomes a
+ * `malformed` token for the UI to flag.
+ */
+function isWellFormedTagInner(inner: string): boolean {
+  if (inner.length === 0) return false;
+
+  if (inner.startsWith("/")) {
+    return isBareTagName(inner.slice(1));
+  }
+
+  const eq = inner.indexOf("=");
+  if (eq === -1) {
+    return isBareTagName(inner);
+  }
+
+  const name = inner.slice(0, eq);
+  const value = inner.slice(eq + 1);
+  if (!isBareTagName(name)) return false;
+  if (value.length === 0) return false;
+  return true;
+}
+
+function isBareTagName(s: string): boolean {
+  if (s.length === 0) return false;
+  for (let k = 0; k < s.length; k++) {
+    const c = s[k]!;
+    if (
+      !(
+        (c >= "a" && c <= "z") ||
+        (c >= "A" && c <= "Z") ||
+        (c >= "0" && c <= "9")
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function parseTag(inner: string, raw: string): RenpyToken | null {
+  if (inner.startsWith("/")) {
+    const name = inner.slice(1);
+    if (CLOSEABLE_TAGS.has(name as RenpyTag)) {
+      return { kind: "close", tag: name as RenpyTag, raw };
+    }
+    return null;
+  }
+
+  const eq = inner.indexOf("=");
+  if (eq === -1) {
+    const classified = classifyTagName(inner);
+    if (classified === null) return null;
+    if (SELF_TAGS.has(classified as RenpySelfTag)) {
+      return { kind: "self", tag: classified as RenpySelfTag, raw };
+    }
+    return { kind: "open", tag: classified as RenpyTag, raw };
+  }
+
+  const name = inner.slice(0, eq);
+  const value = inner.slice(eq + 1);
+  if (CLOSEABLE_TAGS.has(name as RenpyTag)) {
+    return { kind: "open", tag: name as RenpyTag, raw, value };
+  }
+  return null;
+}
+
+/**
+ * Merge runs of adjacent `text` tokens into a single token. This is a
+ * postprocessing pass for the common case of text surrounding an unknown
+ * well-formed tag (e.g. `"Hi {whatever} there"`), where the loop naturally
+ * emits three text tokens. Consumers should never see fragmented text spans.
+ */
+function coalesceAdjacentText(tokens: RenpyToken[]): RenpyToken[] {
+  const out: RenpyToken[] = [];
+  for (const t of tokens) {
+    const last = out.at(-1);
+    if (t.kind === "text" && last?.kind === "text") {
+      last.value += t.value;
+    } else {
+      out.push(t);
+    }
+  }
+  return out;
+}

--- a/apps/frontend/src/lib/renpy-tags.unit.test.ts
+++ b/apps/frontend/src/lib/renpy-tags.unit.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect } from "vitest";
+import { tokenize, stringify, type RenpyToken } from "@/lib/renpy-tags";
+
+/** Convenience: tokenize + stringify and assert round-trip equality. */
+function expectRoundTrip(input: string): void {
+  const tokens = tokenize(input);
+  expect(stringify(tokens)).toBe(input);
+}
+
+describe("renpy-tags tokenize", () => {
+  describe("plain text", () => {
+    it("returns no tokens for empty input", () => {
+      expect(tokenize("")).toEqual([]);
+    });
+
+    it("returns a single text token for input without tags", () => {
+      expect(tokenize("Hello, world.")).toEqual([
+        { kind: "text", value: "Hello, world." },
+      ]);
+    });
+
+    it("preserves whitespace and punctuation", () => {
+      expect(tokenize("  Hi!  Bye.  ")).toEqual([
+        { kind: "text", value: "  Hi!  Bye.  " },
+      ]);
+    });
+  });
+
+  describe("closeable tags (b / i / u / s)", () => {
+    it.each(["b", "i", "u", "s"] as const)("handles {%s}...{/%s}", (tag) => {
+      const input = `This is {${tag}}styled{/${tag}} text.`;
+      expect(tokenize(input)).toEqual([
+        { kind: "text", value: "This is " },
+        { kind: "open", tag, raw: `{${tag}}` },
+        { kind: "text", value: "styled" },
+        { kind: "close", tag, raw: `{/${tag}}` },
+        { kind: "text", value: " text." },
+      ]);
+    });
+
+    it("handles adjacent same-tag spans", () => {
+      const input = "{b}a{/b}{b}b{/b}";
+      expect(tokenize(input)).toEqual([
+        { kind: "open", tag: "b", raw: "{b}" },
+        { kind: "text", value: "a" },
+        { kind: "close", tag: "b", raw: "{/b}" },
+        { kind: "open", tag: "b", raw: "{b}" },
+        { kind: "text", value: "b" },
+        { kind: "close", tag: "b", raw: "{/b}" },
+      ]);
+    });
+  });
+
+  describe("parameterized closeable tags", () => {
+    it("handles {color=#f00}", () => {
+      const input = "{color=#f00}red{/color}";
+      expect(tokenize(input)).toEqual([
+        { kind: "open", tag: "color", raw: "{color=#f00}", value: "#f00" },
+        { kind: "text", value: "red" },
+        { kind: "close", tag: "color", raw: "{/color}" },
+      ]);
+    });
+
+    it("handles {size=+5} with signed value", () => {
+      const input = "{size=+5}big{/size}";
+      const tokens = tokenize(input);
+      expect(tokens[0]).toEqual({
+        kind: "open",
+        tag: "size",
+        raw: "{size=+5}",
+        value: "+5",
+      });
+      expectRoundTrip(input);
+    });
+
+    it("handles {font=arial.ttf} with dots in value", () => {
+      const input = "{font=arial.ttf}hi{/font}";
+      const tokens = tokenize(input);
+      expect(tokens[0]).toEqual({
+        kind: "open",
+        tag: "font",
+        raw: "{font=arial.ttf}",
+        value: "arial.ttf",
+      });
+      expectRoundTrip(input);
+    });
+
+    it("handles {alpha=0.5}", () => {
+      const input = "{alpha=0.5}ghost{/alpha}";
+      const tokens = tokenize(input);
+      expect(tokens[0]).toEqual({
+        kind: "open",
+        tag: "alpha",
+        raw: "{alpha=0.5}",
+        value: "0.5",
+      });
+      expectRoundTrip(input);
+    });
+
+    it("handles {cps=20}", () => {
+      const input = "{cps=20}slow{/cps}";
+      const tokens = tokenize(input);
+      expect(tokens[0]).toEqual({
+        kind: "open",
+        tag: "cps",
+        raw: "{cps=20}",
+        value: "20",
+      });
+      expectRoundTrip(input);
+    });
+  });
+
+  describe("self-closing tags (w / p / nw / fast / clear / done)", () => {
+    it.each(["w", "p", "nw", "fast", "clear", "done"] as const)(
+      "handles {%s}",
+      (tag) => {
+        const input = `Before {${tag}} after`;
+        expect(tokenize(input)).toEqual([
+          { kind: "text", value: "Before " },
+          { kind: "self", tag, raw: `{${tag}}` },
+          { kind: "text", value: " after" },
+        ]);
+      }
+    );
+
+    it("does not treat {w} as a closeable tag", () => {
+      // {w} is self-closing. A literal `{/w}` is well-formed shape but
+      // `w` isn't a known closeable tag, so it round-trips as text rather
+      // than a `close` token. The tokenizer coalesces adjacent text runs.
+      const input = "{w}pause{/w}";
+      const tokens = tokenize(input);
+      expect(tokens[0]).toEqual({ kind: "self", tag: "w", raw: "{w}" });
+      expect(tokens).toEqual([
+        { kind: "self", tag: "w", raw: "{w}" },
+        { kind: "text", value: "pause{/w}" },
+      ]);
+    });
+  });
+
+  describe("escape sequences", () => {
+    it("tokenizes \\n as a newline token", () => {
+      const tokens = tokenize("line1\\nline2");
+      expect(tokens).toEqual([
+        { kind: "text", value: "line1" },
+        { kind: "newline", raw: "\\n" },
+        { kind: "text", value: "line2" },
+      ]);
+    });
+
+    it("tokenizes \\t as a newline token (tab)", () => {
+      const tokens = tokenize("a\\tb");
+      expect(tokens).toEqual([
+        { kind: "text", value: "a" },
+        { kind: "newline", raw: "\\t" },
+        { kind: "text", value: "b" },
+      ]);
+    });
+
+    it("handles \\n inside tags", () => {
+      const input = "{b}bold\\nline2{/b}";
+      expectRoundTrip(input);
+      const tokens = tokenize(input);
+      expect(tokens[2]).toEqual({ kind: "newline", raw: "\\n" });
+    });
+
+    it("does not treat lone backslash as escape", () => {
+      expect(tokenize("a\\b")).toEqual([{ kind: "text", value: "a\\b" }]);
+    });
+
+    it("does not treat \\x (unknown escape) as escape", () => {
+      expect(tokenize("a\\xb")).toEqual([{ kind: "text", value: "a\\xb" }]);
+    });
+
+    it("round-trips \\n correctly", () => {
+      expectRoundTrip("line1\\nline2\\nline3");
+    });
+  });
+
+  describe("nested tags", () => {
+    it("handles bold-inside-italic", () => {
+      const input = "{i}hello {b}world{/b}!{/i}";
+      const tokens = tokenize(input);
+      expect(tokens).toEqual([
+        { kind: "open", tag: "i", raw: "{i}" },
+        { kind: "text", value: "hello " },
+        { kind: "open", tag: "b", raw: "{b}" },
+        { kind: "text", value: "world" },
+        { kind: "close", tag: "b", raw: "{/b}" },
+        { kind: "text", value: "!" },
+        { kind: "close", tag: "i", raw: "{/i}" },
+      ]);
+    });
+
+    it("handles color-inside-italic", () => {
+      const input = "{i}{color=#f00}red{/color} normal{/i}";
+      expectRoundTrip(input);
+    });
+  });
+
+  describe("variable interpolation", () => {
+    it("tokenizes [name] as an interpolation", () => {
+      const input = "Hello [player_name]!";
+      expect(tokenize(input)).toEqual([
+        { kind: "text", value: "Hello " },
+        { kind: "interpolation", name: "player_name", raw: "[player_name]" },
+        { kind: "text", value: "!" },
+      ]);
+    });
+
+    it("handles dotted interpolation names", () => {
+      const input = "Score: [player.score]";
+      expect(tokenize(input)).toEqual([
+        { kind: "text", value: "Score: " },
+        { kind: "interpolation", name: "player.score", raw: "[player.score]" },
+      ]);
+    });
+
+    it("treats a leading-digit interpolation as literal text", () => {
+      // [1bad] — first char is a digit, so per Python identifier rules this
+      // isn't a valid name. Fall back to literal '['.
+      const tokens = tokenize("a[1bad]b");
+      expect(tokens).toEqual([{ kind: "text", value: "a[1bad]b" }]);
+    });
+
+    it("treats empty [] as literal text", () => {
+      expect(tokenize("a[]b")).toEqual([{ kind: "text", value: "a[]b" }]);
+    });
+
+    it("interpolation can sit between tags", () => {
+      const input = "{b}[name]{/b}";
+      expect(tokenize(input)).toEqual([
+        { kind: "open", tag: "b", raw: "{b}" },
+        { kind: "interpolation", name: "name", raw: "[name]" },
+        { kind: "close", tag: "b", raw: "{/b}" },
+      ]);
+    });
+  });
+
+  describe("unknown and malformed tags", () => {
+    it("treats unknown tag as text (preserves raw characters)", () => {
+      // {whatever} is not in our known set — emit as a single text token so
+      // the user sees the literal `{whatever}` in the prose editor.
+      const input = "Hi {whatever} there";
+      expect(tokenize(input)).toEqual([
+        { kind: "text", value: "Hi {whatever} there" },
+      ]);
+    });
+
+    it("treats unknown close as text (preserves raw characters)", () => {
+      // `{/nope}` is well-formed shape (`/name`), but `nope` isn't a
+      // recognized closeable tag. Round-trip as text rather than malformed
+      // so the user sees the literal characters.
+      const input = "a{/nope}b";
+      expect(tokenize(input)).toEqual([{ kind: "text", value: "a{/nope}b" }]);
+    });
+
+    it("treats {b} (no name) as malformed", () => {
+      const tokens = tokenize("a{}b");
+      expect(tokens).toEqual([
+        { kind: "text", value: "a" },
+        { kind: "malformed", raw: "{}" },
+        { kind: "text", value: "b" },
+      ]);
+    });
+
+    it("treats {b=} (empty value) as malformed", () => {
+      const tokens = tokenize("a{b=}b");
+      expect(tokens).toEqual([
+        { kind: "text", value: "a" },
+        { kind: "malformed", raw: "{b=}" },
+        { kind: "text", value: "b" },
+      ]);
+    });
+
+    it("treats unterminated { as literal text", () => {
+      // No closing brace — tokenizer should not loop forever, and the
+      // remainder is treated as literal.
+      const tokens = tokenize("hello {b world");
+      expect(tokens).toEqual([{ kind: "text", value: "hello {b world" }]);
+    });
+
+    it("treats { on its own as literal text", () => {
+      expect(tokenize("a{b")).toEqual([{ kind: "text", value: "a{b" }]);
+    });
+
+    it("treats nested { inside a tag as malformed (no close found)", () => {
+      // {{b} — the inner `{` aborts the tag search, so the outer `{` is
+      // unterminated and the whole thing is text.
+      const tokens = tokenize("a{{b} rest");
+      expect(tokens).toEqual([{ kind: "text", value: "a{{b} rest" }]);
+    });
+
+    it("does not crash on newline inside a tag (treats as unterminated)", () => {
+      const tokens = tokenize("a{b\n}c");
+      expect(tokens[0]).toEqual({ kind: "text", value: "a{b\n}c" });
+    });
+  });
+
+  describe("round-trip (lossless)", () => {
+    it.each([
+      "Hello, world.",
+      "This is {b}bold{/b} and {i}fancy{/i}.",
+      "{color=#f00}Red{/color} and {color=#0f0}green{/color}.",
+      "{size=+5}Big{/size} or {size=-2}small{/size}.",
+      "{font=arial.ttf}Fancy{/font}.",
+      "Wait{w}then continue{nw}now.",
+      "Hello [player_name]!",
+      "{b}[name] is {color=#f00}red{/color}{w}!{/b}",
+    ])("round-trips %j", (input) => {
+      expectRoundTrip(input);
+    });
+  });
+
+  describe("the issue's example", () => {
+    it("tokenizes the canonical example from the design issue", () => {
+      const input =
+        '"This is {b}very important{/b} and {color=#f00}red text{/color}."';
+      const tokens = tokenize(input);
+      const kinds = tokens.map((t) => t.kind);
+      expect(kinds).toEqual([
+        "text",
+        "open",
+        "text",
+        "close",
+        "text",
+        "open",
+        "text",
+        "close",
+        "text",
+      ]);
+      expectRoundTrip(input);
+    });
+  });
+
+  describe("return type", () => {
+    it("RenpyToken is a discriminated union (compile-time check via assignment)", () => {
+      const tokens: RenpyToken[] = tokenize("{b}x{/b}");
+      // If this compiles, the discriminated union is intact.
+      const _exhaustive: RenpyToken = tokens[0]!;
+      expect(_exhaustive).toBeDefined();
+    });
+  });
+});

--- a/apps/frontend/src/test/setup.ts
+++ b/apps/frontend/src/test/setup.ts
@@ -26,6 +26,34 @@ if (typeof HTMLDialogElement !== "undefined") {
   }
 }
 
+// Polyfill Document.caretPositionFromPoint for jsdom.
+// Production click handlers (e.g. DialogueLine.handleRenderedLineClick) use
+// this to map a click on a rendered overlay to a caret offset in the raw
+// textarea text. jsdom doesn't implement it, so without this polyfill the
+// click-to-caret path is never exercised in tests. We find a text node
+// under the rendered-line overlay and return its end-of-text offset so
+// the resulting selection is distinguishable from the "no offset" default.
+if (typeof document.caretPositionFromPoint === "undefined") {
+  document.caretPositionFromPoint = function (_x: number, _y: number) {
+    const wrapper = document.querySelector("[data-rendered-line-wrapper]");
+    if (!wrapper) return null;
+    const span = wrapper.querySelector("[data-raw-start]");
+    const textNode = span?.firstChild;
+    if (
+      !textNode ||
+      textNode.nodeType !== Node.TEXT_NODE ||
+      !textNode.textContent
+    ) {
+      return null;
+    }
+    return {
+      offsetNode: textNode,
+      offset: textNode.textContent.length,
+      getClientRect: () => null,
+    };
+  };
+}
+
 afterEach(() => {
   cleanup();
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Click-to-edit: Click directly on formatted dialogue text to position your cursor
  * Live formatting preview: Dialogue text now displays with applied styles (bold, italic, colors, underline, size) in the editor

* **Tests**
  * Added comprehensive test coverage for dialogue editing and text formatting features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->