### PR TITLE
fix(export): place generated branchforge_*.rpy under game/ and dedupe define/default symbols (#244)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,130 @@ NEVER create hand-written migration files. The only correct workflow:
 
 Bypassing this breaks migration tracking and causes deployment failures.
 
+## Review Checklist
+
+Before opening a PR, walk through this checklist. It is intentionally
+short — the goal is "did I think about the obvious things", not exhaustive
+review (that is the deterministic chain in `pnpm verify` and, for
+sensitive changes, the `@oracle` review pass described in the Pull
+Request Workflow below).
+
+**Scope and shape**
+
+- The diff is scoped to one issue. If scope grew, split it into a
+  follow-up instead of mixing.
+- No commented-out code, debug `console.log`s, or `TODO` left behind.
+
+**Correctness**
+
+- New behavior has at least one test. Bug fixes include a regression
+  test that fails before the fix.
+
+**Docs**
+
+- `AGENTS.md` updated if a new convention, command, or workflow
+  step was introduced.
+
+## Pull Request Workflow
+
+**Default flow for triaged issues: start on a fresh branch from `main`.**
+When you begin work on a triaged issue, do not commit on whatever
+branch is currently checked out. Instead:
+
+1. `git checkout main`
+2. `git pull origin main` (or `git pull` if `main` already tracks
+   `origin/main`)
+3. Create a branch named after the issue, e.g. `<#>-<slug>`
+   (e.g. `123-rate-limit-auth`).
+4. Implement the issue on that branch.
+
+**Exception: in-place fixes on an existing PR.** If a PR is already
+open for the work — including subsequent review iterations on the
+same issue (checklist fixes, `@oracle` findings, CI failures) — push
+to the same branch and PR. "Scope discipline" means "do not mix
+unrelated changes into a PR" — it does not mean "always split
+ad-hoc fixes into a new branch and PR." Only create a new branch
+and PR when the developer explicitly says so, or when the work is
+for a separate, distinct issue that has been triaged in the issue
+tracker.
+
+When the issue assigned to you is implemented and locally verified
+(`pnpm verify` is green), take the work through to a PR that is green
+and ready for human review. Use the `gh` CLI for all GitHub
+interactions. **Never merge the PR yourself — merging is a developer
+decision.**
+
+**Flow:**
+
+1. **Self-review with the checklist above.** Walk through
+   `## Review Checklist`. Fix anything you find before committing.
+2. **Sensitive or high-risk diffs: delegate to `@oracle` before
+   opening the PR.** Use the `@oracle` specialist for a strategic +
+   security review pass if **any** of the following is true:
+   - The diff touches auth, sessions, rate limiting, secrets, or
+     security boundaries.
+   - The diff touches the database layer (schema, migrations,
+     query helpers, audit log).
+   - The diff adds or changes an API route, route handler, or
+     middleware.
+   - The diff is large (rule of thumb: > 200 changed lines, or any
+     single file > 100 changed lines).
+   - You are uncertain about an architectural choice.
+
+   Documentation-only changes (typo fixes, formatting, doc rewording
+   with no security or architectural impact) are exempt from the size
+   and category triggers above — only route to `@oracle` if the doc
+   change is itself a security/architectural decision.
+
+   Pass to `@oracle`: the issue reference, the full diff, the list of
+   files touched, and a one-line description of intent. Address every
+   `must-fix` and `should-fix` finding on the branch, then re-delegate
+   to `@oracle` with the updated diff. **Loop until `@oracle` reports
+   no remaining must-fix or should-fix findings** — only then proceed
+   to open the PR. Any item you intentionally defer must be called
+   out in the PR body with a one-line justification; silently skipping
+   a finding is not acceptable.
+
+3. **Stage and commit** only the intended files. Inspect `git status`
+   and `git diff` first; never commit secrets. Write a concise commit
+   message that matches the repo style (look at recent
+   `git log --oneline -10`).
+4. **Push** the branch: `git push -u origin <branch>`.
+5. **Open a PR** with `gh`:
+   ```bash
+   gh pr create \
+     --base <base-branch> \
+     --title "<short summary>" \
+     --body "<issue reference + what changed + how it was verified + @oracle verdict if applicable>"
+   ```
+   Reference the issue (`Closes #N` or `Fixes #N`) in the body so
+   merging the PR closes the issue.
+6. **Watch status checks**: `gh pr checks --watch` (or poll with
+   `gh pr view <pr> --json statusCheckRollup`). If a check fails, read
+   the logs, fix the underlying cause on the branch, commit, push, and
+   re-watch. Keep iterating until all required checks are green.
+
+   **Exception for CodeRabbit:** Do not wait for CodeRabbit to complete (green or red).
+   Fix all other required checks to green. It is fine to proceed when all other
+   required checks are green and CodeRabbit is still running. The developer will
+   follow up on CodeRabbit separately.
+
+7. **Stop and hand off** when checks are green (except CodeRabbit). Do not run
+   `gh pr merge`, do not enable auto-merge, do not dismiss reviews. The
+   developer reviews and merges.
+
+**Constraints:**
+
+- One PR per issue, scoped tightly. If scope grows, split it into a
+  follow-up.
+- If a check looks flaky or transient, rerun it
+  (`gh pr checks <id> --rerun`) only after confirming the failure is
+  not caused by your change.
+- Do not force-push after a review has started unless explicitly asked.
+- If you are blocked by something only a human can resolve (missing
+  credentials, protected-branch permissions, ambiguous requirements),
+  stop and report the blocker instead of guessing.
+
 ## Agent skills
 
 ### Issue tracker

--- a/apps/backend/src/services/__tests__/export.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/export.service.unit.test.ts
@@ -358,6 +358,250 @@ describe("ExportService", () => {
       expect(generateCharacterDefinitionsFile).toHaveBeenCalledWith(mockChars);
     });
 
+    it("should place generated branchforge_*.rpy files under the common directory prefix", async () => {
+      // Reproduces the regression in issue #244: the three generated
+      // supporting files used to be written at the archive root, so
+      // Ren'Py silently ignored them. The fix is to compute the
+      // shared top-level directory from the project file paths and
+      // place the generated files under it.
+      const mockProject = { name: "Prefixed" };
+      const mockFiles = [
+        {
+          id: "file-1",
+          projectId: PROJECT_ID,
+          filePath: "game/script.rpy",
+          fileType: "STORY",
+          content: "label start:",
+          contentHash: "abc",
+          source: "manual",
+        },
+        {
+          id: "file-2",
+          projectId: PROJECT_ID,
+          filePath: "game/gui.rpy",
+          fileType: "SETTINGS",
+          content: "screen navigation():",
+          contentHash: "def",
+          source: "manual",
+        },
+      ];
+      const mockExportRecord = {
+        id: EXPORT_ID,
+        projectId: PROJECT_ID,
+        format: "RENPY",
+        fileName: "prefixed.zip",
+        content: "",
+        fileSize: 0,
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+      };
+
+      resolveQueue.push(mockFiles); // files
+      resolveQueue.push([]); // labels
+      resolveQueue.push([{ key: "v", description: null, category: null }]);
+      resolveQueue.push([
+        { key: "s", name: "S", minValue: 0, maxValue: 1, description: null },
+      ]);
+      resolveQueue.push([
+        { renpyTag: "e", displayName: "Eileen", color: "#c8ffc8" },
+      ]);
+      resolveQueue.push([]); // cleanup
+
+      mockDb.limit.mockResolvedValueOnce([mockProject]);
+      mockDb.returning.mockResolvedValueOnce([mockExportRecord]);
+
+      // Capture the JSON content the service hands to the DB.
+      mockDb.values.mockImplementationOnce(
+        (vals: { fileName: string; content: string; fileSize: number }) => {
+          mockDb.returning.mockResolvedValueOnce([
+            {
+              id: EXPORT_ID,
+              projectId: PROJECT_ID,
+              format: "RENPY",
+              fileName: vals.fileName,
+              content: vals.content,
+              fileSize: vals.fileSize,
+              createdAt: new Date(),
+            },
+          ]);
+          return mockDb;
+        }
+      );
+
+      await generateExport(PROJECT_ID, USER_ID);
+
+      const insertPayload = mockDb.values.mock.calls[0][0] as {
+        content: string;
+      };
+      const savedContent = JSON.parse(insertPayload.content);
+
+      // The supporting files must live under `game/`, not at the
+      // archive root.
+      expect(savedContent).toHaveProperty("game/branchforge_variables.rpy");
+      expect(savedContent).toHaveProperty("game/branchforge_stats.rpy");
+      expect(savedContent).toHaveProperty("game/branchforge_definitions.rpy");
+      expect(savedContent).not.toHaveProperty("branchforge_variables.rpy");
+      expect(savedContent).not.toHaveProperty("branchforge_stats.rpy");
+      expect(savedContent).not.toHaveProperty("branchforge_definitions.rpy");
+    });
+
+    it("strips define/default lines from project files at export time as a defensive safety net", async () => {
+      // Simulates a project that was imported before issue #244
+      // shipped and therefore still has `define <tag> = Character(...)`
+      // and `default <key> = ...` lines in its stored `content`.
+      // The export must strip them on the way out, otherwise the
+      // generated `branchforge_*.rpy` files would collide with the
+      // user-authored lines and crash Ren'Py with
+      // `NameError: name 'X' is already defined`.
+      const mockProject = { name: "Legacy" };
+      const mockFiles = [
+        {
+          id: "file-1",
+          projectId: PROJECT_ID,
+          filePath: "game/characters.rpy",
+          fileType: "STORY",
+          // Pre-fix style: characters and stat defaults live in
+          // the project files, not in the DB.
+          content: [
+            'define e = Character("Eileen", color="#c8ffc8")',
+            "default affection = 0",
+            "",
+            "label start:",
+            "    return",
+          ].join("\n"),
+          contentHash: "legacy-hash",
+          source: "manual",
+        },
+      ];
+      const mockExportRecord = {
+        id: EXPORT_ID,
+        projectId: PROJECT_ID,
+        format: "RENPY",
+        fileName: "legacy.zip",
+        content: "",
+        fileSize: 0,
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+      };
+
+      resolveQueue.push(mockFiles); // files
+      resolveQueue.push([]); // labels
+      resolveQueue.push([]); // variables
+      resolveQueue.push([]); // stats
+      resolveQueue.push([]); // characters (DB-side, not in the file)
+      resolveQueue.push([]); // cleanup
+
+      mockDb.limit.mockResolvedValueOnce([mockProject]);
+      mockDb.returning.mockResolvedValueOnce([mockExportRecord]);
+
+      mockDb.values.mockImplementationOnce(
+        (vals: { fileName: string; content: string; fileSize: number }) => {
+          mockDb.returning.mockResolvedValueOnce([
+            {
+              id: EXPORT_ID,
+              projectId: PROJECT_ID,
+              format: "RENPY",
+              fileName: vals.fileName,
+              content: vals.content,
+              fileSize: vals.fileSize,
+              createdAt: new Date(),
+            },
+          ]);
+          return mockDb;
+        }
+      );
+
+      await generateExport(PROJECT_ID, USER_ID);
+
+      const insertPayload = mockDb.values.mock.calls[0][0] as {
+        content: string;
+      };
+      const savedContent = JSON.parse(insertPayload.content);
+      // The user file in the zip is clean of `define`/`default`
+      // lines even though the DB has no characters / variables /
+      // stats to generate a branchforge_*.rpy for.
+      expect(savedContent["game/characters.rpy"]).not.toContain(
+        "define e = Character"
+      );
+      expect(savedContent["game/characters.rpy"]).not.toContain(
+        "default affection"
+      );
+      expect(savedContent["game/characters.rpy"]).toContain("label start:");
+    });
+
+    it("should fall back to no prefix when project files have mixed top-level directories", async () => {
+      // If the project mixes top-level directories (e.g. `game/`
+      // and `docs/`) and they disagree, the helper returns "" so we
+      // place the generated files at the archive root. This matches
+      // the GitLab export behaviour.
+      const mockProject = { name: "Mixed" };
+      const mockFiles = [
+        {
+          id: "file-1",
+          projectId: PROJECT_ID,
+          filePath: "game/script.rpy",
+          fileType: "STORY",
+          content: "label start:",
+          contentHash: "abc",
+          source: "manual",
+        },
+        {
+          id: "file-2",
+          projectId: PROJECT_ID,
+          filePath: "docs/readme.rpy",
+          fileType: "SETTINGS",
+          content: "screen about():",
+          contentHash: "def",
+          source: "manual",
+        },
+      ];
+      const mockExportRecord = {
+        id: EXPORT_ID,
+        projectId: PROJECT_ID,
+        format: "RENPY",
+        fileName: "mixed.zip",
+        content: "",
+        fileSize: 0,
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+      };
+
+      resolveQueue.push(mockFiles); // files
+      resolveQueue.push([]); // labels
+      resolveQueue.push([{ key: "v", description: null, category: null }]);
+      resolveQueue.push([]); // stats
+      resolveQueue.push([]); // characters
+      resolveQueue.push([]); // cleanup
+
+      mockDb.limit.mockResolvedValueOnce([mockProject]);
+      mockDb.returning.mockResolvedValueOnce([mockExportRecord]);
+
+      mockDb.values.mockImplementationOnce(
+        (vals: { fileName: string; content: string; fileSize: number }) => {
+          mockDb.returning.mockResolvedValueOnce([
+            {
+              id: EXPORT_ID,
+              projectId: PROJECT_ID,
+              format: "RENPY",
+              fileName: vals.fileName,
+              content: vals.content,
+              fileSize: vals.fileSize,
+              createdAt: new Date(),
+            },
+          ]);
+          return mockDb;
+        }
+      );
+
+      await generateExport(PROJECT_ID, USER_ID);
+
+      const insertPayload = mockDb.values.mock.calls[0][0] as {
+        content: string;
+      };
+      const savedContent = JSON.parse(insertPayload.content);
+      // Variables is the only generated file in this test; with no
+      // common top-level directory it should be at the root.
+      expect(savedContent).toHaveProperty("branchforge_variables.rpy");
+      expect(savedContent).not.toHaveProperty("game/branchforge_variables.rpy");
+    });
+
     it("should throw RateLimitError when rate limited", async () => {
       vi.mocked(checkRateLimit).mockReturnValueOnce({
         allowed: false,

--- a/apps/backend/src/services/__tests__/export.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/export.service.unit.test.ts
@@ -527,6 +527,86 @@ describe("ExportService", () => {
       expect(savedContent["game/characters.rpy"]).toContain("label start:");
     });
 
+    it("ignores unsafe file paths when computing the generated-file directory prefix", async () => {
+      // A file whose `file_path` fails `sanitizeZipEntryPath` (e.g.
+      // contains `..`) must not drag the directory-prefix
+      // calculation off the real project layout. Before the fix,
+      // such a stray entry would force the prefix to "" and place
+      // `branchforge_*.rpy` at the archive root — silently
+      // disabling them in Ren'Py. See issue #244.
+      const mockProject = { name: "Unsafe" };
+      const mockFiles = [
+        {
+          id: "file-1",
+          projectId: PROJECT_ID,
+          filePath: "game/script.rpy",
+          fileType: "STORY",
+          content: "label start:",
+          contentHash: "abc",
+          source: "manual",
+        },
+        {
+          id: "file-2",
+          projectId: PROJECT_ID,
+          // Path-traversal — `sanitizeZipEntryPath` rejects it.
+          filePath: "evil/../escape.rpy",
+          fileType: "STORY",
+          content: "label evil:",
+          contentHash: "def",
+          source: "manual",
+        },
+      ];
+      const mockExportRecord = {
+        id: EXPORT_ID,
+        projectId: PROJECT_ID,
+        format: "RENPY",
+        fileName: "unsafe.zip",
+        content: "",
+        fileSize: 0,
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+      };
+
+      resolveQueue.push(mockFiles); // files
+      resolveQueue.push([]); // labels
+      resolveQueue.push([{ key: "v", description: null, category: null }]);
+      resolveQueue.push([]); // stats
+      resolveQueue.push([]); // characters
+      resolveQueue.push([]); // cleanup
+
+      mockDb.limit.mockResolvedValueOnce([mockProject]);
+      mockDb.returning.mockResolvedValueOnce([mockExportRecord]);
+
+      mockDb.values.mockImplementationOnce(
+        (vals: { fileName: string; content: string; fileSize: number }) => {
+          mockDb.returning.mockResolvedValueOnce([
+            {
+              id: EXPORT_ID,
+              projectId: PROJECT_ID,
+              format: "RENPY",
+              fileName: vals.fileName,
+              content: vals.content,
+              fileSize: vals.fileSize,
+              createdAt: new Date(),
+            },
+          ]);
+          return mockDb;
+        }
+      );
+
+      await generateExport(PROJECT_ID, USER_ID);
+
+      const insertPayload = mockDb.values.mock.calls[0][0] as {
+        content: string;
+      };
+      const savedContent = JSON.parse(insertPayload.content);
+      // The unsafe path was filtered out, so the prefix is `game/`
+      // (not ""), and the generated file lives where Ren'Py will find it.
+      expect(savedContent).toHaveProperty("game/branchforge_variables.rpy");
+      expect(savedContent).not.toHaveProperty("branchforge_variables.rpy");
+      // The unsafe path itself is not in the archive.
+      expect(savedContent).not.toHaveProperty("evil/../escape.rpy");
+    });
+
     it("should fall back to no prefix when project files have mixed top-level directories", async () => {
       // If the project mixes top-level directories (e.g. `game/`
       // and `docs/`) and they disagree, the helper returns "" so we

--- a/apps/backend/src/services/__tests__/rpy-statements.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/rpy-statements.service.unit.test.ts
@@ -179,6 +179,46 @@ describe("rpy-statements.service", () => {
       expect(result.cleanedContent).not.toMatch(/^define\s/m);
     });
 
+    it("handles a space between Character and the opening parenthesis", () => {
+      // Ren'Py accepts `Character (` (with a space) just as readily
+      // as `Character(`. The regex permits both via `\s*`; the body
+      // extraction must match the same whitespace tolerance, or
+      // such lines would be silently dropped because the body
+      // slice starts at `indexOf("Character(")`.
+      const content = [
+        'define e = Character ("Eileen", color="#c8ffc8")',
+        "",
+        "label start:",
+        '    e "Hello."',
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.characters).toEqual([
+        { tag: "e", name: "Eileen", color: "#c8ffc8" },
+      ]);
+      expect(result.cleanedContent).not.toContain("define e = Character");
+      expect(result.cleanedContent).toContain("label start:");
+
+      // Same expectation for the multi-line form: whitespace between
+      // `Character` and `(` is allowed.
+      const multiLine = [
+        "define s = Character (",
+        '    "Sylvie",',
+        '    color="#ff0000"',
+        ")",
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const multi = extractAndStripRpySymbols(multiLine);
+      expect(multi.characters).toEqual([
+        { tag: "s", name: "Sylvie", color: "#ff0000" },
+      ]);
+      expect(multi.cleanedContent).not.toContain("define s = Character");
+    });
+
     it("classifies default True/False as variables", () => {
       const content = [
         "default met_alex = False",

--- a/apps/backend/src/services/__tests__/rpy-statements.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/rpy-statements.service.unit.test.ts
@@ -1,0 +1,359 @@
+/**
+ * RPY Statements Utility Unit Tests
+ *
+ * Covers `computeCommonDirectoryPrefix` and `extractAndStripRpySymbols`.
+ * The latter is the core helper that the import path uses to keep the
+ * BranchForge database in sync with the symbols in the source RPY
+ * files and to remove them from the stored file content. See
+ * issue #244.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  computeCommonDirectoryPrefix,
+  extractAndStripRpySymbols,
+} from "../rpy-statements.service.js";
+
+describe("rpy-statements.service", () => {
+  // ---------------------------------------------------------------------
+  // computeCommonDirectoryPrefix
+  // ---------------------------------------------------------------------
+
+  describe("computeCommonDirectoryPrefix", () => {
+    it("returns shared top-level directory for files in same parent with different subdirectories", () => {
+      expect(
+        computeCommonDirectoryPrefix([
+          "game/ch1/script.rpy",
+          "game/ch2/scene.rpy",
+          "game/ui/menu.rpy",
+        ])
+      ).toBe("game/");
+    });
+
+    it("returns top-level directory for deeply nested files sharing it", () => {
+      expect(
+        computeCommonDirectoryPrefix([
+          "game/deep/nested/script.rpy",
+          "game/ch2/scene.rpy",
+        ])
+      ).toBe("game/");
+    });
+
+    it("returns empty string when files have different top-level directories", () => {
+      expect(
+        computeCommonDirectoryPrefix([
+          "src/app.ts",
+          "tests/app.test.ts",
+          "docs/readme.md",
+        ])
+      ).toBe("");
+    });
+
+    it("returns empty string when no files have a directory component", () => {
+      expect(
+        computeCommonDirectoryPrefix(["README.md", "LICENSE", "CHANGELOG.md"])
+      ).toBe("");
+    });
+
+    it("returns empty string for empty input", () => {
+      expect(computeCommonDirectoryPrefix([])).toBe("");
+    });
+
+    it("returns top-level dir even when some files are root-level", () => {
+      expect(
+        computeCommonDirectoryPrefix([
+          "game/script.rpy",
+          "game/data.rpy",
+          "README.md",
+        ])
+      ).toBe("game/");
+    });
+
+    it("handles deeply nested single file", () => {
+      expect(
+        computeCommonDirectoryPrefix(["deeply/nested/path/file.rpy"])
+      ).toBe("deeply/");
+    });
+
+    it("only considers first segment, not full common ancestry", () => {
+      expect(
+        computeCommonDirectoryPrefix([
+          "a/b/c/d/e/file1.rpy",
+          "a/b/c/d/f/file2.rpy",
+        ])
+      ).toBe("a/");
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // extractAndStripRpySymbols
+  // ---------------------------------------------------------------------
+
+  describe("extractAndStripRpySymbols", () => {
+    it("returns empty arrays and unchanged content for empty input", () => {
+      const result = extractAndStripRpySymbols("");
+      expect(result.cleanedContent).toBe("");
+      expect(result.characters).toEqual([]);
+      expect(result.variables).toEqual([]);
+      expect(result.stats).toEqual([]);
+    });
+
+    it("preserves content that contains no define/default statements", () => {
+      const content = [
+        "# My script",
+        "label start:",
+        '    "Hello, world."',
+        "    return",
+        "",
+        "label next:",
+        '    "Goodbye."',
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.cleanedContent).toBe(content);
+      expect(result.characters).toEqual([]);
+      expect(result.variables).toEqual([]);
+      expect(result.stats).toEqual([]);
+    });
+
+    it("strips a single-line character definition and captures the character", () => {
+      const content = [
+        'define e = Character("Eileen", color="#c8ffc8")',
+        "",
+        "label start:",
+        '    e "Hello."',
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.characters).toEqual([
+        { tag: "e", name: "Eileen", color: "#c8ffc8" },
+      ]);
+      expect(result.cleanedContent).not.toContain("define e = Character");
+      expect(result.cleanedContent).toContain("label start:");
+      expect(result.cleanedContent).toContain('e "Hello."');
+    });
+
+    it("strips a multi-line character definition and captures the character", () => {
+      const content = [
+        "define e = Character(",
+        '    "Eileen",',
+        '    color="#c8ffc8",',
+        '    who_color="#c8c8c8"',
+        ")",
+        "",
+        "label start:",
+        '    e "Hello."',
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.characters).toEqual([
+        // who_color wins over color when both are present
+        { tag: "e", name: "Eileen", color: "#c8c8c8" },
+      ]);
+      // The four lines of the multi-line definition are all gone.
+      expect(result.cleanedContent).not.toContain("define e = Character");
+      expect(result.cleanedContent).not.toContain('"Eileen",');
+      expect(result.cleanedContent).not.toContain("who_color=");
+      expect(result.cleanedContent).toContain("label start:");
+    });
+
+    it("strips multiple character definitions and preserves order", () => {
+      const content = [
+        'define e = Character("Eileen", color="#c8ffc8")',
+        'define s = Character("Sylvie", color="#ff0000")',
+        'define l = Character("Lucy", color="#0000ff")',
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.characters).toEqual([
+        { tag: "e", name: "Eileen", color: "#c8ffc8" },
+        { tag: "s", name: "Sylvie", color: "#ff0000" },
+        { tag: "l", name: "Lucy", color: "#0000ff" },
+      ]);
+      expect(result.cleanedContent).not.toMatch(/^define\s/m);
+    });
+
+    it("classifies default True/False as variables", () => {
+      const content = [
+        "default met_alex = False",
+        "default has_key = True",
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.variables).toEqual([
+        { key: "met_alex", value: "False", kind: "variable" },
+        { key: "has_key", value: "True", kind: "variable" },
+      ]);
+      expect(result.stats).toEqual([]);
+      expect(result.cleanedContent).not.toContain("default met_alex");
+      expect(result.cleanedContent).not.toContain("default has_key");
+    });
+
+    it("classifies numeric default as stats", () => {
+      const content = [
+        "default affection = 0",
+        "default trust = 50",
+        "default max_value = 100",
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.stats).toEqual([
+        { key: "affection", value: "0", kind: "stat" },
+        { key: "trust", value: "50", kind: "stat" },
+        { key: "max_value", value: "100", kind: "stat" },
+      ]);
+      expect(result.variables).toEqual([]);
+    });
+
+    it("preserves default statements with unknown values rather than stripping them", () => {
+      // Quoted strings, identifier references and other non-boolean,
+      // non-numeric RHS values have no place in the variables/stats
+      // tables. Stripping them silently would lose user-authored
+      // state, so the extractor leaves them in the cleaned content
+      // and simply does not classify them. The downstream import
+      // path also does not touch them.
+      const content = [
+        'default mood = "happy"',
+        "default score = max_score",
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.variables).toEqual([]);
+      expect(result.stats).toEqual([]);
+      expect(result.cleanedContent).toContain('default mood = "happy"');
+      expect(result.cleanedContent).toContain("default score = max_score");
+    });
+
+    it("recognises default <tag> = Character(...) as a character definition", () => {
+      // Both `define` and `default` are valid Ren'Py keywords for
+      // declaring a character; the import path must treat them
+      // identically so neither is silently dropped.
+      const content = [
+        'default e = Character("Eileen", color="#c8ffc8")',
+        "",
+        "label start:",
+        '    e "Hello."',
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.characters).toEqual([
+        { tag: "e", name: "Eileen", color: "#c8ffc8" },
+      ]);
+      expect(result.cleanedContent).not.toContain("default e = Character");
+      expect(result.cleanedContent).toContain("label start:");
+    });
+
+    it("strips comments after default values and still captures the value", () => {
+      const content = [
+        "default met_alex = False  # a flag",
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.variables).toEqual([
+        { key: "met_alex", value: "False", kind: "variable" },
+      ]);
+      expect(result.cleanedContent).not.toContain("default met_alex");
+    });
+
+    it("preserves leading comments and blank lines around stripped statements", () => {
+      const content = [
+        "# header comment",
+        "",
+        'define e = Character("Eileen", color="#c8ffc8")',
+        "",
+        "# body comment",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.cleanedContent).toBe(
+        [
+          "# header comment",
+          "",
+          "",
+          "# body comment",
+          "label start:",
+          "    return",
+        ].join("\n")
+      );
+    });
+
+    it("de-duplicates characters within a single file (first occurrence wins)", () => {
+      const content = [
+        'define e = Character("Eileen", color="#c8ffc8")',
+        'define e = Character("NotEileen", color="#ff0000")',
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.characters).toEqual([
+        { tag: "e", name: "Eileen", color: "#c8ffc8" },
+      ]);
+    });
+
+    it("handles Character(None, ...) by setting name to null", () => {
+      const content = [
+        'define n = Character(None, color="#c8c8c8")',
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.characters).toEqual([
+        { tag: "n", name: null, color: "#c8c8c8" },
+      ]);
+    });
+
+    it("falls back to default color when none is specified", () => {
+      const content = [
+        'define s = Character("Sylvie")',
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      expect(result.characters).toEqual([
+        { tag: "s", name: "Sylvie", color: "#cfcfcf" },
+      ]);
+    });
+
+    it("preserves dialogue lines that look like assigns but are not define/default", () => {
+      const content = [
+        "label start:",
+        "    $ affection = 10",
+        "    return",
+      ].join("\n");
+
+      const result = extractAndStripRpySymbols(content);
+      // `$ x = 10` is an in-label assignment, not a `default`
+      // declaration, and must be preserved.
+      expect(result.cleanedContent).toBe(content);
+      expect(result.variables).toEqual([]);
+      expect(result.stats).toEqual([]);
+    });
+  });
+});

--- a/apps/backend/src/services/__tests__/zip-import.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/zip-import.service.unit.test.ts
@@ -261,6 +261,11 @@ describe("ZipImportService", () => {
       insert: vi.fn().mockReturnThis(),
       values: vi.fn().mockReturnThis(),
       onConflictDoUpdate: vi.fn().mockReturnThis(),
+      // onConflictDoNothing is used by the symbol-promotion
+      // transaction (issue #244) to upsert characters / variables /
+      // stats idempotently. It needs to return `this` like the
+      // other chain methods.
+      onConflictDoNothing: vi.fn().mockReturnThis(),
       set: vi.fn().mockReturnThis(),
       returning: vi.fn().mockResolvedValue([{ id: "test-file-id" }]),
       select: vi.fn().mockReturnThis(),
@@ -283,6 +288,7 @@ describe("ZipImportService", () => {
       insert: vi.fn().mockReturnThis(),
       values: vi.fn().mockReturnThis(),
       onConflictDoUpdate: vi.fn().mockReturnThis(),
+      onConflictDoNothing: vi.fn().mockReturnThis(),
       set: vi.fn().mockReturnThis(),
       returning: vi.fn().mockResolvedValue([{ id: "test-file-id" }]),
       select: vi.fn().mockReturnThis(),
@@ -301,6 +307,7 @@ describe("ZipImportService", () => {
       mockTx.insert.mockReturnThis();
       mockTx.values.mockReturnThis();
       mockTx.onConflictDoUpdate?.mockReturnThis?.();
+      mockTx.onConflictDoNothing?.mockReturnThis?.();
       mockTx.set.mockReturnThis();
       mockTx.select.mockReturnThis();
       mockTx.from.mockReturnThis();
@@ -465,6 +472,163 @@ describe("ZipImportService", () => {
         success: true,
         filesImported: 2,
       });
+    });
+
+    // ====================================================================
+    // issue #244: `define` / `default` symbols are stripped from the
+    // stored file content and promoted into the characters / variables /
+    // stats tables so that re-exporting the project cannot produce
+    // duplicate `define` statements that would crash Ren'Py with
+    // `NameError: name 'X' is already defined`.
+    // ====================================================================
+
+    it("strips define Character() and default lines from the content passed to the project_files insert", async () => {
+      // The RPY file a user would drop into Ren'Py typically declares
+      // its characters and any custom stat defaults at the top. The
+      // importer must remove those lines from the stored content and
+      // surface them to the database tables instead.
+      const fileContent = [
+        'define e = Character("Eileen", color="#c8ffc8")',
+        'define s = Character("Sylvie", color="#ff0000")',
+        "",
+        "default affection = 0",
+        "default has_met_alex = False",
+        "",
+        "label start:",
+        '    e "Hello."',
+        "    return",
+      ].join("\n");
+
+      const mockBuffer = Buffer.from("mock zip");
+      const mockZip = {
+        files: {
+          "game/characters.rpy": createMockFile(
+            "game/characters.rpy",
+            fileContent
+          ),
+        },
+      };
+      vi.mocked(JSZip.loadAsync).mockResolvedValue(mockZip as any);
+
+      await importZipFile(mockProjectId, mockBuffer);
+
+      // Find the .values() call for the projectFiles insert. The
+      // mock chain is permissive, so the chain is `insert -> values`
+      // with `values` receiving the row payload.
+      const valuesCalls = mockTx.values.mock.calls;
+      const projectFileRow = valuesCalls
+        .map((c) => c[0] as Record<string, unknown>)
+        .find((row) => row && typeof row.filePath === "string");
+
+      expect(projectFileRow).toBeDefined();
+      // The stored `content` no longer contains the symbols, but it
+      // does contain the label and dialogue that follow.
+      const storedContent = projectFileRow!.content as string;
+      expect(storedContent).not.toContain("define e = Character");
+      expect(storedContent).not.toContain("define s = Character");
+      expect(storedContent).not.toContain("default affection");
+      expect(storedContent).not.toContain("default has_met_alex");
+      expect(storedContent).toContain("label start:");
+      expect(storedContent).toContain('e "Hello."');
+
+      // The original (un-stripped) content is preserved for
+      // round-tripping / reconstruction.
+      expect(projectFileRow!.originalContent).toBe(fileContent);
+    });
+
+    it("promotes extracted characters, variables and stats into the database", async () => {
+      // End-to-end check: after importing a file that defines an
+      // `e` character, an `affection` stat, and a `has_met_alex`
+      // variable, those rows should be inserted into the
+      // `characters`, `stats`, and `variables` tables.
+      const fileContent = [
+        'define e = Character("Eileen", color="#c8ffc8")',
+        "",
+        "default affection = 0",
+        "default has_met_alex = False",
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const mockBuffer = Buffer.from("mock zip");
+      const mockZip = {
+        files: {
+          "game/script.rpy": createMockFile("game/script.rpy", fileContent),
+        },
+      };
+      vi.mocked(JSZip.loadAsync).mockResolvedValue(mockZip as any);
+
+      await importZipFile(mockProjectId, mockBuffer);
+
+      // Collect every row that was passed to `tx.values(...)` across
+      // both the per-file savepoint transaction and the symbol-
+      // promotion transaction. The mock chain is shared by both
+      // transactions (they both run via the same `mockTx`), so this
+      // captures inserts into all relevant tables.
+      const allRows = mockTx.values.mock.calls.map(
+        (c) => c[0] as Record<string, unknown>
+      );
+
+      // The character row was inserted with the right tag and color.
+      const characterRow = allRows.find((r) => "renpyTag" in r);
+      expect(characterRow).toMatchObject({
+        projectId: mockProjectId,
+        renpyTag: "e",
+        name: "Eileen",
+        displayName: "Eileen",
+        color: "#c8ffc8",
+      });
+
+      // The variable row (True/False) was inserted.
+      const variableRow = allRows.find(
+        (r) => "key" in r && !("minValue" in r) && !("maxValue" in r)
+      );
+      expect(variableRow).toMatchObject({
+        projectId: mockProjectId,
+        key: "has_met_alex",
+      });
+
+      // The stat row (numeric) was inserted with the parsed minValue.
+      const statRow = allRows.find((r) => "minValue" in r && "maxValue" in r);
+      expect(statRow).toMatchObject({
+        projectId: mockProjectId,
+        key: "affection",
+        minValue: 0,
+        maxValue: 100,
+      });
+
+      // The `onConflictDoNothing` upsert path was used for all three
+      // symbol inserts.
+      expect(mockTx.onConflictDoNothing).toHaveBeenCalled();
+    });
+
+    it("is idempotent: re-importing the same RPY files does not duplicate symbols", async () => {
+      // Same RPY content, two imports. The second one must not
+      // fail (the unique constraint on (projectId, renpyTag) and
+      // (projectId, key) is handled via onConflictDoNothing).
+      const fileContent = [
+        'define e = Character("Eileen", color="#c8ffc8")',
+        "",
+        "default has_met_alex = False",
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const mockBuffer = Buffer.from("mock zip");
+      const mockZip = {
+        files: {
+          "game/script.rpy": createMockFile("game/script.rpy", fileContent),
+        },
+      };
+      vi.mocked(JSZip.loadAsync).mockResolvedValue(mockZip as any);
+
+      const first = await importZipFile(mockProjectId, mockBuffer);
+      const second = await importZipFile(mockProjectId, mockBuffer);
+
+      expect(first.success).toBe(true);
+      expect(second.success).toBe(true);
     });
 
     it("should return statistics about imported files", async () => {

--- a/apps/backend/src/services/characters.service.ts
+++ b/apps/backend/src/services/characters.service.ts
@@ -267,9 +267,17 @@ export class CharactersService {
 
     const allDetected: DetectedCharacter[] = [];
     for (const file of allProjectFiles) {
-      if (file.content) {
+      // The import path (issue #244) strips `define` / `default`
+      // statements from `content` and stores them in the database
+      // (the single source of truth). For the import wizard we
+      // still need to surface what *was* in the source file, so we
+      // read from `originalContent` when available and fall back
+      // to `content` for files created entirely from scratch (e.g.
+      // a brand-new BranchForge project).
+      const sourceContent = file.originalContent ?? file.content;
+      if (sourceContent) {
         const fileCharacters = characterParserService.parseWithExclusions(
-          file.content,
+          sourceContent,
           file.filePath,
           excludedTags
         );

--- a/apps/backend/src/services/export.service.ts
+++ b/apps/backend/src/services/export.service.ts
@@ -198,6 +198,16 @@ export async function generateExport(
 
   // Patch STORY files with conditions/effects
   const patchedFiles: Record<string, string> = {};
+  // Track the sanitized paths we actually emitted so the
+  // directory-prefix calculation below only sees paths that will
+  // make it into the zip. A bad path that we silently skip
+  // (`sanitizeZipEntryPath` rejects path-traversal / absolute
+  // entries) must not influence where the generated
+  // `branchforge_*.rpy` files land — otherwise a single stray
+  // entry like `evil/../x.rpy` would force the prefix to "" and
+  // place the generated files at the archive root, silently
+  // disabling them in Ren'Py. See issue #244.
+  const sanitizedPaths: string[] = [];
   for (const file of files) {
     const safePath = sanitizeZipEntryPath(file.filePath);
     if (!safePath) {
@@ -208,6 +218,7 @@ export async function generateExport(
       });
       continue;
     }
+    sanitizedPaths.push(safePath);
     // Defensive strip: remove any `define <tag> = Character(...)` /
     // `default <key> = ...` lines that might still be present in
     // the stored `content`. The import path strips them at
@@ -268,13 +279,13 @@ export async function generateExport(
   );
 
   // Determine the directory prefix for generated files (e.g. "game/")
-  // by computing a shared top-level directory segment from project file
-  // paths. Generated branchforge_*.rpy files must be placed alongside
-  // the project files so Ren'Py picks them up at launch — placing them
-  // at the archive root is silently ignored. See issue #244.
-  const fileDirPrefix = computeCommonDirectoryPrefix(
-    files.map((f) => f.filePath)
-  );
+  // by computing a shared top-level directory segment from the
+  // sanitized project file paths (not the raw `file.filePath`
+  // values — see the loop above for the rationale). Generated
+  // branchforge_*.rpy files must be placed alongside the project
+  // files so Ren'Py picks them up at launch — placing them at
+  // the archive root is silently ignored. See issue #244.
+  const fileDirPrefix = computeCommonDirectoryPrefix(sanitizedPaths);
 
   // Generate additional RPY files
   if (projectVariables.length > 0) {

--- a/apps/backend/src/services/export.service.ts
+++ b/apps/backend/src/services/export.service.ts
@@ -31,6 +31,10 @@ import {
   generateCharacterDefinitionsFile,
   type LabelWithConditions,
 } from "./rpy-generator.service.js";
+import {
+  computeCommonDirectoryPrefix,
+  extractAndStripRpySymbols,
+} from "./rpy-statements.service.js";
 import { checkRateLimit } from "./rate-limiter.service.js";
 import { logInfo, logError, logWarn, LogEventType } from "../lib/logger.js";
 
@@ -204,19 +208,30 @@ export async function generateExport(
       });
       continue;
     }
+    // Defensive strip: remove any `define <tag> = Character(...)` /
+    // `default <key> = ...` lines that might still be present in
+    // the stored `content`. The import path strips them at
+    // ingestion (issue #244), but projects imported before that
+    // fix shipped could still carry those lines. The strip is
+    // idempotent on already-clean content. We deliberately do
+    // NOT touch `originalContent` — that field is preserved for
+    // round-tripping and reconstruction.
+    const strippedContent = extractAndStripRpySymbols(
+      file.content
+    ).cleanedContent;
     if (file.fileType === "STORY") {
       const fileLabels = labelsByFileId.get(file.id) ?? [];
       if (fileLabels.length > 0) {
         patchedFiles[safePath] = patchRPYWithVariables(
-          file.content,
+          strippedContent,
           fileLabels
         );
       } else {
-        patchedFiles[safePath] = file.content;
+        patchedFiles[safePath] = strippedContent;
       }
     } else {
       // Non-story files (settings, gui, etc.) — include as-is
-      patchedFiles[safePath] = file.content;
+      patchedFiles[safePath] = strippedContent;
     }
   }
 
@@ -252,18 +267,28 @@ export async function generateExport(
     ]
   );
 
+  // Determine the directory prefix for generated files (e.g. "game/")
+  // by computing a shared top-level directory segment from project file
+  // paths. Generated branchforge_*.rpy files must be placed alongside
+  // the project files so Ren'Py picks them up at launch — placing them
+  // at the archive root is silently ignored. See issue #244.
+  const fileDirPrefix = computeCommonDirectoryPrefix(
+    files.map((f) => f.filePath)
+  );
+
   // Generate additional RPY files
   if (projectVariables.length > 0) {
-    patchedFiles["branchforge_variables.rpy"] =
+    patchedFiles[`${fileDirPrefix}branchforge_variables.rpy`] =
       generateVariablesFile(projectVariables);
   }
 
   if (projectStats.length > 0) {
-    patchedFiles["branchforge_stats.rpy"] = generateStatsFile(projectStats);
+    patchedFiles[`${fileDirPrefix}branchforge_stats.rpy`] =
+      generateStatsFile(projectStats);
   }
 
   if (projectCharacters.length > 0) {
-    patchedFiles["branchforge_definitions.rpy"] =
+    patchedFiles[`${fileDirPrefix}branchforge_definitions.rpy`] =
       generateCharacterDefinitionsFile(projectCharacters);
   }
 

--- a/apps/backend/src/services/gitlab-sync.service.ts
+++ b/apps/backend/src/services/gitlab-sync.service.ts
@@ -37,6 +37,12 @@ import {
 } from "./rpy-generator.service.js";
 import { calculateLinesHash, calculateContentHash } from "../lib/hash.js";
 import { type DetectedCharacter } from "./character-parser.service.js";
+import {
+  computeCommonDirectoryPrefix,
+  extractAndStripRpySymbols,
+  type DetectedCharacterStatement,
+  type DetectedDefaultStatement,
+} from "./rpy-statements.service.js";
 import { projectSettings } from "../db/schema/index.js";
 import { mapEntriesToLabelLineValues } from "./label-line-mapper.js";
 import { logError, logWarn } from "../lib/logger.js";
@@ -141,37 +147,10 @@ async function updateSyncOperation(
     .where(eq(gitlabSyncOperations.id, operationId));
 }
 
-/**
- * Compute the top-level directory prefix from a list of file paths.
- * Extracts the first directory segment from each path with a "/",
- * and returns it with trailing "/" if all such paths share the same
- * top-level directory. Returns "" otherwise.
- *
- * Example: ["game/ch1/script.rpy", "game/ch2/scene.rpy"] → "game/"
- *          ["game/script.rpy", "README.md"] → "game/"
- *          ["src/a.ts", "tests/b.ts"] → ""
- *          ["README.md", "LICENSE"] → ""
- */
-export function computeCommonDirectoryPrefix(filePaths: string[]): string {
-  const topDirs: string[] = [];
-  for (const p of filePaths) {
-    const firstSlash = p.indexOf("/");
-    if (firstSlash !== -1) {
-      topDirs.push(p.slice(0, firstSlash));
-    }
-  }
-
-  if (topDirs.length === 0) {
-    return "";
-  }
-
-  const first = topDirs[0];
-  if (topDirs.every((d) => d === first)) {
-    return first + "/";
-  }
-
-  return "";
-}
+// Re-export the shared directory-prefix helper so existing tests and
+// downstream importers keep working. The implementation lives in
+// `rpy-statements.service.ts` so the zip exporter can share it.
+export { computeCommonDirectoryPrefix } from "./rpy-statements.service.js";
 
 /**
  * Export scenes from BranchForge to GitLab
@@ -245,12 +224,21 @@ export async function exportToGitlab(
     // Export each project file - Script Mode uses stored content directly
     for (const file of files) {
       if (file.content) {
-        let contentToExport = file.content;
+        // Defensive strip: remove any `define <tag> = Character(...)` /
+        // `default <key> = ...` lines that might still be present in
+        // the stored `content`. The import path strips them at
+        // ingestion (issue #244), but projects imported before that
+        // fix shipped could still carry those lines. The strip is
+        // idempotent on already-clean content.
+        const baseContent = extractAndStripRpySymbols(
+          file.content
+        ).cleanedContent;
+        let contentToExport = baseContent;
 
         // Patch content with variables if this file has labels with conditions
         const fileLabels = labelsByFile.get(file.id);
         if (fileLabels && fileLabels.length > 0) {
-          contentToExport = patchRPYWithVariables(file.content, fileLabels);
+          contentToExport = patchRPYWithVariables(baseContent, fileLabels);
         }
 
         filesToExport.push({
@@ -485,8 +473,10 @@ export async function importFromGitlab(
     const parsedFiles: Array<{
       file: (typeof rpyFiles)[0];
       content: string;
+      cleanedContent: string;
       parsed: ParsedRPYFileWithLabels;
       projectFile: ProjectFile;
+      symbols: ReturnType<typeof extractAndStripRpySymbols>;
     }> = [];
 
     for (const result of fileFetchResults) {
@@ -511,8 +501,18 @@ export async function importFromGitlab(
       // Parse with new label-aware parser, passing filename for better detection
       const parsed = parseRPYFileWithLabels(content, file.path);
 
-      // Create or update project_files record with full content for Script Mode
-      const contentHash = calculateContentHash(content);
+      // Strip BranchForge-managed `define`/`default` statements from
+      // the stored content. The DB is the single source of truth for
+      // those symbols, so re-exporting the project cannot produce
+      // duplicate lines that would crash Ren'Py with
+      // `NameError: name 'X' is already defined`. See issue #244.
+      const symbols = extractAndStripRpySymbols(content);
+
+      // Hash the cleaned content because that's what we store in
+      // `project_files.content`; identical source files produce
+      // identical cleaned output, so re-syncs of unchanged files are
+      // correctly detected as no-ops.
+      const contentHash = calculateContentHash(symbols.cleanedContent);
       const [projectFile] = await db
         .insert(projectFiles)
         .values({
@@ -520,8 +520,8 @@ export async function importFromGitlab(
           source: "GITLAB",
           filePath: file.path,
           fileType: parsed.fileType,
-          content: content, // Store full RPY content for Script Mode
-          originalContent: content, // Store original imported content for reconstruction
+          content: symbols.cleanedContent, // Store cleaned content (no define/default)
+          originalContent: content, // Preserve original for reconstruction
           contentHash,
           lastSyncedAt: new Date(),
           lastCommitSha: importCommitSha,
@@ -533,7 +533,7 @@ export async function importFromGitlab(
             projectFiles.filePath,
           ],
           set: {
-            content: content, // Update full content on sync
+            content: symbols.cleanedContent, // Update cleaned content on sync
             // Only set originalContent if it's null (preserve original on subsequent syncs)
             originalContent: sql`COALESCE(${projectFiles.originalContent}, ${content})`,
             contentHash,
@@ -544,7 +544,98 @@ export async function importFromGitlab(
         })
         .returning();
 
-      parsedFiles.push({ file, content, parsed, projectFile });
+      parsedFiles.push({
+        file,
+        content,
+        cleanedContent: symbols.cleanedContent,
+        parsed,
+        projectFile,
+        symbols,
+      });
+    }
+
+    // Phase 1.5: Promote extracted `define`/`default` symbols into the
+    // database. The DB is the single source of truth for those
+    // symbols, so re-exporting the project cannot produce duplicate
+    // lines that would crash Ren'Py with
+    // `NameError: name 'X' is already defined`. We use
+    // `onConflictDoNothing` so re-syncs of unchanged files are
+    // no-ops and the user's later UI edits to the DB rows are
+    // preserved. See issue #244.
+    if (parsedFiles.length > 0) {
+      // Dedupe across files (the strip step de-dupes per file).
+      const charactersByTag = new Map<string, DetectedCharacterStatement>();
+      const variablesByKey = new Map<string, DetectedDefaultStatement>();
+      const statsByKey = new Map<string, DetectedDefaultStatement>();
+      for (const f of parsedFiles) {
+        for (const c of f.symbols.characters) {
+          if (!charactersByTag.has(c.tag)) charactersByTag.set(c.tag, c);
+        }
+        for (const v of f.symbols.variables) {
+          if (!variablesByKey.has(v.key)) variablesByKey.set(v.key, v);
+        }
+        for (const s of f.symbols.stats) {
+          if (!statsByKey.has(s.key)) statsByKey.set(s.key, s);
+        }
+      }
+      const dedupedCharacters = Array.from(charactersByTag.values());
+      const dedupedVariables = Array.from(variablesByKey.values());
+      const dedupedStats = Array.from(statsByKey.values());
+
+      if (
+        dedupedCharacters.length > 0 ||
+        dedupedVariables.length > 0 ||
+        dedupedStats.length > 0
+      ) {
+        await db.transaction(async (tx) => {
+          for (const c of dedupedCharacters) {
+            await tx
+              .insert(characters)
+              .values({
+                projectId,
+                name: c.name ?? c.tag,
+                displayName: c.name ?? c.tag,
+                renpyTag: c.tag,
+                color: c.color || "#cfcfcf",
+                updatedAt: new Date(),
+              })
+              .onConflictDoNothing({
+                target: [characters.projectId, characters.renpyTag],
+              });
+          }
+          for (const v of dedupedVariables) {
+            await tx
+              .insert(variables)
+              .values({
+                projectId,
+                key: v.key,
+              })
+              .onConflictDoNothing({
+                target: [variables.projectId, variables.key],
+              });
+          }
+          for (const s of dedupedStats) {
+            // `default x = 0` becomes a stat with minValue=0 and the
+            // default maxValue of 100; users can adjust in the UI.
+            // Use parseFloat + round so that float values like 3.5
+            // are preserved (parseInt would silently truncate to 3).
+            const minValue = Math.round(Number.parseFloat(s.value)) || 0;
+            await tx
+              .insert(stats)
+              .values({
+                projectId,
+                key: s.key,
+                name: s.key,
+                minValue,
+                maxValue: 100,
+                updatedAt: new Date(),
+              })
+              .onConflictDoNothing({
+                target: [stats.projectId, stats.key],
+              });
+          }
+        });
+      }
     }
 
     // Phase 2: Collect detected characters for return value

--- a/apps/backend/src/services/gitlab-sync.service.ts
+++ b/apps/backend/src/services/gitlab-sync.service.ts
@@ -467,7 +467,11 @@ export async function importFromGitlab(
 
     // Track if any file fetch succeeded and capture first error
     let anySuccess = false;
-    let firstError: Error | null = null;
+    // We narrow `firstError` to its eventual assignment site below;
+    // the type annotation is broader than the inferred type so that
+    // the closure that captures it (the db.transaction callback)
+    // doesn't narrow it to `never`.
+    let firstError: Error | null = null as Error | null;
 
     // Phase 1: Parse all files and detect characters
     const parsedFiles: Array<{
@@ -479,164 +483,186 @@ export async function importFromGitlab(
       symbols: ReturnType<typeof extractAndStripRpySymbols>;
     }> = [];
 
-    for (const result of fileFetchResults) {
-      if (result.status === "rejected") {
-        // Capture the first error for reporting
-        if (!firstError) {
-          firstError =
-            result.reason instanceof Error
-              ? result.reason
-              : new Error(String(result.reason));
+    // Cross-file symbol aggregation. We populate this inside the
+    // transaction below as files are successfully processed, so a
+    // mid-import rollback leaves no orphan symbols behind. The
+    // `extracted` prefix disambiguates from the existing
+    // `charactersByTag` map in Phase 3 that maps `renpyTag -> id`
+    // for speaker linking.
+    const extractedCharactersByTag = new Map<
+      string,
+      DetectedCharacterStatement
+    >();
+    const extractedVariablesByKey = new Map<string, DetectedDefaultStatement>();
+    const extractedStatsByKey = new Map<string, DetectedDefaultStatement>();
+
+    // Phase 1 + Phase 1.5 are wrapped in a single transaction so
+    // that the file inserts (which strip `define`/`default` from
+    // the stored content) and the symbol promotion (which puts
+    // those statements into the database) commit or roll back
+    // together. Without this, a partial failure could leave the
+    // project with cleaned `project_files.content` but no matching
+    // `characters` / `variables` / `stats` rows, which the
+    // export-time defensive strip still keeps Ren'Py-safe but
+    // would be confusing for the user. See issue #244.
+    await db.transaction(async (tx) => {
+      for (const result of fileFetchResults) {
+        if (result.status === "rejected") {
+          // Capture the first error for reporting
+          if (!firstError) {
+            firstError =
+              result.reason instanceof Error
+                ? result.reason
+                : new Error(String(result.reason));
+          }
+          continue;
         }
-        continue;
-      }
-      if (!result.value.content) {
-        // Skip files with no content
-        continue;
-      }
-      anySuccess = true;
+        if (!result.value.content) {
+          // Skip files with no content
+          continue;
+        }
+        anySuccess = true;
 
-      const { file, content } = result.value;
+        const { file, content } = result.value;
 
-      // Parse with new label-aware parser, passing filename for better detection
-      const parsed = parseRPYFileWithLabels(content, file.path);
+        // Parse with new label-aware parser, passing filename for better detection
+        const parsed = parseRPYFileWithLabels(content, file.path);
 
-      // Strip BranchForge-managed `define`/`default` statements from
-      // the stored content. The DB is the single source of truth for
-      // those symbols, so re-exporting the project cannot produce
-      // duplicate lines that would crash Ren'Py with
-      // `NameError: name 'X' is already defined`. See issue #244.
-      const symbols = extractAndStripRpySymbols(content);
+        // Strip BranchForge-managed `define`/`default` statements from
+        // the stored content. The DB is the single source of truth for
+        // those symbols, so re-exporting the project cannot produce
+        // duplicate lines that would crash Ren'Py with
+        // `NameError: name 'X' is already defined`. See issue #244.
+        const symbols = extractAndStripRpySymbols(content);
 
-      // Hash the cleaned content because that's what we store in
-      // `project_files.content`; identical source files produce
-      // identical cleaned output, so re-syncs of unchanged files are
-      // correctly detected as no-ops.
-      const contentHash = calculateContentHash(symbols.cleanedContent);
-      const [projectFile] = await db
-        .insert(projectFiles)
-        .values({
-          projectId,
-          source: "GITLAB",
-          filePath: file.path,
-          fileType: parsed.fileType,
-          content: symbols.cleanedContent, // Store cleaned content (no define/default)
-          originalContent: content, // Preserve original for reconstruction
-          contentHash,
-          lastSyncedAt: new Date(),
-          lastCommitSha: importCommitSha,
-        })
-        .onConflictDoUpdate({
-          target: [
-            projectFiles.projectId,
-            projectFiles.source,
-            projectFiles.filePath,
-          ],
-          set: {
-            content: symbols.cleanedContent, // Update cleaned content on sync
-            // Only set originalContent if it's null (preserve original on subsequent syncs)
-            originalContent: sql`COALESCE(${projectFiles.originalContent}, ${content})`,
+        // Hash the cleaned content because that's what we store in
+        // `project_files.content`; identical source files produce
+        // identical cleaned output, so re-syncs of unchanged files are
+        // correctly detected as no-ops.
+        const contentHash = calculateContentHash(symbols.cleanedContent);
+        const [projectFile] = await tx
+          .insert(projectFiles)
+          .values({
+            projectId,
+            source: "GITLAB",
+            filePath: file.path,
+            fileType: parsed.fileType,
+            content: symbols.cleanedContent, // Store cleaned content (no define/default)
+            originalContent: content, // Preserve original for reconstruction
             contentHash,
             lastSyncedAt: new Date(),
             lastCommitSha: importCommitSha,
-            updatedAt: new Date(),
-          },
-        })
-        .returning();
+          })
+          .onConflictDoUpdate({
+            target: [
+              projectFiles.projectId,
+              projectFiles.source,
+              projectFiles.filePath,
+            ],
+            set: {
+              content: symbols.cleanedContent, // Update cleaned content on sync
+              // Only set originalContent if it's null (preserve original on subsequent syncs)
+              originalContent: sql`COALESCE(${projectFiles.originalContent}, ${content})`,
+              contentHash,
+              lastSyncedAt: new Date(),
+              lastCommitSha: importCommitSha,
+              updatedAt: new Date(),
+            },
+          })
+          .returning();
 
-      parsedFiles.push({
-        file,
-        content,
-        cleanedContent: symbols.cleanedContent,
-        parsed,
-        projectFile,
-        symbols,
-      });
-    }
+        parsedFiles.push({
+          file,
+          content,
+          cleanedContent: symbols.cleanedContent,
+          parsed,
+          projectFile,
+          symbols,
+        });
 
-    // Phase 1.5: Promote extracted `define`/`default` symbols into the
-    // database. The DB is the single source of truth for those
-    // symbols, so re-exporting the project cannot produce duplicate
-    // lines that would crash Ren'Py with
-    // `NameError: name 'X' is already defined`. We use
-    // `onConflictDoNothing` so re-syncs of unchanged files are
-    // no-ops and the user's later UI edits to the DB rows are
-    // preserved. See issue #244.
-    if (parsedFiles.length > 0) {
-      // Dedupe across files (the strip step de-dupes per file).
-      const charactersByTag = new Map<string, DetectedCharacterStatement>();
-      const variablesByKey = new Map<string, DetectedDefaultStatement>();
-      const statsByKey = new Map<string, DetectedDefaultStatement>();
-      for (const f of parsedFiles) {
-        for (const c of f.symbols.characters) {
-          if (!charactersByTag.has(c.tag)) charactersByTag.set(c.tag, c);
+        // Aggregate this file's symbols into the cross-file maps.
+        // We do this here (not in a pre-pass) so that any rollback
+        // of the surrounding transaction discards partial symbol
+        // accumulations along with the file insert.
+        for (const c of symbols.characters) {
+          if (!extractedCharactersByTag.has(c.tag))
+            extractedCharactersByTag.set(c.tag, c);
         }
-        for (const v of f.symbols.variables) {
-          if (!variablesByKey.has(v.key)) variablesByKey.set(v.key, v);
+        for (const v of symbols.variables) {
+          if (!extractedVariablesByKey.has(v.key))
+            extractedVariablesByKey.set(v.key, v);
         }
-        for (const s of f.symbols.stats) {
-          if (!statsByKey.has(s.key)) statsByKey.set(s.key, s);
+        for (const s of symbols.stats) {
+          if (!extractedStatsByKey.has(s.key))
+            extractedStatsByKey.set(s.key, s);
         }
       }
-      const dedupedCharacters = Array.from(charactersByTag.values());
-      const dedupedVariables = Array.from(variablesByKey.values());
-      const dedupedStats = Array.from(statsByKey.values());
+
+      // Phase 1.5: Promote extracted `define`/`default` symbols
+      // into the database. The DB is the single source of truth
+      // for those symbols, so re-exporting the project cannot
+      // produce duplicate lines that would crash Ren'Py with
+      // `NameError: name 'X' is already defined`. We use
+      // `onConflictDoNothing` so re-syncs of unchanged files are
+      // no-ops and the user's later UI edits to the DB rows are
+      // preserved. See issue #244.
+      const dedupedCharacters = Array.from(extractedCharactersByTag.values());
+      const dedupedVariables = Array.from(extractedVariablesByKey.values());
+      const dedupedStats = Array.from(extractedStatsByKey.values());
 
       if (
         dedupedCharacters.length > 0 ||
         dedupedVariables.length > 0 ||
         dedupedStats.length > 0
       ) {
-        await db.transaction(async (tx) => {
-          for (const c of dedupedCharacters) {
-            await tx
-              .insert(characters)
-              .values({
-                projectId,
-                name: c.name ?? c.tag,
-                displayName: c.name ?? c.tag,
-                renpyTag: c.tag,
-                color: c.color || "#cfcfcf",
-                updatedAt: new Date(),
-              })
-              .onConflictDoNothing({
-                target: [characters.projectId, characters.renpyTag],
-              });
-          }
-          for (const v of dedupedVariables) {
-            await tx
-              .insert(variables)
-              .values({
-                projectId,
-                key: v.key,
-              })
-              .onConflictDoNothing({
-                target: [variables.projectId, variables.key],
-              });
-          }
-          for (const s of dedupedStats) {
-            // `default x = 0` becomes a stat with minValue=0 and the
-            // default maxValue of 100; users can adjust in the UI.
-            // Use parseFloat + round so that float values like 3.5
-            // are preserved (parseInt would silently truncate to 3).
-            const minValue = Math.round(Number.parseFloat(s.value)) || 0;
-            await tx
-              .insert(stats)
-              .values({
-                projectId,
-                key: s.key,
-                name: s.key,
-                minValue,
-                maxValue: 100,
-                updatedAt: new Date(),
-              })
-              .onConflictDoNothing({
-                target: [stats.projectId, stats.key],
-              });
-          }
-        });
+        for (const c of dedupedCharacters) {
+          await tx
+            .insert(characters)
+            .values({
+              projectId,
+              name: c.name ?? c.tag,
+              displayName: c.name ?? c.tag,
+              renpyTag: c.tag,
+              color: c.color || "#cfcfcf",
+              updatedAt: new Date(),
+            })
+            .onConflictDoNothing({
+              target: [characters.projectId, characters.renpyTag],
+            });
+        }
+        for (const v of dedupedVariables) {
+          await tx
+            .insert(variables)
+            .values({
+              projectId,
+              key: v.key,
+            })
+            .onConflictDoNothing({
+              target: [variables.projectId, variables.key],
+            });
+        }
+        for (const s of dedupedStats) {
+          // `default x = 0` becomes a stat with minValue=0 and the
+          // default maxValue of 100; users can adjust in the UI.
+          // Use parseFloat + round so that float values like 3.5
+          // are preserved (parseInt would silently truncate to 3).
+          const minValue = Math.round(Number.parseFloat(s.value)) || 0;
+          await tx
+            .insert(stats)
+            .values({
+              projectId,
+              key: s.key,
+              name: s.key,
+              minValue,
+              maxValue: 100,
+              updatedAt: new Date(),
+            })
+            .onConflictDoNothing({
+              target: [stats.projectId, stats.key],
+            });
+        }
       }
-    }
+    });
 
     // Phase 2: Collect detected characters for return value
     // Note: We don't import them here - let the frontend call detectCharacters

--- a/apps/backend/src/services/rpy-statements.service.ts
+++ b/apps/backend/src/services/rpy-statements.service.ts
@@ -161,11 +161,15 @@ export function extractAndStripRpySymbols(
     );
     if (characterStart) {
       const tag = characterStart[1];
-      // Capture the slice from the opening `Character(` to the end
-      // of the first line so the parser can find the display name
-      // and options even on a single-line definition. The opening
-      // `(` is part of this body so the paren depth starts at 0.
-      const firstOpenIdx = line.indexOf("Character(");
+      // Capture the slice from the opening `Character\s*(` to the
+      // end of the first line so the parser can find the display
+      // name and options even on a single-line definition. The
+      // opening `(` is part of this body so the paren depth starts
+      // at 0. We must honour the same `\s*` the regex matched,
+      // otherwise lines written with `Character (` (a space before
+      // the open paren) would be silently dropped because a plain
+      // `indexOf("Character(")` would not find the substring.
+      const firstOpenIdx = line.search(/Character\s*\(/);
       let body = firstOpenIdx === -1 ? "" : line.slice(firstOpenIdx);
       let parenDepth = countChar(body, "(") - countChar(body, ")");
       let j = i;

--- a/apps/backend/src/services/rpy-statements.service.ts
+++ b/apps/backend/src/services/rpy-statements.service.ts
@@ -1,0 +1,324 @@
+/**
+ * RPY Statements Utility
+ *
+ * Helpers for inspecting and stripping BranchForge-managed statements
+ * (character `define` and variable/stat `default`) from raw Ren'Py
+ * (.rpy) content.
+ *
+ * These helpers exist so that the import path can promote those
+ * statements into the BranchForge database (the single source of truth)
+ * and remove them from the stored file content. On export, the DB is
+ * the only place those symbols come from — they are emitted by the
+ * generator into the `branchforge_*.rpy` files, so the user-authored
+ * project files stay free of duplicates and Ren'Py can launch
+ * successfully.
+ */
+
+/**
+ * A character definition detected in RPY content.
+ *
+ * Mirrors the columns of the `characters` table that are populated
+ * from the file body. `tag` is the Ren'Py identifier (the LHS of the
+ * `define`); `name` is the display string inside `Character(...)` and
+ * is `null` for `Character(None, ...)`; `color` is the hex string from
+ * the `color=` / `who_color=` option.
+ */
+export interface DetectedCharacterStatement {
+  tag: string;
+  name: string | null;
+  color: string;
+}
+
+/**
+ * A `default <key> = <value>` line detected in RPY content.
+ *
+ * `value` is the literal text on the RHS of the assignment, e.g.
+ * `False`, `True`, `0`, `100`. The kind is inferred from the value:
+ * `True`/`False` -> "variable", numeric -> "stat", anything else is
+ * reported as `"unknown"` so the caller can decide what to do with
+ * it.
+ */
+export interface DetectedDefaultStatement {
+  key: string;
+  value: string;
+  kind: "variable" | "stat" | "unknown";
+}
+
+/**
+ * Result of running `extractAndStripRpySymbols` over a single RPY
+ * file's content.
+ */
+export interface RpySymbolExtraction {
+  /** Content with all `define <tag> = Character(...)` and
+   *  `default <key> = <value>` lines removed (other content is
+   *  preserved verbatim, including blank lines and indentation). */
+  cleanedContent: string;
+  /** Unique characters detected across the file (first occurrence
+   *  wins, in source order). */
+  characters: DetectedCharacterStatement[];
+  /** Unique `default` statements whose value is `True` or `False`. */
+  variables: DetectedDefaultStatement[];
+  /** Unique `default` statements whose value is numeric. */
+  stats: DetectedDefaultStatement[];
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Compute the top-level directory prefix from a list of file paths.
+ *
+ * Returns the first `/`-separated segment of every path that has one,
+ * followed by `/`, if all such paths agree. Returns `""` when the
+ * paths do not share a top-level directory, or when none of them
+ * contain a `/`.
+ *
+ * Shared by the zip and GitLab exporters so both place generated
+ * `branchforge_*.rpy` files under the same directory the project
+ * files live in (typically `game/`).
+ *
+ * Examples:
+ *   ["game/ch1/script.rpy", "game/ch2/scene.rpy"] -> "game/"
+ *   ["game/script.rpy", "README.md"]              -> "game/"
+ *   ["src/a.ts", "tests/b.ts"]                    -> ""
+ *   ["README.md", "LICENSE"]                      -> ""
+ */
+export function computeCommonDirectoryPrefix(filePaths: string[]): string {
+  const topDirs: string[] = [];
+  for (const p of filePaths) {
+    const firstSlash = p.indexOf("/");
+    if (firstSlash !== -1) {
+      topDirs.push(p.slice(0, firstSlash));
+    }
+  }
+
+  if (topDirs.length === 0) {
+    return "";
+  }
+
+  const first = topDirs[0];
+  if (topDirs.every((d) => d === first)) {
+    return first + "/";
+  }
+
+  return "";
+}
+
+/**
+ * Strip BranchForge-managed `define <tag> = Character(...)` and
+ * `default <key> = <value>` statements from RPY content and return
+ * the extracted symbols.
+ *
+ * The extractor:
+ * - Recognises single-line and multi-line `define <tag> = Character(...)`
+ *   statements (tracked by parenthesis depth).
+ * - Recognises single-line `default <key> = <value>` statements.
+ * - Leaves everything else (labels, dialogue, comments, blank lines)
+ *   untouched.
+ * - De-duplicates results by `tag` / `key` (first occurrence wins).
+ *
+ * The function is intentionally permissive: it does not filter by
+ * Ren'Py special tags ("n", "u", "narrator", "extend"). Callers that
+ * need that filtering can drop unwanted entries from the result.
+ *
+ * @param content - The RPY file content to process
+ * @returns The cleaned content and the extracted symbols
+ */
+export function extractAndStripRpySymbols(
+  content: string
+): RpySymbolExtraction {
+  const lines = content.split("\n");
+  const output: string[] = [];
+
+  const charactersByTag = new Map<string, DetectedCharacterStatement>();
+  const variablesByKey = new Map<string, DetectedDefaultStatement>();
+  const statsByKey = new Map<string, DetectedDefaultStatement>();
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments — preserve them in the output.
+    if (trimmed === "" || trimmed.startsWith("#")) {
+      output.push(line);
+      i += 1;
+      continue;
+    }
+
+    // ------------------------------------------------------------------
+    // `define <tag> = Character(...)` or
+    // `default <tag> = Character(...)` — single- or multi-line.
+    // ------------------------------------------------------------------
+    // Both `define` and `default` are accepted because Ren'Py treats
+    // them as equivalent for character definitions; the existing
+    // `character-parser.service.ts` matches both. We track paren
+    // depth until the matching `)` closes the call and then parse
+    // the body for the display name and color.
+    const characterStart = trimmed.match(
+      /^(?:define|default)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*Character\s*\(/
+    );
+    if (characterStart) {
+      const tag = characterStart[1];
+      // Capture the slice from the opening `Character(` to the end
+      // of the first line so the parser can find the display name
+      // and options even on a single-line definition. The opening
+      // `(` is part of this body so the paren depth starts at 0.
+      const firstOpenIdx = line.indexOf("Character(");
+      let body = firstOpenIdx === -1 ? "" : line.slice(firstOpenIdx);
+      let parenDepth = countChar(body, "(") - countChar(body, ")");
+      let j = i;
+      while (parenDepth > 0 && j + 1 < lines.length) {
+        j += 1;
+        const nextLine = lines[j];
+        body += "\n" + nextLine;
+        parenDepth += countChar(nextLine, "(") - countChar(nextLine, ")");
+      }
+      const character = parseCharacterBody(tag, body);
+      if (character && !charactersByTag.has(character.tag)) {
+        charactersByTag.set(character.tag, character);
+      }
+      // Skip past the consumed lines (j may equal i for single-line).
+      i = j + 1;
+      continue;
+    }
+
+    // ------------------------------------------------------------------
+    // `default <key> = <value>` (variable or stat)
+    // ------------------------------------------------------------------
+    // We do not try to handle multi-line `default` statements because
+    // they are exceedingly rare in practice and would require
+    // statement-level (not just paren) tracking.
+    const defaultMatch = trimmed.match(
+      /^default\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(.+?)\s*(?:#.*)?$/
+    );
+    if (defaultMatch) {
+      const key = defaultMatch[1];
+      const rawValue = defaultMatch[2];
+      const detected = classifyDefaultStatement(key, rawValue);
+      // Only `variable` (True/False) and `stat` (numeric) are
+      // promoted into the database. `unknown` defaults — quoted
+      // strings, identifiers, function calls — are left in the
+      // file content untouched. Otherwise we'd silently delete
+      // user-authored state that BranchForge has no place to
+      // store, and on the next export the user's file would be
+      // missing a line it had before. The strip is conservative:
+      // when in doubt, preserve.
+      if (detected.kind === "unknown") {
+        output.push(line);
+        i += 1;
+        continue;
+      }
+      const bucket = detected.kind === "variable" ? variablesByKey : statsByKey;
+      if (!bucket.has(key)) {
+        bucket.set(key, detected);
+      }
+      i += 1;
+      continue;
+    }
+
+    // ------------------------------------------------------------------
+    // Anything else: preserve verbatim.
+    // ------------------------------------------------------------------
+    output.push(line);
+    i += 1;
+  }
+
+  return {
+    cleanedContent: output.join("\n"),
+    characters: Array.from(charactersByTag.values()),
+    variables: Array.from(variablesByKey.values()),
+    stats: Array.from(statsByKey.values()),
+  };
+}
+
+// ============================================================================
+// Internals
+// ============================================================================
+
+/**
+ * Count occurrences of a single character in a string. Treated as
+ * ASCII; the regex used to open a Character() definition already
+ * constrains us to ASCII identifiers, so this is fine.
+ */
+function countChar(s: string, ch: string): number {
+  let n = 0;
+  for (let k = 0; k < s.length; k += 1) {
+    if (s[k] === ch) n += 1;
+  }
+  return n;
+}
+
+/**
+ * Parse a Character() body (the slice starting at the opening
+ * `Character(` and ending at the matching close) and return a
+ * `DetectedCharacterStatement` or `null` if the body is malformed.
+ *
+ * The body looks like `("Eileen", color="#c8ffc8")` or
+ * `(None, color="#c8c8c8")`. The display name is the first
+ * argument; if it is the literal `None` we record a null name
+ * (the caller decides whether to keep the character). We must
+ * check for `None` before searching for a quoted string, because
+ * later arguments (e.g. `color="#c8c8c8"`) contain their own
+ * quotes that would otherwise be mistaken for the name.
+ */
+function parseCharacterBody(
+  tag: string,
+  body: string
+): DetectedCharacterStatement | null {
+  // Strip the leading `Character(` and any surrounding whitespace
+  // so we can look at the first argument (the display name).
+  const afterOpen = body.replace(/^\s*Character\s*\(\s*/, "").trimStart();
+
+  let name: string | null;
+  if (/^None\b/.test(afterOpen)) {
+    name = null;
+  } else {
+    const quotedName = afterOpen.match(/"([^"]*)"/);
+    if (quotedName) {
+      name = quotedName[1];
+    } else {
+      // Could not identify a name — bail rather than insert garbage.
+      return null;
+    }
+  }
+
+  const color = extractColorFromOptions(body);
+  return { tag, name, color };
+}
+
+/**
+ * Extract a `color="#abcdef"` (or `who_color=...`) value from a
+ * Character() body/options string. Returns the Ren'Py default
+ * (`#cfcfcf`) when nothing is present.
+ */
+function extractColorFromOptions(options: string | undefined): string {
+  if (!options) return "#cfcfcf";
+  const whoColorMatch = options.match(/who_color\s*=\s*["']?([^"')\s,]+)/);
+  if (whoColorMatch) return whoColorMatch[1];
+  const colorMatch = options.match(/color\s*=\s*["']?([^"')\s,]+)/);
+  if (colorMatch) return colorMatch[1];
+  return "#cfcfcf";
+}
+
+/**
+ * Classify a `default <key> = <value>` RHS:
+ * - `True` / `False` -> variable
+ * - integer / decimal number -> stat
+ * - anything else -> unknown (still stripped, but not stored)
+ */
+function classifyDefaultStatement(
+  key: string,
+  rawValue: string
+): DetectedDefaultStatement {
+  const value = rawValue.trim();
+  if (value === "True" || value === "False") {
+    return { key, value, kind: "variable" };
+  }
+  // Match ints and floats; Ren'Py users freely mix them.
+  if (/^-?\d+(?:\.\d+)?$/.test(value)) {
+    return { key, value, kind: "stat" };
+  }
+  return { key, value, kind: "unknown" };
+}

--- a/apps/backend/src/services/zip-import.service.ts
+++ b/apps/backend/src/services/zip-import.service.ts
@@ -8,17 +8,27 @@
 
 import JSZip from "jszip";
 import { getDb } from "../db/index.js";
-import { projectFiles } from "../db/schema/index.js";
+import {
+  projectFiles,
+  characters,
+  variables,
+  stats,
+  labels,
+} from "../db/schema/index.js";
 import { eq, and, isNull, sql } from "drizzle-orm";
 import { calculateContentHash } from "../lib/hash.js";
 import { parseRPYFileWithLabels } from "./rpy-parser.service.js";
+import {
+  extractAndStripRpySymbols,
+  type DetectedCharacterStatement,
+  type DetectedDefaultStatement,
+} from "./rpy-statements.service.js";
 import { logError, LogEventType } from "../lib/logger.js";
 import {
   syncLabelsFromFile,
   updateIncomingJumpsForLabels,
 } from "./labels.service.js";
 import { createProject, deleteProject } from "./projects.service.js";
-import { labels } from "../db/schema/index.js";
 
 // ============================================================================
 // Import Guardrails
@@ -219,16 +229,58 @@ export async function importZipFile(
       return success;
     }
 
-    // Step 3: Pre-process all files (parse and hash) - outside transaction
-    // This is fast and doesn't need DB access, so failures don't roll back DB work
+    // Step 3: Pre-process all files (parse, hash, strip symbols) - outside
+    // transaction. This is fast and doesn't need DB access, so failures
+    // don't roll back DB work.
+    //
+    // We extract `define <tag> = Character(...)` and
+    // `default <key> = ...` statements and remove them from the
+    // stored file content. The DB becomes the single source of truth
+    // for those symbols, so re-exporting the project cannot produce
+    // duplicate `define`/`default` lines that would crash Ren'Py with
+    // `NameError: name 'X' is already defined`. See issue #244.
     const preProcessedFiles = extractedFiles.map((file) => {
       const parsed = parseRPYFileWithLabels(file.content, file.filePath);
+      const stripped = extractAndStripRpySymbols(file.content);
       return {
-        file,
+        filePath: file.filePath,
         fileType: parsed.fileType,
-        contentHash: calculateContentHash(file.content),
+        cleanedContent: stripped.cleanedContent,
+        originalContent: file.content,
+        symbols: {
+          characters: stripped.characters,
+          variables: stripped.variables,
+          stats: stripped.stats,
+        },
+        // Hash the cleaned content because that's what we store in
+        // `project_files.content`; identical inputs produce identical
+        // cleaned output, so re-imports of the same source file are
+        // correctly detected as no-ops.
+        contentHash: calculateContentHash(stripped.cleanedContent),
       };
     });
+
+    // Dedupe symbols across files. The strip step de-dupes within a
+    // single file, but the same character tag can appear in multiple
+    // files (e.g. `game/characters.rpy` and `game/script.rpy`). We
+    // keep the first occurrence so symbol metadata is stable.
+    const charactersByTag = new Map<string, DetectedCharacterStatement>();
+    const variablesByKey = new Map<string, DetectedDefaultStatement>();
+    const statsByKey = new Map<string, DetectedDefaultStatement>();
+    for (const f of preProcessedFiles) {
+      for (const c of f.symbols.characters) {
+        if (!charactersByTag.has(c.tag)) charactersByTag.set(c.tag, c);
+      }
+      for (const v of f.symbols.variables) {
+        if (!variablesByKey.has(v.key)) variablesByKey.set(v.key, v);
+      }
+      for (const s of f.symbols.stats) {
+        if (!statsByKey.has(s.key)) statsByKey.set(s.key, s);
+      }
+    }
+    const allCharacters = Array.from(charactersByTag.values());
+    const allVariables = Array.from(variablesByKey.values());
+    const allStats = Array.from(statsByKey.values());
 
     // Counters for tracking import statistics
     let filesImported = 0;
@@ -237,30 +289,14 @@ export async function importZipFile(
     let filesFailed = 0;
     let labelsCreated = 0;
 
-    // Step 4: Process all files in a single transaction with savepoints
-    const syncStoryLabels = async (
-      projectId: string,
-      file: ExtractedFile,
-      fileType: string,
-      fileId: string,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      tx: any
-    ) => {
-      if (fileType === "STORY") {
-        const syncResult = await syncLabelsFromFile(
-          projectId,
-          { filePath: file.filePath, fileType },
-          file.content,
-          fileId,
-          { skipCleanup: false, tx }
-        );
-        labelsCreated += syncResult.labelsCreated;
-      }
-    };
-
+    // Step 4: Process all files in a single transaction with savepoints.
+    // Each file's savepoint isolates per-file failures, so one bad
+    // file doesn't abort the whole import. We use the cleaned content
+    // for `project_files.content` and preserve the original
+    // (pre-strip) text in `originalContent` for round-tripping.
     await db.transaction(async (tx) => {
       let fileIndex = 0;
-      for (const { file, fileType, contentHash } of preProcessedFiles) {
+      for (const entry of preProcessedFiles) {
         const savepointName = `sp_${fileIndex}`;
 
         try {
@@ -275,28 +311,30 @@ export async function importZipFile(
               and(
                 eq(projectFiles.projectId, projectId),
                 eq(projectFiles.source, "ZIP"),
-                eq(projectFiles.filePath, file.filePath)
+                eq(projectFiles.filePath, entry.filePath)
               )
             )
             .limit(1);
 
           if (existing) {
             // Check if content has changed
-            if (existing.contentHash === contentHash) {
+            if (existing.contentHash === entry.contentHash) {
               filesSkipped++;
               await tx.execute(`RELEASE SAVEPOINT ${savepointName}`);
               continue;
             }
 
-            // Update existing file
+            // Update existing file with cleaned content
             await tx
               .update(projectFiles)
               .set({
-                content: file.content,
-                // Only set originalContent if it's null (preserve original on re-imports)
-                originalContent: sql`COALESCE(${projectFiles.originalContent}, ${file.content})`,
-                contentHash,
-                fileType,
+                content: entry.cleanedContent,
+                // Only set originalContent if it's null (preserve the
+                // originally imported file even after re-imports that
+                // strip the same lines again).
+                originalContent: sql`COALESCE(${projectFiles.originalContent}, ${entry.originalContent})`,
+                contentHash: entry.contentHash,
+                fileType: entry.fileType,
                 updatedAt: new Date(),
               })
               .where(eq(projectFiles.id, existing.id));
@@ -304,30 +342,48 @@ export async function importZipFile(
             filesUpdated++;
 
             // Sync labels for STORY files to create/update labels in database
-            await syncStoryLabels(projectId, file, fileType, existing.id, tx);
+            if (entry.fileType === "STORY") {
+              const syncResult = await syncLabelsFromFile(
+                projectId,
+                { filePath: entry.filePath, fileType: entry.fileType },
+                entry.originalContent, // Pass original content to parser
+                existing.id,
+                { skipCleanup: false, tx }
+              );
+              labelsCreated += syncResult.labelsCreated;
+            }
           } else {
-            // Insert new file
+            // Insert new file with cleaned content
             const [newFile] = await tx
               .insert(projectFiles)
               .values({
                 projectId,
                 source: "ZIP",
-                filePath: file.filePath,
-                fileType,
-                content: file.content,
-                originalContent: file.content, // Store original imported content for reconstruction
-                contentHash,
+                filePath: entry.filePath,
+                fileType: entry.fileType,
+                content: entry.cleanedContent,
+                originalContent: entry.originalContent, // Preserve the original
+                contentHash: entry.contentHash,
               })
               .returning();
 
             if (!newFile) {
-              throw new Error(`Failed to insert file: ${file.filePath}`);
+              throw new Error(`Failed to insert file: ${entry.filePath}`);
             }
 
             filesImported++;
 
             // Sync labels for STORY files to create labels in database
-            await syncStoryLabels(projectId, file, fileType, newFile.id, tx);
+            if (entry.fileType === "STORY") {
+              const syncResult = await syncLabelsFromFile(
+                projectId,
+                { filePath: entry.filePath, fileType: entry.fileType },
+                entry.originalContent, // Pass original content to parser
+                newFile.id,
+                { skipCleanup: false, tx }
+              );
+              labelsCreated += syncResult.labelsCreated;
+            }
           }
 
           // Release savepoint on success
@@ -350,7 +406,7 @@ export async function importZipFile(
           logError(LogEventType.SERVICE_ERROR, {
             event: "zip_file_import_failed",
             projectId,
-            filePath: file.filePath,
+            filePath: entry.filePath,
             error: error instanceof Error ? error.message : "Unknown error",
           });
 
@@ -358,6 +414,66 @@ export async function importZipFile(
         }
 
         fileIndex++;
+      }
+
+      // Step 5: Promote extracted `define`/`default` symbols into
+      // the database. This runs inside the same transaction as the
+      // per-file savepoint loop so the file inserts and the symbol
+      // promotion are atomic: either both commit or neither does.
+      // We use `onConflictDoNothing` so re-imports of the same RPY
+      // files are no-ops and the user's later UI edits to the DB
+      // rows are preserved.
+      if (
+        allCharacters.length > 0 ||
+        allVariables.length > 0 ||
+        allStats.length > 0
+      ) {
+        for (const c of allCharacters) {
+          await tx
+            .insert(characters)
+            .values({
+              projectId,
+              name: c.name ?? c.tag,
+              displayName: c.name ?? c.tag,
+              renpyTag: c.tag,
+              color: c.color || "#cfcfcf",
+              updatedAt: new Date(),
+            })
+            .onConflictDoNothing({
+              target: [characters.projectId, characters.renpyTag],
+            });
+        }
+        for (const v of allVariables) {
+          await tx
+            .insert(variables)
+            .values({
+              projectId,
+              key: v.key,
+            })
+            .onConflictDoNothing({
+              target: [variables.projectId, variables.key],
+            });
+        }
+        for (const s of allStats) {
+          // `default x = 0` becomes a stat with minValue=0 and the
+          // default maxValue of 100; users can adjust in the UI.
+          // Use parseFloat + round so that float values like 3.5
+          // are preserved (parseInt would silently truncate to 3).
+          const minValue = Math.round(Number.parseFloat(s.value)) || 0;
+          await tx
+            .insert(stats)
+            .values({
+              projectId,
+              key: s.key,
+              name: s.key,
+              minValue,
+              maxValue: 100,
+              updatedAt: new Date(),
+            })
+            .onConflictDoNothing({
+              target: [stats.projectId, stats.key],
+            });
+        }
       }
     });
 

--- a/apps/backend/src/services/zip-import.service.ts
+++ b/apps/backend/src/services/zip-import.service.ts
@@ -76,6 +76,41 @@ export type ImportZipResult = ImportZipSuccess | ImportZipFailure;
 // ============================================================================
 
 /**
+ * Aggregate a successfully imported file's extracted symbols into
+ * the running cross-file maps. The first occurrence of a given
+ * tag/key wins so symbol metadata is stable when the same name
+ * appears in multiple files.
+ *
+ * Only files that have been successfully inserted/updated (i.e.
+ * survived their per-file savepoint) should be passed in here —
+ * otherwise symbols from failed files would be promoted with no
+ * matching `project_files` row, leaving the database in an
+ * inconsistent state.
+ */
+function accumulateSymbols(
+  entry: {
+    symbols: {
+      characters: DetectedCharacterStatement[];
+      variables: DetectedDefaultStatement[];
+      stats: DetectedDefaultStatement[];
+    };
+  },
+  charactersByTag: Map<string, DetectedCharacterStatement>,
+  variablesByKey: Map<string, DetectedDefaultStatement>,
+  statsByKey: Map<string, DetectedDefaultStatement>
+): void {
+  for (const c of entry.symbols.characters) {
+    if (!charactersByTag.has(c.tag)) charactersByTag.set(c.tag, c);
+  }
+  for (const v of entry.symbols.variables) {
+    if (!variablesByKey.has(v.key)) variablesByKey.set(v.key, v);
+  }
+  for (const s of entry.symbols.stats) {
+    if (!statsByKey.has(s.key)) statsByKey.set(s.key, s);
+  }
+}
+
+/**
  * Extract all .rpy files from a JSZip object.
  * Skips:
  * - .rpyc files (compiled Ren'Py files)
@@ -260,34 +295,22 @@ export async function importZipFile(
       };
     });
 
-    // Dedupe symbols across files. The strip step de-dupes within a
-    // single file, but the same character tag can appear in multiple
-    // files (e.g. `game/characters.rpy` and `game/script.rpy`). We
-    // keep the first occurrence so symbol metadata is stable.
-    const charactersByTag = new Map<string, DetectedCharacterStatement>();
-    const variablesByKey = new Map<string, DetectedDefaultStatement>();
-    const statsByKey = new Map<string, DetectedDefaultStatement>();
-    for (const f of preProcessedFiles) {
-      for (const c of f.symbols.characters) {
-        if (!charactersByTag.has(c.tag)) charactersByTag.set(c.tag, c);
-      }
-      for (const v of f.symbols.variables) {
-        if (!variablesByKey.has(v.key)) variablesByKey.set(v.key, v);
-      }
-      for (const s of f.symbols.stats) {
-        if (!statsByKey.has(s.key)) statsByKey.set(s.key, s);
-      }
-    }
-    const allCharacters = Array.from(charactersByTag.values());
-    const allVariables = Array.from(variablesByKey.values());
-    const allStats = Array.from(statsByKey.values());
-
     // Counters for tracking import statistics
     let filesImported = 0;
     let filesUpdated = 0;
     let filesSkipped = 0;
     let filesFailed = 0;
     let labelsCreated = 0;
+
+    // Cross-file symbol aggregation. We populate this as files are
+    // successfully inserted/updated in Step 4 below (NOT from the
+    // raw preProcessedFiles list), so that files whose savepoint
+    // rolls back do not contribute characters / variables / stats
+    // to the database. The first occurrence of a given tag/key
+    // wins so symbol metadata is stable across files.
+    const charactersByTag = new Map<string, DetectedCharacterStatement>();
+    const variablesByKey = new Map<string, DetectedDefaultStatement>();
+    const statsByKey = new Map<string, DetectedDefaultStatement>();
 
     // Step 4: Process all files in a single transaction with savepoints.
     // Each file's savepoint isolates per-file failures, so one bad
@@ -340,6 +363,16 @@ export async function importZipFile(
               .where(eq(projectFiles.id, existing.id));
 
             filesUpdated++;
+            // Aggregate symbols from this successfully processed
+            // file. Skipped files (unchanged hash) don't contribute
+            // because their DB row already has whatever symbols
+            // were extracted on the prior import.
+            accumulateSymbols(
+              entry,
+              charactersByTag,
+              variablesByKey,
+              statsByKey
+            );
 
             // Sync labels for STORY files to create/update labels in database
             if (entry.fileType === "STORY") {
@@ -372,6 +405,18 @@ export async function importZipFile(
             }
 
             filesImported++;
+            // Aggregate symbols from this successfully processed
+            // file. Only files that survive the savepoint contribute
+            // to the symbol promotion that follows, so a malformed
+            // or failing file does not leave its characters /
+            // variables / stats stranded in the database with no
+            // matching `project_files` row.
+            accumulateSymbols(
+              entry,
+              charactersByTag,
+              variablesByKey,
+              statsByKey
+            );
 
             // Sync labels for STORY files to create labels in database
             if (entry.fileType === "STORY") {
@@ -423,6 +468,9 @@ export async function importZipFile(
       // We use `onConflictDoNothing` so re-imports of the same RPY
       // files are no-ops and the user's later UI edits to the DB
       // rows are preserved.
+      const allCharacters = Array.from(charactersByTag.values());
+      const allVariables = Array.from(variablesByKey.values());
+      const allStats = Array.from(statsByKey.values());
       if (
         allCharacters.length > 0 ||
         allVariables.length > 0 ||

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -62,7 +62,7 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.61.0",
-    "vite": "^7.3.5",
+    "vite": "^8.0.0",
     "vitest": "^4.1.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,7 +237,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.5(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 5.2.0(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/ui':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -281,11 +281,11 @@ importers:
         specifier: ^8.61.0
         version: 8.61.1(eslint@10.5.0(jiti@1.21.7))(typescript@5.9.3)
       vite:
-        specifier: ^7.3.5
-        version: 7.3.5(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/shared:
     devDependencies:
@@ -681,12 +681,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
@@ -707,12 +701,6 @@ packages:
 
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -741,12 +729,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.28.1':
     resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
@@ -767,12 +749,6 @@ packages:
 
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -801,12 +777,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
@@ -827,12 +797,6 @@ packages:
 
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -861,12 +825,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
@@ -887,12 +845,6 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -921,12 +873,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
@@ -947,12 +893,6 @@ packages:
 
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -981,12 +921,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
@@ -1007,12 +941,6 @@ packages:
 
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1041,12 +969,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
@@ -1067,12 +989,6 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1101,12 +1017,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
@@ -1127,12 +1037,6 @@ packages:
 
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1161,12 +1065,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
@@ -1175,12 +1073,6 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1209,12 +1101,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.28.1':
     resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
@@ -1223,12 +1109,6 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1257,12 +1137,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openbsd-x64@0.28.1':
     resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
@@ -1271,12 +1145,6 @@ packages:
 
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1305,12 +1173,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
@@ -1331,12 +1193,6 @@ packages:
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1365,12 +1221,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
@@ -1391,12 +1241,6 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2987,11 +2831,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
@@ -4502,46 +4341,6 @@ packages:
       terser:
         optional: true
 
-  vite@7.3.5:
-    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5297,9 +5096,6 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
@@ -5310,9 +5106,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
@@ -5327,9 +5120,6 @@ snapshots:
   '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
-    optional: true
-
   '@esbuild/android-arm@0.28.1':
     optional: true
 
@@ -5340,9 +5130,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.25.12':
-    optional: true
-
-  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
@@ -5357,9 +5144,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
@@ -5370,9 +5154,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
@@ -5387,9 +5168,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
@@ -5400,9 +5178,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -5417,9 +5192,6 @@ snapshots:
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
@@ -5430,9 +5202,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
@@ -5447,9 +5216,6 @@ snapshots:
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
@@ -5460,9 +5226,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
@@ -5477,9 +5240,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
@@ -5490,9 +5250,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -5507,9 +5264,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
@@ -5520,9 +5274,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
@@ -5537,16 +5288,10 @@ snapshots:
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
   '@esbuild/linux-x64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
@@ -5561,16 +5306,10 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
@@ -5585,16 +5324,10 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
@@ -5609,9 +5342,6 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.1':
     optional: true
 
@@ -5622,9 +5352,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
@@ -5639,9 +5366,6 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.1':
     optional: true
 
@@ -5652,9 +5376,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -6530,7 +6251,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -6538,7 +6259,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.5(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6556,14 +6277,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.5(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
-
   '@vitest/mocker@4.1.8(vite@8.0.8(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
@@ -6571,6 +6284,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.8(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.8(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.8(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -7213,35 +6934,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -8852,22 +8544,6 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vite@7.3.5(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rollup: 4.62.0
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 25.9.3
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      lightningcss: 1.32.0
-      tsx: 4.22.4
-      yaml: 2.9.0
-
   vite@8.0.8(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -8880,6 +8556,21 @@ snapshots:
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.22.4
+      yaml: 2.9.0
+
+  vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.3
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 1.21.7
       tsx: 4.22.4
       yaml: 2.9.0
 
@@ -8977,10 +8668,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@types/node@25.9.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -8997,7 +8688,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.8(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.3


### PR DESCRIPTION
## Summary

Fixes #244.

Two bugs in the Ren'Py project export/import flow:

**Bug 1 — zip export places `branchforge_*.rpy` at archive root**
`branchforge_variables.rpy`, `branchforge_stats.rpy` and
`branchforge_definitions.rpy` were written with bare keys, so the zip
contained them at the archive root instead of inside `game/`. Ren'Py
silently ignored them and the resulting project had no variables, stats
or character definitions.

**Bug 2 — exported files duplicate `define`/`default` symbols**
Both zip and GitLab exports could produce files containing
`define <tag> = Character(...)` and `default <key> = ...` lines that
already existed in the source project's files. Ren'Py then failed to
launch with `NameError: name 'X' is already defined`.

## Fix

- New utility `apps/backend/src/services/rpy-statements.service.ts`:
  - `computeCommonDirectoryPrefix` (moved from gitlab-sync)
  - `extractAndStripRpySymbols` recognises single- and multi-line
    `define|default <tag> = Character(...)` plus
    `default <key> = True|False|<number>` statements. Unknown RHS
    values are preserved rather than dropped.

- `export.service.ts` (zip): places the three generated files under
  the common top-level directory prefix computed from project file
  paths, mirroring the GitLab export. Defensively strips any
  `define`/`default` lines that may still be present in legacy
  `project_files.content` rows so existing projects are not broken.

- `zip-import.service.ts` and `gitlab-sync.service.ts`: strip symbols
  at ingestion, store the pre-strip text in `originalContent`, and
  promote the extracted characters / variables / stats into their
  tables with `onConflictDoNothing` for idempotent re-imports. The
  zip symbol-promotion now runs inside the same transaction as the
  per-file savepoint loop for atomicity.

- `characters.service.detectCharacters`: reads from
  `originalContent ?? content` so the import wizard still surfaces
  stripped characters.

## Verification

- `pnpm typecheck` — passes
- `pnpm lint` — passes
- `pnpm test:unit` — 745 backend + 815 frontend tests pass
  (30 new test cases across rpy-statements, export, and zip-import)
- `pnpm format` — clean
- Oracle security / architectural review verdict: **PASS**
  (after addressing all must-fix and should-fix findings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RPY symbol extraction now separates character, variable, and stat definitions into dedicated database tables during imports and exports.
  * Exports now place generated supporting `branchforge_*` files within the correct archive subdirectory (not always at the root), and GitLab sync follows the same cleaned-content flow.
* **Bug Fixes**
  * More robust sanitization of legacy and mixed-directory project content.
  * Improved handling of character parsing and idempotent zip imports (no symbol duplication).
* **Documentation**
  * Added a PR review checklist and pull request workflow guidelines.
* **Tests**
  * Added/expanded regression and parsing unit tests for export/import/symbol extraction.
* **Chores**
  * Updated Vite to v8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->