### PR TITLE
feat(visual-systems): add per-project visual system configuration

### DIFF
--- a/.changeset/green-emus-grin.md
+++ b/.changeset/green-emus-grin.md
@@ -1,0 +1,6 @@
+---
+"@branchforge/frontend": patch
+"@branchforge/backend": patch
+---
+
+Added per-project visual system configuration

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -21,6 +21,7 @@ import { statsRoutes } from "./routes/stats.routes.js";
 import { zipImportRoutes } from "./routes/zip-import.routes.js";
 import { flowRoutes } from "./routes/flow.routes.js";
 import { exportsRoutes } from "./routes/exports.routes.js";
+import { visualSystemsRoutes } from "./routes/visual-systems.routes.js";
 import { createDrizzleSessionStore } from "./services/session-store.service.js";
 import { setupShutdownHandlers } from "./lib/shutdown.js";
 import { globalErrorHandler } from "./middleware/error-handler.middleware.js";
@@ -157,6 +158,7 @@ await server.register(statsRoutes, { prefix: basePath });
 await server.register(zipImportRoutes, { prefix: basePath });
 await server.register(flowRoutes, { prefix: basePath });
 await server.register(exportsRoutes, { prefix: basePath });
+await server.register(visualSystemsRoutes, { prefix: basePath });
 
 // Register a global preValidation hook that enforces double-submit
 // CSRF protection on every state-changing request. The hook itself

--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -793,6 +793,98 @@ export const projectSettingsSchema = z
   .partial();
 
 /**
+ * Padding value for zero-padded number fields in visual system config.
+ * Matches the `1 | 2` union declared in VisualSystemConfig.
+ */
+const paddingSchema = z.union([z.literal(1), z.literal(2)], {
+  message: "Padding must be 1 or 2",
+});
+
+/**
+ * Group prefix entry: maps a group value (e.g. "I", "1") to a short
+ * filename prefix (e.g. "ai", "ch1"). Keys are non-empty trimmed strings.
+ */
+const groupPrefixEntrySchema = z.record(
+  z.string().trim().min(1),
+  z
+    .string()
+    .trim()
+    .min(1, "Group prefix cannot be empty")
+    .max(50, "Group prefix is too long")
+);
+
+/**
+ * Visual system config validation.
+ *
+ * The wire shape matches the shared `VisualSystemConfig` interface so
+ * frontend and backend stay in lockstep. All fields are optional in
+ * the update schema (`.partial()`) so clients can PATCH a subset.
+ *
+ * Clearing semantics: `defaultGroupType: ""` and `placeholderBaseUrl: ""`
+ * are explicitly accepted so clients can send an empty string to clear
+ * a previously-set value back to NULL. `groupPrefixes: {}` clears the
+ * stored map back to NULL too. The service layer converts these
+ * sentinels into `null` on write.
+ */
+export const visualSystemConfigSchema = z
+  .object({
+    namingTemplate: z
+      .string()
+      .trim()
+      .min(1, "Naming template is required")
+      .max(500, "Naming template is too long"),
+    groupPrefixes: z
+      .record(z.string().trim().min(1), groupPrefixEntrySchema)
+      .optional(),
+    defaultGroupType: z
+      .string()
+      .trim()
+      .max(50, "Default group type is too long")
+      .optional()
+      .or(z.literal("")),
+    labelPadding: paddingSchema,
+    counterPadding: paddingSchema,
+    jumpPrefixShared: z
+      .string()
+      .trim()
+      .min(1, "Shared jump prefix is required")
+      .max(100, "Shared jump prefix is too long"),
+    placeholderBaseUrl: z
+      .string()
+      .trim()
+      .max(2000, "Placeholder base URL is too long")
+      .refine(
+        (value) => {
+          if (value === "") return true;
+          try {
+            const url = new URL(value);
+            return url.protocol === "http:" || url.protocol === "https:";
+          } catch {
+            return false;
+          }
+        },
+        { message: "Placeholder base URL must be an http or https URL" }
+      )
+      .optional()
+      .or(z.literal("")),
+  })
+  .strict()
+  .partial();
+
+/**
+ * Visual system config defaults — applied when a project has no row in
+ * `visual_systems` yet (or when the client sends only a partial update).
+ *
+ * Kept in sync with the column defaults in `db/schema/tables/visual-systems.ts`.
+ */
+export const VISUAL_SYSTEM_CONFIG_DEFAULTS = {
+  namingTemplate: "{route}{group}_{label}_{counter}_{slug}",
+  labelPadding: 2,
+  counterPadding: 2,
+  jumpPrefixShared: "",
+} as const;
+
+/**
  * Character ID params validation
  */
 export const characterIdParamsSchema = z.object({
@@ -1133,6 +1225,7 @@ export type CreateCharacterInput = z.infer<typeof createCharacterSchema>;
 export type UpdateCharacterInput = z.infer<typeof updateCharacterSchema>;
 export type ImportCharactersInput = z.infer<typeof importCharactersSchema>;
 export type ProjectSettingsInput = z.infer<typeof projectSettingsSchema>;
+export type VisualSystemConfigInput = z.infer<typeof visualSystemConfigSchema>;
 export type DetectedCharacterInput = z.infer<typeof detectedCharacterSchema>;
 export type CreateGitLabIntegrationInput = z.infer<
   typeof createGitLabIntegrationSchema

--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -848,7 +848,12 @@ export const visualSystemConfigSchema = z
       .string()
       .trim()
       .min(1, "Shared jump prefix is required")
-      .max(100, "Shared jump prefix is too long"),
+      .max(100, "Shared jump prefix is too long")
+      // Empty string is the default value (see
+      // VISUAL_SYSTEM_CONFIG_DEFAULTS) and the clearing sentinel; the
+      // service stores it as-is since the column is NOT NULL and the
+      // shared `VisualSystemConfig` type declares the field as required.
+      .or(z.literal("")),
     placeholderBaseUrl: z
       .string()
       .trim()

--- a/apps/backend/src/routes/__tests__/visual-systems.routes.integration.test.ts
+++ b/apps/backend/src/routes/__tests__/visual-systems.routes.integration.test.ts
@@ -1,0 +1,607 @@
+/**
+ * Visual Systems Routes Integration Tests
+ *
+ * Tests for the visual system configuration HTTP endpoints
+ * (GET/PUT /projects/:projectId/visual-system) against a real database.
+ * Verifies full request/response cycles, auth middleware, service
+ * integration, and the default-row creation behavior.
+ *
+ * Prerequisites:
+ * - DATABASE_URL_TEST environment variable must be set
+ * - Test database must exist and have proper schema
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from "vitest";
+import Fastify, { type FastifyReply, type FastifyRequest } from "fastify";
+import cookie from "@fastify/cookie";
+import session from "@fastify/session";
+import { visualSystemsRoutes } from "../visual-systems.routes.js";
+import { getDb, closeDb } from "../../db/index.js";
+import { SESSION_COOKIE_NAME } from "../../lib/session.js";
+import { globalErrorHandler } from "../../middleware/error-handler.middleware.js";
+import { testEmail, testUuid } from "../../utils/test-ids.js";
+import {
+  users,
+  projects,
+  visualSystems,
+  userSessions,
+  type NewUser,
+  type NewProject,
+} from "../../db/schema/index.js";
+import { eq } from "drizzle-orm";
+
+describe("VisualSystemsRoutes (Integration)", () => {
+  let db: ReturnType<typeof getDb>;
+  let fastify: ReturnType<typeof Fastify>;
+
+  const testUserId = testUuid("02000000", 1);
+  const otherUserId = testUuid("02000000", 2);
+
+  const testUser: NewUser = {
+    id: testUserId,
+    email: testEmail("visual-systems-routes", "owner"),
+    passwordHash: "hashed_password",
+    role: "OWNER",
+  };
+
+  const otherUser: NewUser = {
+    id: otherUserId,
+    email: testEmail("visual-systems-routes", "other"),
+    passwordHash: "hashed_password",
+    role: "OWNER",
+  };
+
+  const testProject: NewProject = {
+    id: testUuid("12000000", 1),
+    userId: testUserId,
+    name: "Visual Systems Test Project",
+    description: "A test project for visual system routes",
+    maxStatDelta: 10,
+    source: "ZIP",
+  };
+
+  const otherProject: NewProject = {
+    id: testUuid("12000000", 2),
+    userId: otherUserId,
+    name: "Other User's Project",
+    description: "Owned by another user",
+    maxStatDelta: 10,
+    source: "ZIP",
+  };
+
+  async function cleanupTestData() {
+    // Visual systems cascade on project delete, but clean up first
+    // to be safe in case the project delete fails.
+    await db
+      .delete(visualSystems)
+      .where(eq(visualSystems.projectId, testProject.id!));
+    await db
+      .delete(visualSystems)
+      .where(eq(visualSystems.projectId, otherProject.id!));
+    await db.delete(projects).where(eq(projects.id, testProject.id!));
+    await db.delete(projects).where(eq(projects.id, otherProject.id!));
+    await db.delete(userSessions).where(eq(userSessions.userId, testUserId));
+    await db.delete(userSessions).where(eq(userSessions.userId, otherUserId));
+    await db.delete(users).where(eq(users.id, testUserId));
+    await db.delete(users).where(eq(users.id, otherUserId));
+  }
+
+  async function setupTestData() {
+    await db.insert(users).values([testUser, otherUser]);
+    await db.insert(projects).values([testProject, otherProject]);
+  }
+
+  async function createAuthenticatedRequest(userId: string) {
+    const loginResponse = await fastify.inject({
+      method: "POST",
+      url: "/test-login",
+      payload: { userId },
+    });
+
+    if (loginResponse.statusCode !== 200) {
+      throw new Error(
+        `Test login failed with status ${
+          loginResponse.statusCode
+        }: ${JSON.stringify(loginResponse.json())}`
+      );
+    }
+
+    const sessionCookie = loginResponse.cookies.find(
+      (c: { name: string; value: string }) => c.name === SESSION_COOKIE_NAME
+    );
+    const sessionId =
+      sessionCookie?.value ??
+      loginResponse.cookies.find(
+        (c: { name: string; value: string }) => c.name === "connect.sid"
+      )?.value;
+
+    if (!sessionId) {
+      throw new Error("Failed to create session cookie for test login");
+    }
+
+    return { sessionId };
+  }
+
+  beforeAll(async () => {
+    db = getDb();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestData();
+    await setupTestData();
+
+    fastify = Fastify();
+    await fastify.register(cookie);
+    await fastify.register(session, {
+      secret: "test-session-secret-for-visual-systems-integration-tests",
+      cookieName: SESSION_COOKIE_NAME,
+      cookie: {
+        secure: false,
+        httpOnly: true,
+        sameSite: "lax",
+        maxAge: 86400000,
+        path: "/",
+      },
+      saveUninitialized: true,
+      rolling: false,
+    });
+
+    await visualSystemsRoutes(fastify);
+    fastify.setErrorHandler(globalErrorHandler);
+
+    // Test-only login route — sets the session user from a userId in the body.
+    fastify.post(
+      "/test-login",
+      async (
+        request: FastifyRequest<{ Body: { userId: string } }>,
+        reply: FastifyReply
+      ) => {
+        const { userId } = request.body;
+        const [user] = await db
+          .select()
+          .from(users)
+          .where(eq(users.id, userId))
+          .limit(1);
+
+        if (!user) {
+          return reply.code(404).send({
+            success: false,
+            error: "user not found",
+          });
+        }
+
+        request.session.user = {
+          id: user.id,
+          email: user.email,
+          // The DB column allows NULL; the session shape doesn't.
+          // For tests we always seed a real role, so the cast is safe.
+          role: user.role as "OWNER" | "READER" | "TESTER",
+        };
+
+        reply.send({ success: true });
+      }
+    );
+
+    await fastify.ready();
+  });
+
+  afterEach(async () => {
+    if (fastify) {
+      await fastify.close();
+    }
+    await cleanupTestData();
+  });
+
+  // --------------------------------------------------------------------------
+  // GET /projects/:projectId/visual-system
+  // --------------------------------------------------------------------------
+
+  describe("GET /projects/:projectId/visual-system", () => {
+    it("returns 401 when not authenticated", async () => {
+      const response = await fastify.inject({
+        method: "GET",
+        url: `/projects/${testProject.id}/visual-system`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("returns 403 when user does not own the project", async () => {
+      const auth = await createAuthenticatedRequest(otherUserId);
+
+      const response = await fastify.inject({
+        method: "GET",
+        url: `/projects/${testProject.id}/visual-system`,
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it("returns 400 for an invalid projectId format", async () => {
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      const response = await fastify.inject({
+        method: "GET",
+        url: `/projects/not-a-uuid/visual-system`,
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("creates a default row and returns it on first read", async () => {
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      const response = await fastify.inject({
+        method: "GET",
+        url: `/projects/${testProject.id}/visual-system`,
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const config = response.json();
+      expect(config).toMatchObject({
+        namingTemplate: "{route}{group}_{label}_{counter}_{slug}",
+        labelPadding: 2,
+        counterPadding: 2,
+        jumpPrefixShared: "",
+      });
+      // Optional fields are absent (not null)
+      expect(config.groupPrefixes).toBeUndefined();
+      expect(config.defaultGroupType).toBeUndefined();
+      expect(config.placeholderBaseUrl).toBeUndefined();
+
+      // Verify the row was actually created in the DB
+      const [row] = await db
+        .select()
+        .from(visualSystems)
+        .where(eq(visualSystems.projectId, testProject.id!))
+        .limit(1);
+      expect(row).toBeDefined();
+      expect(row!.scenePadding).toBe(2); // legacy column maps to labelPadding
+    });
+
+    it("returns the existing config on subsequent reads", async () => {
+      // Pre-insert a custom config
+      await db.insert(visualSystems).values({
+        projectId: testProject.id!,
+        namingTemplate: "{label}_{slug}",
+        groupPrefixes: { act: { I: "ai" } },
+        defaultGroupType: "act",
+        scenePadding: 1,
+        counterPadding: 1,
+        jumpPrefixShared: "shared_",
+        placeholderBaseUrl: "https://example.com/img/",
+      });
+
+      const auth = await createAuthenticatedRequest(testUserId);
+      const response = await fastify.inject({
+        method: "GET",
+        url: `/projects/${testProject.id}/visual-system`,
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        namingTemplate: "{label}_{slug}",
+        groupPrefixes: { act: { I: "ai" } },
+        defaultGroupType: "act",
+        labelPadding: 1,
+        counterPadding: 1,
+        jumpPrefixShared: "shared_",
+        placeholderBaseUrl: "https://example.com/img/",
+      });
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // PUT /projects/:projectId/visual-system
+  // --------------------------------------------------------------------------
+
+  describe("PUT /projects/:projectId/visual-system", () => {
+    it("returns 401 when not authenticated", async () => {
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { namingTemplate: "x" },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("returns 403 when user does not own the project", async () => {
+      const auth = await createAuthenticatedRequest(otherUserId);
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { namingTemplate: "{label}_{slug}" },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
+    it("creates a row from a partial payload and returns the merged config", async () => {
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { labelPadding: 1 },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const config = response.json();
+      // labelPadding was patched
+      expect(config.labelPadding).toBe(1);
+      // other fields were filled with defaults
+      expect(config.namingTemplate).toBe(
+        "{route}{group}_{label}_{counter}_{slug}"
+      );
+      expect(config.counterPadding).toBe(2);
+      expect(config.jumpPrefixShared).toBe("");
+
+      // Confirm the DB has the expected value (legacy column = labelPadding)
+      const [row] = await db
+        .select()
+        .from(visualSystems)
+        .where(eq(visualSystems.projectId, testProject.id!))
+        .limit(1);
+      expect(row!.scenePadding).toBe(1);
+    });
+
+    it("patches only the supplied fields and leaves the rest alone", async () => {
+      // Pre-seed a custom config
+      await db.insert(visualSystems).values({
+        projectId: testProject.id!,
+        namingTemplate: "{label}_{slug}",
+        groupPrefixes: null,
+        defaultGroupType: "act",
+        scenePadding: 1,
+        counterPadding: 1,
+        jumpPrefixShared: "shared_",
+        placeholderBaseUrl: null,
+      });
+
+      const auth = await createAuthenticatedRequest(testUserId);
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { counterPadding: 2, defaultGroupType: "chapter" },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        namingTemplate: "{label}_{slug}", // unchanged
+        defaultGroupType: "chapter", // updated
+        labelPadding: 1, // unchanged
+        counterPadding: 2, // updated
+        jumpPrefixShared: "shared_", // unchanged
+      });
+    });
+
+    it("stores groupPrefixes as JSONB and round-trips it", async () => {
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: {
+          groupPrefixes: {
+            act: { I: "ai", II: "aii" },
+            chapter: { "1": "ch1" },
+          },
+        },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().groupPrefixes).toEqual({
+        act: { I: "ai", II: "aii" },
+        chapter: { "1": "ch1" },
+      });
+
+      // Confirm the underlying JSONB column holds the same data
+      const [row] = await db
+        .select({ groupPrefixes: visualSystems.groupPrefixes })
+        .from(visualSystems)
+        .where(eq(visualSystems.projectId, testProject.id!))
+        .limit(1);
+      expect(row!.groupPrefixes).toEqual({
+        act: { I: "ai", II: "aii" },
+        chapter: { "1": "ch1" },
+      });
+    });
+
+    it("treats empty placeholderBaseUrl as null", async () => {
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      // Seed with a value first
+      await db.insert(visualSystems).values({
+        projectId: testProject.id!,
+        namingTemplate: "{label}_{slug}",
+        groupPrefixes: null,
+        defaultGroupType: null,
+        scenePadding: 2,
+        counterPadding: 2,
+        jumpPrefixShared: "",
+        placeholderBaseUrl: "https://old.example.com/",
+      });
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { placeholderBaseUrl: "" },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(200);
+      // Empty string is normalized to null, so the wire shape omits the key
+      expect(response.json().placeholderBaseUrl).toBeUndefined();
+
+      const [row] = await db
+        .select({ placeholderBaseUrl: visualSystems.placeholderBaseUrl })
+        .from(visualSystems)
+        .where(eq(visualSystems.projectId, testProject.id!))
+        .limit(1);
+      expect(row!.placeholderBaseUrl).toBeNull();
+    });
+
+    it("clears defaultGroupType when set to an empty string", async () => {
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      // Seed with a value first
+      await db.insert(visualSystems).values({
+        projectId: testProject.id!,
+        namingTemplate: "{label}_{slug}",
+        groupPrefixes: null,
+        defaultGroupType: "act",
+        scenePadding: 2,
+        counterPadding: 2,
+        jumpPrefixShared: "",
+        placeholderBaseUrl: null,
+      });
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { defaultGroupType: "" },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().defaultGroupType).toBeUndefined();
+
+      const [row] = await db
+        .select({ defaultGroupType: visualSystems.defaultGroupType })
+        .from(visualSystems)
+        .where(eq(visualSystems.projectId, testProject.id!))
+        .limit(1);
+      expect(row!.defaultGroupType).toBeNull();
+    });
+
+    it("clears groupPrefixes when set to an empty object", async () => {
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      // Seed with a value first
+      await db.insert(visualSystems).values({
+        projectId: testProject.id!,
+        namingTemplate: "{label}_{slug}",
+        groupPrefixes: { act: { I: "ai" } },
+        defaultGroupType: "act",
+        scenePadding: 2,
+        counterPadding: 2,
+        jumpPrefixShared: "",
+        placeholderBaseUrl: null,
+      });
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { groupPrefixes: {} },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().groupPrefixes).toBeUndefined();
+
+      const [row] = await db
+        .select({ groupPrefixes: visualSystems.groupPrefixes })
+        .from(visualSystems)
+        .where(eq(visualSystems.projectId, testProject.id!))
+        .limit(1);
+      expect(row!.groupPrefixes).toBeNull();
+    });
+
+    it("returns 400 when placeholderBaseUrl uses a non-http(s) protocol", async () => {
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { placeholderBaseUrl: "ftp://example.com/img/" },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 400 when labelPadding is not 1 or 2", async () => {
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { labelPadding: 3 },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 400 when an unknown field is included", async () => {
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { totallyMadeUpField: "x" },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 400 when placeholderBaseUrl is not a URL", async () => {
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { placeholderBaseUrl: "not-a-url" },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 400 when an empty body is sent", async () => {
+      // Partial + strict means an empty object is technically valid.
+      // The schema-level `strict()` check is about unknown keys, not
+      // about emptiness. Sanity check: a totally empty body should
+      // produce a 200 with the defaults applied (no fields to patch).
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: {},
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        namingTemplate: "{route}{group}_{label}_{counter}_{slug}",
+        labelPadding: 2,
+        counterPadding: 2,
+        jumpPrefixShared: "",
+      });
+    });
+  });
+});

--- a/apps/backend/src/routes/__tests__/visual-systems.routes.integration.test.ts
+++ b/apps/backend/src/routes/__tests__/visual-systems.routes.integration.test.ts
@@ -529,6 +529,54 @@ describe("VisualSystemsRoutes (Integration)", () => {
       expect(row!.groupPrefixes).toBeNull();
     });
 
+    it("accepts an empty string for jumpPrefixShared and round-trips it", async () => {
+      // Regression: jumpPrefixShared is NOT NULL in the DB and is
+      // required by the shared VisualSystemConfig type, so empty
+      // string is the natural default/cleared value. The schema
+      // must accept it (no 400), the service must store it as-is
+      // (not NULL), and a subsequent GET must return "" unchanged.
+      const auth = await createAuthenticatedRequest(testUserId);
+
+      // Seed with a non-empty value first so we can verify the
+      // empty-string write actually overwrites it.
+      await db.insert(visualSystems).values({
+        projectId: testProject.id!,
+        namingTemplate: "{label}_{slug}",
+        groupPrefixes: null,
+        defaultGroupType: null,
+        scenePadding: 2,
+        counterPadding: 2,
+        jumpPrefixShared: "shared_",
+        placeholderBaseUrl: null,
+      });
+
+      const response = await fastify.inject({
+        method: "PUT",
+        url: `/projects/${testProject.id}/visual-system`,
+        payload: { jumpPrefixShared: "" },
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().jumpPrefixShared).toBe("");
+
+      const [row] = await db
+        .select({ jumpPrefixShared: visualSystems.jumpPrefixShared })
+        .from(visualSystems)
+        .where(eq(visualSystems.projectId, testProject.id!))
+        .limit(1);
+      expect(row!.jumpPrefixShared).toBe("");
+
+      // Round-trip: a subsequent GET should reflect the empty value.
+      const getResponse = await fastify.inject({
+        method: "GET",
+        url: `/projects/${testProject.id}/visual-system`,
+        cookies: { [SESSION_COOKIE_NAME]: auth.sessionId },
+      });
+      expect(getResponse.statusCode).toBe(200);
+      expect(getResponse.json().jumpPrefixShared).toBe("");
+    });
+
     it("returns 400 when placeholderBaseUrl uses a non-http(s) protocol", async () => {
       const auth = await createAuthenticatedRequest(testUserId);
 

--- a/apps/backend/src/routes/visual-systems.routes.ts
+++ b/apps/backend/src/routes/visual-systems.routes.ts
@@ -1,0 +1,110 @@
+/**
+ * Visual Systems Routes
+ *
+ * Thin HTTP wrappers that delegate to `visualSystemsService`. Handles
+ * request parsing, validation, and response mapping only.
+ *
+ * Endpoints:
+ *   GET  /projects/:projectId/visual-system
+ *   PUT  /projects/:projectId/visual-system
+ *
+ * Both require the caller to own the project (enforced in the service).
+ */
+
+import type { FastifyInstance } from "fastify";
+import type { FastifyRequest, FastifyReply } from "fastify";
+import { authenticate } from "../middleware/auth.middleware.js";
+import {
+  validateParams,
+  validateBody,
+} from "../middleware/validation.middleware.js";
+import {
+  projectIdParamsSchema,
+  visualSystemConfigSchema,
+  type VisualSystemConfigInput,
+} from "../lib/validation.js";
+import { visualSystemsService } from "../services/visual-systems.service.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ProjectParams {
+  projectId: string;
+}
+
+// ============================================================================
+// Route Handlers
+// ============================================================================
+
+/**
+ * Get the visual system config for a project.
+ *
+ * GET /projects/:projectId/visual-system
+ *
+ * Creates a default row on first read.
+ */
+async function getVisualSystemHandler(
+  request: FastifyRequest<{ Params: ProjectParams }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { projectId } = request.params;
+  const config = await visualSystemsService.getVisualSystemConfig(
+    projectId,
+    request.user!.id
+  );
+  reply.status(200).send(config);
+}
+
+/**
+ * Update the visual system config for a project.
+ *
+ * PUT /projects/:projectId/visual-system
+ * Body: VisualSystemConfigInput (partial — only provided fields are written)
+ */
+async function updateVisualSystemHandler(
+  request: FastifyRequest<{
+    Params: ProjectParams;
+    Body: VisualSystemConfigInput;
+  }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { projectId } = request.params;
+  const config = await visualSystemsService.updateVisualSystemConfig(
+    projectId,
+    request.user!.id,
+    request.body
+  );
+  reply.status(200).send(config);
+}
+
+// ============================================================================
+// Routes Registration
+// ============================================================================
+
+export async function visualSystemsRoutes(
+  fastify: FastifyInstance
+): Promise<void> {
+  // Get visual system config (auto-creates a default row on first read)
+  fastify.get<{ Params: ProjectParams }>(
+    "/projects/:projectId/visual-system",
+    {
+      onRequest: authenticate,
+      preValidation: validateParams(projectIdParamsSchema),
+    },
+    getVisualSystemHandler
+  );
+
+  // Update visual system config (partial; missing fields are left alone)
+  fastify.put<{ Params: ProjectParams; Body: VisualSystemConfigInput }>(
+    "/projects/:projectId/visual-system",
+    {
+      onRequest: authenticate,
+      preValidation: [
+        validateParams(projectIdParamsSchema),
+        validateBody(visualSystemConfigSchema),
+      ],
+    },
+    updateVisualSystemHandler
+  );
+}

--- a/apps/backend/src/services/visual-systems.service.ts
+++ b/apps/backend/src/services/visual-systems.service.ts
@@ -1,0 +1,240 @@
+/**
+ * Visual Systems Service
+ *
+ * Business logic for visual system configuration (1:1 with projects).
+ * The visual system config controls how generated Ren'Py visual
+ * filenames are produced (template tokens, group prefixes, padding).
+ *
+ * Authorization is enforced via `requireProjectOwnership` from
+ * `authz.service` — only the project owner may read or modify
+ * this configuration.
+ *
+ * The DB column `scene_padding` predates the shared `labelPadding`
+ * field on `VisualSystemConfig` and remains in the schema for
+ * backward compatibility. This service maps between the two
+ * transparently so the wire API always uses `labelPadding`.
+ */
+
+import { getDb } from "../db/index.js";
+import { visualSystems } from "../db/schema/index.js";
+import { eq } from "drizzle-orm";
+import { requireProjectOwnership } from "./authz.service.js";
+import {
+  VISUAL_SYSTEM_CONFIG_DEFAULTS,
+  type VisualSystemConfigInput,
+} from "../lib/validation.js";
+import type { VisualSystem, NewVisualSystem } from "../db/schema/index.js";
+import type { VisualSystemConfig } from "@branchforge/shared";
+import { logWarn, LogEventType } from "../lib/logger.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Wire shape returned to clients — matches the shared `VisualSystemConfig`. */
+export type VisualSystemConfigResult = VisualSystemConfig;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Map a DB row to the wire `VisualSystemConfig` shape.
+ *
+ * The DB still has `scenePadding` (a deprecated column name from the
+ * pre-shared-type era). The shared API uses `labelPadding`. They are
+ * the same value; this function renames the field for the response.
+ */
+function toConfig(row: VisualSystem): VisualSystemConfigResult {
+  // Drizzle's `jsonb` column type is typed as `unknown` at the row
+  // level; the application always writes a `Record<string, Record<string, string>>`
+  // there (validated by the Zod schema), so the cast is safe.
+  const groupPrefixes = row.groupPrefixes as
+    | Record<string, Record<string, string>>
+    | null
+    | undefined;
+  return {
+    namingTemplate: row.namingTemplate,
+    // Strip `null` → `undefined` so the wire shape matches the
+    // optional-fields interface in `@branchforge/shared`.
+    ...(groupPrefixes !== null && groupPrefixes !== undefined
+      ? { groupPrefixes }
+      : {}),
+    ...(row.defaultGroupType !== null && row.defaultGroupType !== undefined
+      ? { defaultGroupType: row.defaultGroupType }
+      : {}),
+    labelPadding: row.scenePadding as 1 | 2,
+    counterPadding: row.counterPadding as 1 | 2,
+    jumpPrefixShared: row.jumpPrefixShared,
+    ...(row.placeholderBaseUrl !== null && row.placeholderBaseUrl !== undefined
+      ? { placeholderBaseUrl: row.placeholderBaseUrl }
+      : {}),
+  };
+}
+
+/**
+ * Normalize an "optional string that can be cleared with empty string"
+ * field. Returns `null` for both `undefined` (field omitted from PATCH)
+ * and `""` (explicit clear).
+ */
+function optionalStringOrNull(value: string | undefined): string | null {
+  if (value === undefined || value === "") return null;
+  return value;
+}
+
+/**
+ * Normalize the `groupPrefixes` field. Returns `null` for both
+ * `undefined` (omitted) and `{}` (explicit clear).
+ */
+function optionalGroupPrefixes(
+  value: Record<string, Record<string, string>> | undefined
+): Record<string, Record<string, string>> | null {
+  if (value === undefined) return null;
+  if (Object.keys(value).length === 0) return null;
+  return value;
+}
+
+/**
+ * Build a full insert payload by merging the provided config
+ * with the project defaults. Any field left `undefined` in the
+ * input falls back to the default (this is what makes the
+ * "first get creates a default row" path safe).
+ */
+function buildInsertValues(
+  projectId: string,
+  input: Partial<VisualSystemConfigInput>
+): NewVisualSystem {
+  return {
+    projectId,
+    namingTemplate:
+      input.namingTemplate ?? VISUAL_SYSTEM_CONFIG_DEFAULTS.namingTemplate,
+    groupPrefixes: optionalGroupPrefixes(input.groupPrefixes),
+    defaultGroupType: optionalStringOrNull(input.defaultGroupType),
+    scenePadding:
+      input.labelPadding ?? VISUAL_SYSTEM_CONFIG_DEFAULTS.labelPadding,
+    counterPadding:
+      input.counterPadding ?? VISUAL_SYSTEM_CONFIG_DEFAULTS.counterPadding,
+    jumpPrefixShared:
+      input.jumpPrefixShared ?? VISUAL_SYSTEM_CONFIG_DEFAULTS.jumpPrefixShared,
+    placeholderBaseUrl: optionalStringOrNull(input.placeholderBaseUrl),
+    updatedAt: new Date(),
+  };
+}
+
+// ============================================================================
+// VisualSystemsService
+// ============================================================================
+
+export class VisualSystemsService {
+  /**
+   * Get the visual system config for a project, creating a default
+   * row on first read. Enforces project ownership.
+   */
+  async getVisualSystemConfig(
+    projectId: string,
+    userId: string
+  ): Promise<VisualSystemConfigResult> {
+    await requireProjectOwnership(projectId, userId);
+
+    const db = getDb();
+
+    // Insert defaults on conflict-do-nothing, then select. This makes
+    // the first GET idempotent: a concurrent second caller will not
+    // overwrite the row that the first caller is about to create.
+    await db
+      .insert(visualSystems)
+      .values(buildInsertValues(projectId, {}))
+      .onConflictDoNothing({ target: [visualSystems.projectId] });
+
+    const [row] = await db
+      .select()
+      .from(visualSystems)
+      .where(eq(visualSystems.projectId, projectId))
+      .limit(1);
+
+    if (!row) {
+      // Defensive: should be impossible after the upsert above. If it
+      // does happen, fall back to in-memory defaults so the caller
+      // still gets a usable config — but surface the anomaly so we
+      // can investigate a DB consistency issue if it ever fires.
+      logWarn(LogEventType.SERVICE_ERROR, {
+        message:
+          "Visual system row missing after upsert; returning in-memory defaults",
+        projectId,
+      });
+      return {
+        namingTemplate: VISUAL_SYSTEM_CONFIG_DEFAULTS.namingTemplate,
+        labelPadding: VISUAL_SYSTEM_CONFIG_DEFAULTS.labelPadding as 1 | 2,
+        counterPadding: VISUAL_SYSTEM_CONFIG_DEFAULTS.counterPadding as 1 | 2,
+        jumpPrefixShared: VISUAL_SYSTEM_CONFIG_DEFAULTS.jumpPrefixShared,
+      };
+    }
+
+    return toConfig(row);
+  }
+
+  /**
+   * Upsert (PATCH) the visual system config for a project.
+   * Enforces project ownership.
+   */
+  async updateVisualSystemConfig(
+    projectId: string,
+    userId: string,
+    input: VisualSystemConfigInput
+  ): Promise<VisualSystemConfigResult> {
+    await requireProjectOwnership(projectId, userId);
+
+    const db = getDb();
+
+    // Build the patch set. Only fields that the caller explicitly
+    // provided are written — `.partial()` on the schema guarantees
+    // `undefined` for omitted fields, and we treat that as "leave alone".
+    // For clearable fields (`defaultGroupType`, `placeholderBaseUrl`,
+    // `groupPrefixes`) an explicit empty value (`""` / `{}`) means
+    // "clear back to NULL", matching the dialog's clearing semantics.
+    const patch: Partial<NewVisualSystem> = { updatedAt: new Date() };
+    if (input.namingTemplate !== undefined) {
+      patch.namingTemplate = input.namingTemplate;
+    }
+    if (input.groupPrefixes !== undefined) {
+      patch.groupPrefixes = optionalGroupPrefixes(input.groupPrefixes);
+    }
+    if (input.defaultGroupType !== undefined) {
+      patch.defaultGroupType = optionalStringOrNull(input.defaultGroupType);
+    }
+    if (input.labelPadding !== undefined) {
+      patch.scenePadding = input.labelPadding;
+    }
+    if (input.counterPadding !== undefined) {
+      patch.counterPadding = input.counterPadding;
+    }
+    if (input.jumpPrefixShared !== undefined) {
+      patch.jumpPrefixShared = input.jumpPrefixShared;
+    }
+    if (input.placeholderBaseUrl !== undefined) {
+      patch.placeholderBaseUrl = optionalStringOrNull(input.placeholderBaseUrl);
+    }
+
+    const [updated] = await db
+      .insert(visualSystems)
+      .values(buildInsertValues(projectId, input))
+      .onConflictDoUpdate({
+        target: [visualSystems.projectId],
+        set: patch,
+      })
+      .returning();
+
+    if (!updated) {
+      // Both insert and update must return a row; if not, something
+      // is very wrong. Throw to surface the issue rather than
+      // silently returning a partial config.
+      throw new Error(
+        `Failed to upsert visual system config for project ${projectId}`
+      );
+    }
+
+    return toConfig(updated);
+  }
+}
+
+export const visualSystemsService = new VisualSystemsService();

--- a/apps/frontend/src/components/CharacterDialog.tsx
+++ b/apps/frontend/src/components/CharacterDialog.tsx
@@ -1,19 +1,20 @@
 /**
  * Character Dialog
  *
- * Dialog wrapper for character management.
- * Renders character list with add/edit/delete functionality.
- * Opens CharacterEditDialog for create and edit operations.
+ * Standalone wrapper that hosts the Characters settings inside a
+ * `Dialog`. The body is provided by `CharacterSettingsContent`,
+ * which is also used by the unified `ProjectSettingsDialog`.
+ *
+ * Currently no sidebar entry opens this directly — the unified
+ * modal is the primary entry. This component is kept for future
+ * call sites that want just the character CRUD without the full
+ * settings chrome (e.g. inline from a label's character list).
  */
 
-import { useState } from "react";
-import { X, Plus, Loader2 } from "lucide-react";
+import { X } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { InlineMessage } from "@/components/ui/inline-error";
-import { CharacterList } from "./CharacterList";
-import { CharacterEditDialog } from "./CharacterEditDialog.lazy";
-import { useCharacters } from "@/hooks/useCharacters";
+import { CharacterSettingsContent } from "@/components/CharacterSettingsContent";
 
 interface CharacterDialogProps {
   open: boolean;
@@ -21,154 +22,54 @@ interface CharacterDialogProps {
   projectId: string;
 }
 
-// Special mode ID for creating a new character.
-// EditMode uses a three-state pattern:
-// - null: Not editing any character
-// - MODE_NEW ("__new__"): Creating a new character (undefined characterId in edit dialog)
-// - string (actual ID): Editing existing character
-const MODE_NEW = "__new__" as const;
-type EditMode = null | typeof MODE_NEW | string;
-
 export function CharacterDialog({
   open,
   onOpenChange,
   projectId,
 }: CharacterDialogProps) {
-  const {
-    characters,
-    isLoadingCharacters,
-    charactersError,
-    isCreatingCharacter,
-    isUpdatingCharacter,
-    isDeletingCharacter,
-    isUploadingAvatar,
-    isDeletingAvatar,
-    deleteCharacter,
-  } = useCharacters(projectId);
-
-  const [editingCharacterId, setEditingCharacterId] = useState<EditMode>(null);
-
-  const isSaving =
-    isCreatingCharacter ||
-    isUpdatingCharacter ||
-    isDeletingCharacter ||
-    isUploadingAvatar ||
-    isDeletingAvatar;
-
-  const handleDelete = async (characterId: string) => {
-    try {
-      await deleteCharacter(characterId);
-    } catch {
-      // Error handled by hook's toast
-    }
-  };
-
   return (
-    <>
-      <Dialog
-        open={open}
-        onOpenChange={(open) => {
-          if (!open) setEditingCharacterId(null);
-          onOpenChange(open);
-        }}
-      >
-        <DialogContent className="max-w-3xl w-full max-h-[90vh] p-0 gap-0 flex flex-col">
-          {/* Header */}
-          <div className="p-6 border-b border-border/30 flex items-start justify-between">
-            <div>
-              <h2 className="text-lg font-medium">Character Management</h2>
-              <p className="text-sm text-muted-foreground mt-1">
-                Manage characters for your visual novel project. Characters are
-                NPCs and love interests that appear in dialogue.
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => onOpenChange(false)}
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <X className="size-5" />
-            </button>
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onOpenChange(false);
+        else onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent className="max-w-3xl w-full max-h-[90vh] p-0 gap-0 flex flex-col">
+        {/* Header */}
+        <div className="p-6 border-b border-border/30 flex items-start justify-between">
+          <div>
+            <h2 className="text-lg font-medium">Character Management</h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              Manage characters for your visual novel project. Characters are
+              NPCs and love interests that appear in dialogue.
+            </p>
           </div>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <X className="size-5" />
+          </button>
+        </div>
 
-          {/* Content */}
-          <div className="flex-1 overflow-y-auto p-6">
-            <div className="space-y-4">
-              {isLoadingCharacters ? (
-                <div className="flex items-center justify-center py-8">
-                  <output>
-                    <Loader2 className="size-6 animate-spin text-muted-foreground" />
-                  </output>
-                </div>
-              ) : charactersError ? (
-                <InlineMessage variant="error">
-                  Failed to load characters
-                </InlineMessage>
-              ) : characters.length === 0 ? (
-                <div className="space-y-4">
-                  <div className="p-8 border border-dashed border-border/30 rounded-md text-center">
-                    <p className="text-sm text-muted-foreground">
-                      No characters configured yet. Add your first character to
-                      get started.
-                    </p>
-                  </div>
-                  <Button
-                    type="button"
-                    onClick={() => setEditingCharacterId(MODE_NEW)}
-                    disabled={isSaving}
-                    className="w-full"
-                  >
-                    <Plus className="size-4 mr-2" />
-                    Add Character
-                  </Button>
-                </div>
-              ) : (
-                <div className="space-y-4">
-                  <Button
-                    type="button"
-                    onClick={() => setEditingCharacterId(MODE_NEW)}
-                    disabled={isSaving}
-                    className="w-full"
-                  >
-                    <Plus className="size-4 mr-2" />
-                    Add Another Character
-                  </Button>
-                  <CharacterList
-                    characters={characters}
-                    isSaving={isSaving}
-                    onEdit={setEditingCharacterId}
-                    onDelete={handleDelete}
-                  />
-                </div>
-              )}
-            </div>
-          </div>
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-6">
+          <CharacterSettingsContent projectId={projectId} />
+        </div>
 
-          {/* Footer */}
-          <div className="p-6 border-t border-border/30 flex justify-end">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              Close
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      <CharacterEditDialog
-        open={editingCharacterId !== null}
-        onOpenChange={(open) => {
-          if (!open) setEditingCharacterId(null);
-        }}
-        projectId={projectId}
-        characterId={
-          editingCharacterId === MODE_NEW
-            ? undefined
-            : (editingCharacterId as string | undefined)
-        }
-      />
-    </>
+        {/* Footer */}
+        <div className="p-6 border-t border-border/30 flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/frontend/src/components/CharacterDialog.tsx
+++ b/apps/frontend/src/components/CharacterDialog.tsx
@@ -49,6 +49,7 @@ export function CharacterDialog({
             type="button"
             onClick={() => onOpenChange(false)}
             className="text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Close character dialog"
           >
             <X className="size-5" />
           </button>

--- a/apps/frontend/src/components/CharacterList.tsx
+++ b/apps/frontend/src/components/CharacterList.tsx
@@ -16,6 +16,13 @@ interface CharacterListProps {
   isSaving: boolean;
   onEdit: (characterId: string) => void;
   onDelete: (characterId: string) => void | Promise<void>;
+  /**
+   * Number of columns in the card grid. Defaults to 1
+   * (single-column stack). Pass 2 to render in a 2-column grid —
+   * used by the `ProjectSettingsDialog` tab to keep the dialog
+   * frame height stable.
+   */
+  columns?: 1 | 2;
 }
 
 export function CharacterList({
@@ -23,6 +30,7 @@ export function CharacterList({
   isSaving,
   onEdit,
   onDelete,
+  columns = 1,
 }: CharacterListProps) {
   const [deleteTarget, setDeleteTarget] = useState<Character | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -45,7 +53,11 @@ export function CharacterList({
 
   return (
     <>
-      <div className="space-y-4">
+      <div
+        className={
+          columns === 2 ? "grid grid-cols-1 sm:grid-cols-2 gap-3" : "space-y-4"
+        }
+      >
         {characters.map((character) => (
           <div
             key={character.id}

--- a/apps/frontend/src/components/CharacterSettingsContent.tsx
+++ b/apps/frontend/src/components/CharacterSettingsContent.tsx
@@ -1,0 +1,138 @@
+/**
+ * Character Settings Content
+ *
+ * Body of the "Characters" tab. Renders the list of project
+ * characters with add / edit / delete, plus the inner
+ * `CharacterEditDialog` for the create-or-edit flow. No dialog
+ * chrome here — the parent (`ProjectSettingsDialog` or the
+ * standalone `CharacterDialog`) provides that.
+ */
+
+import { useState } from "react";
+import { Loader2, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { InlineMessage } from "@/components/ui/inline-error";
+import { CharacterList } from "./CharacterList";
+import { CharacterEditDialog } from "./CharacterEditDialog.lazy";
+import { useCharacters } from "@/hooks/useCharacters";
+
+interface CharacterSettingsContentProps {
+  projectId: string;
+  /**
+   * Number of columns for the character list grid. Defaults to 1
+   * (single-column stack — matches the standalone `CharacterDialog`).
+   * The `ProjectSettingsDialog` tab uses 2 to keep the dialog
+   * frame height stable across tabs.
+   */
+  columns?: 1 | 2;
+}
+
+// Special mode ID for creating a new character.
+// EditMode uses a three-state pattern:
+// - null: Not editing any character
+// - MODE_NEW ("__new__"): Creating a new character
+// - string (actual ID): Editing existing character
+const MODE_NEW = "__new__" as const;
+type EditMode = null | typeof MODE_NEW | string;
+
+export function CharacterSettingsContent({
+  projectId,
+  columns = 1,
+}: CharacterSettingsContentProps) {
+  const {
+    characters,
+    isLoadingCharacters,
+    charactersError,
+    isCreatingCharacter,
+    isUpdatingCharacter,
+    isDeletingCharacter,
+    isUploadingAvatar,
+    isDeletingAvatar,
+    deleteCharacter,
+  } = useCharacters(projectId);
+
+  const [editingCharacterId, setEditingCharacterId] = useState<EditMode>(null);
+
+  const isSaving =
+    isCreatingCharacter ||
+    isUpdatingCharacter ||
+    isDeletingCharacter ||
+    isUploadingAvatar ||
+    isDeletingAvatar;
+
+  const handleDelete = async (characterId: string) => {
+    try {
+      await deleteCharacter(characterId);
+    } catch {
+      // Error handled by hook's toast
+    }
+  };
+
+  return (
+    <>
+      <div className="space-y-4">
+        {isLoadingCharacters ? (
+          <div className="flex items-center justify-center py-8">
+            <output>
+              <Loader2 className="size-6 animate-spin text-muted-foreground" />
+            </output>
+          </div>
+        ) : charactersError ? (
+          <InlineMessage variant="error">
+            Failed to load characters
+          </InlineMessage>
+        ) : characters.length === 0 ? (
+          <div className="space-y-4">
+            <div className="p-8 border border-dashed border-border/30 rounded-md text-center">
+              <p className="text-sm text-muted-foreground">
+                No characters configured yet. Add your first character to get
+                started.
+              </p>
+            </div>
+            <Button
+              type="button"
+              onClick={() => setEditingCharacterId(MODE_NEW)}
+              disabled={isSaving}
+              className="w-full"
+            >
+              <Plus className="size-4 mr-2" />
+              Add Character
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <Button
+              type="button"
+              onClick={() => setEditingCharacterId(MODE_NEW)}
+              disabled={isSaving}
+              className="w-full"
+            >
+              <Plus className="size-4 mr-2" />
+              Add Another Character
+            </Button>
+            <CharacterList
+              characters={characters}
+              isSaving={isSaving}
+              onEdit={setEditingCharacterId}
+              onDelete={handleDelete}
+              columns={columns}
+            />
+          </div>
+        )}
+      </div>
+
+      <CharacterEditDialog
+        open={editingCharacterId !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditingCharacterId(null);
+        }}
+        projectId={projectId}
+        characterId={
+          editingCharacterId === MODE_NEW
+            ? undefined
+            : (editingCharacterId as string | undefined)
+        }
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -17,7 +17,14 @@
  */
 
 import { useState } from "react";
-import { Loader2, Users, Route as RouteIcon, Wand2, X } from "lucide-react";
+import {
+  AlertCircle,
+  Loader2,
+  Users,
+  Route as RouteIcon,
+  Wand2,
+  X,
+} from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsPanel } from "@/components/ui/tabs";
@@ -188,7 +195,7 @@ interface VisualSystemTabContentProps {
 }
 
 function VisualSystemTabContent({ projectId }: VisualSystemTabContentProps) {
-  const { config, isLoading, isSaving, updateConfig } =
+  const { config, isLoading, isError, isSaving, updateConfig, refetch } =
     useVisualSystem(projectId);
 
   const handleSave = async (form: VisualSystemFormState) => {
@@ -211,6 +218,31 @@ function VisualSystemTabContent({ projectId }: VisualSystemTabContentProps) {
       groupPrefixes: parsed.value ?? {},
     });
   };
+
+  // Three states: loading (spinner), error (retry UI), ready (form).
+  // Previously the dialog showed the spinner whenever `config` was
+  // undefined, which also fires on a failed fetch — leaving the
+  // user with no recovery path.
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+        <AlertCircle className="size-8 text-destructive" aria-hidden="true" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Failed to load visual system</p>
+          <p className="text-xs text-muted-foreground">
+            Check your connection and try again.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="text-sm font-medium text-[var(--theme-color)] hover:underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
 
   if (isLoading || !config) {
     return (

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -16,7 +16,7 @@
  * the left sidebar.
  */
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Loader2, Users, Route as RouteIcon, Wand2, X } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -78,21 +78,32 @@ export function ProjectSettingsDialog({
   // Reset to the default tab each time the modal opens. This way a
   // user who closes the dialog while on "Visual" comes back to
   // "Characters" (the most-edited tab) rather than landing on a
-  // config screen they were last fiddling with.
+  // config screen they were last fiddling with. The reset is done
+  // during render (not in an effect) so there's no flash of the
+  // previous tab on reopen — React's "storing information from
+  // previous renders" pattern.
+  // (The previous-value tracker must be `useState` rather than
+  // `useRef` because the `react-hooks/refs` rule forbids reading
+  // and writing refs during render. The extra render that the
+  // tracker produces is the cost of this pattern.)
   const [activeTab, setActiveTab] = useState<SettingsTab>(defaultTab);
-  useEffect(() => {
+  // react-doctor-disable-next-line react-doctor/no-derived-useState, react-doctor/rerender-state-only-in-handlers
+  const [prevOpen, setPrevOpen] = useState(open);
+  // react-doctor-disable-next-line react-doctor/no-derived-useState, react-doctor/rerender-state-only-in-handlers
+  const [prevDefaultTab, setPrevDefaultTab] = useState(defaultTab);
+  if (open !== prevOpen || defaultTab !== prevDefaultTab) {
+    setPrevOpen(open);
+    setPrevDefaultTab(defaultTab);
     if (open) {
       setActiveTab(defaultTab);
     }
-  }, [open, defaultTab]);
+  }
 
   return (
     <Dialog
       open={open}
-      onOpenChange={(next) => {
-        if (!next) setActiveTab(defaultTab);
-        onOpenChange(next);
-      }}
+      onOpenChange={onOpenChange}
+      aria-label="Project Settings"
     >
       <DialogContent className="max-w-3xl w-full h-[80vh] min-h-[500px] p-0 gap-0 flex flex-col overflow-hidden">
         {/* Header */}

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -1,0 +1,227 @@
+/**
+ * Project Settings Dialog
+ *
+ * Unified modal that hosts the project's configuration tabs:
+ *   - Characters (1:N CRUD — list + add/edit/delete)
+ *   - Routes (1:N CRUD — list + add/edit/delete)
+ *   - Visual System (1:1 config — single form with live preview)
+ *
+ * Each tab is a self-contained piece of state and persistence.
+ * The outer dialog is just a navigation shell: no global save,
+ * just a Close button. Inner edit dialogs (for Characters and
+ * Routes) stack on top as dialog-over-dialog, matching the
+ * pattern the user prefers over inline editing.
+ *
+ * Replaces the separate Routes / Characters sidebar entries in
+ * the left sidebar.
+ */
+
+import { useEffect, useState } from "react";
+import { Loader2, Users, Route as RouteIcon, Wand2, X } from "lucide-react";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger, TabsPanel } from "@/components/ui/tabs";
+import { CharacterSettingsContent } from "@/components/CharacterSettingsContent";
+import { RouteSettingsContent } from "@/components/RouteSettingsContent";
+import { VisualSystemFormContent } from "@/components/VisualSystemDialog";
+import { useVisualSystem } from "@/hooks/useVisualSystem";
+import {
+  parseGroupPrefixes,
+  type VisualSystemFormState,
+} from "@/components/visual-system.helpers";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ProjectSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  /** Optional initial tab. Defaults to "characters". */
+  defaultTab?: SettingsTab;
+}
+
+export type SettingsTab = "characters" | "routes" | "visual";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const TAB_LABELS: Record<SettingsTab, string> = {
+  characters: "Characters",
+  routes: "Routes",
+  visual: "Visual System",
+};
+
+const TAB_ICONS: Record<
+  SettingsTab,
+  React.ComponentType<{ className?: string }>
+> = {
+  characters: Users,
+  routes: RouteIcon,
+  visual: Wand2,
+};
+
+const TAB_ORDER: SettingsTab[] = ["characters", "routes", "visual"];
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function ProjectSettingsDialog({
+  open,
+  onOpenChange,
+  projectId,
+  defaultTab = "characters",
+}: ProjectSettingsDialogProps) {
+  // Reset to the default tab each time the modal opens. This way a
+  // user who closes the dialog while on "Visual" comes back to
+  // "Characters" (the most-edited tab) rather than landing on a
+  // config screen they were last fiddling with.
+  const [activeTab, setActiveTab] = useState<SettingsTab>(defaultTab);
+  useEffect(() => {
+    if (open) {
+      setActiveTab(defaultTab);
+    }
+  }, [open, defaultTab]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setActiveTab(defaultTab);
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="max-w-3xl w-full h-[80vh] min-h-[500px] p-0 gap-0 flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="p-6 border-b border-border/30 flex items-start justify-between shrink-0">
+          <div>
+            <h2 className="text-lg font-medium">Project Settings</h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              Configure characters, routes, and visual filename generation.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Close project settings"
+          >
+            <X className="size-5" />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <Tabs
+          value={activeTab}
+          onValueChange={(next) => setActiveTab(next as SettingsTab)}
+          className="flex flex-col flex-1 min-h-0"
+        >
+          <div className="px-6 pt-2 shrink-0">
+            <TabsList ariaLabel="Project settings sections">
+              {TAB_ORDER.map((tab) => {
+                const Icon = TAB_ICONS[tab];
+                return (
+                  <TabsTrigger key={tab} value={tab}>
+                    <span className="inline-flex items-center gap-1.5">
+                      <Icon className="size-3.5" />
+                      {TAB_LABELS[tab]}
+                    </span>
+                  </TabsTrigger>
+                );
+              })}
+            </TabsList>
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-6">
+            <TabsPanel value="characters" className="space-y-4">
+              <CharacterSettingsContent projectId={projectId} columns={2} />
+            </TabsPanel>
+            <TabsPanel value="routes" className="space-y-4">
+              <RouteSettingsContent projectId={projectId} columns={2} />
+            </TabsPanel>
+            <TabsPanel value="visual" className="space-y-4">
+              <VisualSystemTabContent projectId={projectId} />
+            </TabsPanel>
+          </div>
+        </Tabs>
+
+        {/* Footer */}
+        <div className="p-6 border-t border-border/30 flex justify-end shrink-0">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ============================================================================
+// Visual System tab content
+// ============================================================================
+//
+// Renders the visual system form directly inside the tab — not as
+// a nested dialog. Closing the project-settings modal also closes
+// the tab. Cancel/Save are scoped to the form (the outer dialog
+// has its own Close button).
+
+interface VisualSystemTabContentProps {
+  projectId: string;
+}
+
+function VisualSystemTabContent({ projectId }: VisualSystemTabContentProps) {
+  const { config, isLoading, isSaving, updateConfig } =
+    useVisualSystem(projectId);
+
+  const handleSave = async (form: VisualSystemFormState) => {
+    const parsed = parseGroupPrefixes(form.groupPrefixesJson);
+    // Always include all fields. The PATCH semantics on the server
+    // mean that *omitting* a key would leave the existing value
+    // untouched, so to *clear* optional fields we have to send the
+    // explicit empty-string / empty-object sentinel. The service
+    // converts these to NULL on write.
+    await updateConfig({
+      namingTemplate: form.namingTemplate.trim(),
+      labelPadding: form.labelPadding,
+      counterPadding: form.counterPadding,
+      jumpPrefixShared: form.jumpPrefixShared.trim(),
+      defaultGroupType: form.defaultGroupType.trim(),
+      placeholderBaseUrl: form.placeholderBaseUrl.trim(),
+      // `parsed.value` is `null` for empty input. The service treats
+      // `{}` as "clear to NULL", so always pass either the parsed
+      // object or `{}` (never `undefined`).
+      groupPrefixes: parsed.value ?? {},
+    });
+  };
+
+  if (isLoading || !config) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <output>
+          <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        </output>
+      </div>
+    );
+  }
+
+  return (
+    <VisualSystemFormContent
+      key="visual-system-tab"
+      initialConfig={config}
+      isSaving={isSaving}
+      onSave={handleSave}
+      // The form's "Cancel" button is a no-op inside the tab — the
+      // user closes the project-settings modal via the outer Close
+      // button (or the X in the header). Keeping Cancel visible
+      // preserves visual parity with the standalone dialog.
+      onClose={() => {}}
+    />
+  );
+}

--- a/apps/frontend/src/components/RouteList.tsx
+++ b/apps/frontend/src/components/RouteList.tsx
@@ -15,6 +15,13 @@ interface RouteListProps {
   isSaving: boolean;
   onEdit: (routeId: string) => void;
   onDelete: (routeId: string) => void | Promise<void>;
+  /**
+   * Number of columns in the route card grid. Defaults to 1
+   * (single-column stack). Pass 2 to render in a 2-column grid —
+   * used by the `ProjectSettingsDialog` tab to keep the dialog
+   * frame height stable.
+   */
+  columns?: 1 | 2;
 }
 
 export function RouteList({
@@ -22,6 +29,7 @@ export function RouteList({
   isSaving,
   onEdit,
   onDelete,
+  columns = 1,
 }: RouteListProps) {
   const [deleteTarget, setDeleteTarget] = useState<RouteConfig | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -44,7 +52,11 @@ export function RouteList({
 
   return (
     <>
-      <div className="space-y-2">
+      <div
+        className={
+          columns === 2 ? "grid grid-cols-1 sm:grid-cols-2 gap-3" : "space-y-2"
+        }
+      >
         {routes.map((route) => (
           <div
             key={route.id}

--- a/apps/frontend/src/components/RouteSettingsContent.tsx
+++ b/apps/frontend/src/components/RouteSettingsContent.tsx
@@ -1,0 +1,127 @@
+/**
+ * Route Settings Content
+ *
+ * Body of the "Routes" tab. Renders the list of project route
+ * configurations with add / edit / delete, plus the inner
+ * `RouteEditDialog` for the create-or-edit flow. No dialog chrome
+ * here — the parent (`ProjectSettingsDialog` or the standalone
+ * `RouteSettingsDialog`) provides that.
+ */
+
+import { useState } from "react";
+import { Loader2, Plus } from "lucide-react";
+import { InlineMessage } from "@/components/ui/inline-error";
+import { Button } from "@/components/ui/button";
+import { RouteList } from "@/components/RouteList";
+import { RouteEditDialog } from "@/components/RouteEditDialog.lazy";
+import { useRouteConfigs } from "@/hooks/useRouteConfigs";
+
+interface RouteSettingsContentProps {
+  projectId: string;
+  /**
+   * Number of columns for the route list grid. Defaults to 1
+   * (single-column stack — matches the standalone `RouteSettingsDialog`).
+   * The `ProjectSettingsDialog` tab uses 2 to keep the dialog
+   * frame height stable across tabs.
+   */
+  columns?: 1 | 2;
+}
+
+// Special mode ID for creating a new route. See the matching
+// pattern in `CharacterSettingsContent` for context.
+const MODE_NEW = "__new__" as const;
+type EditMode = null | typeof MODE_NEW | string;
+
+export function RouteSettingsContent({
+  projectId,
+  columns = 1,
+}: RouteSettingsContentProps) {
+  const [editingRouteId, setEditingRouteId] = useState<EditMode>(null);
+
+  const {
+    routeConfigs,
+    isLoadingRouteConfigs,
+    routeConfigsError,
+    isCreatingRouteConfig,
+    isUpdatingRouteConfig,
+    isDeletingRouteConfig,
+    deleteRouteConfig,
+  } = useRouteConfigs(projectId);
+
+  const isSaving =
+    isCreatingRouteConfig || isUpdatingRouteConfig || isDeletingRouteConfig;
+
+  const handleDelete = async (routeId: string) => {
+    try {
+      await deleteRouteConfig(routeId);
+    } catch {
+      // Error handled by hook toast
+    }
+  };
+
+  return (
+    <>
+      <div className="space-y-4">
+        {isLoadingRouteConfigs ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="size-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : routeConfigsError ? (
+          <InlineMessage variant="error">
+            Failed to load route configurations
+          </InlineMessage>
+        ) : routeConfigs.length === 0 ? (
+          <div className="space-y-4">
+            <div className="p-8 border border-dashed border-border/30 rounded-md text-center">
+              <p className="text-sm text-muted-foreground">
+                No routes configured yet. Add your first route to get started.
+              </p>
+            </div>
+            <Button
+              type="button"
+              onClick={() => setEditingRouteId(MODE_NEW)}
+              disabled={isSaving}
+              className="w-full"
+            >
+              <Plus className="size-4 mr-2" />
+              Add Route
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setEditingRouteId(MODE_NEW)}
+              disabled={isSaving}
+              className="w-full"
+            >
+              <Plus className="size-4 mr-2" />
+              Add Another Route
+            </Button>
+            <RouteList
+              routes={routeConfigs}
+              isSaving={isSaving}
+              onEdit={setEditingRouteId}
+              onDelete={handleDelete}
+              columns={columns}
+            />
+          </div>
+        )}
+      </div>
+
+      <RouteEditDialog
+        open={editingRouteId !== null}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setEditingRouteId(null);
+        }}
+        projectId={projectId}
+        routeId={
+          editingRouteId === MODE_NEW
+            ? undefined
+            : (editingRouteId as string | undefined)
+        }
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/components/VisualSystemDialog.tsx
+++ b/apps/frontend/src/components/VisualSystemDialog.tsx
@@ -10,7 +10,7 @@
  * so the user gets immediate feedback on their template edits.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Loader2, Wand2 } from "lucide-react";
 import {
   Dialog,
@@ -130,12 +130,21 @@ export function VisualSystemFormContent({
   );
   const [errors, setErrors] = useState<VisualSystemFormErrors>({});
 
-  // When the server config first arrives, hydrate the form.
-  useEffect(() => {
+  // When the server config first arrives (or changes after a save),
+  // re-hydrate the form. Done during render — not in an effect — so
+  // the form is in sync with `initialConfig` from the same commit,
+  // avoiding a one-frame flash of stale values.
+  // (The previous-value tracker must be `useState` rather than
+  // `useRef` because the `react-hooks/refs` rule forbids reading
+  // and writing refs during render.)
+  // react-doctor-disable-next-line react-doctor/rerender-state-only-in-handlers
+  const [hydratedConfig, setHydratedConfig] = useState(initialConfig);
+  if (initialConfig !== hydratedConfig) {
+    setHydratedConfig(initialConfig);
     if (initialConfig) {
       setForm(toVisualSystemFormState(initialConfig));
     }
-  }, [initialConfig]);
+  }
 
   const handleChange = <K extends keyof VisualSystemFormState>(
     field: K,
@@ -331,6 +340,7 @@ export function VisualSystemFormContent({
         </Label>
         <textarea
           id="vs-group-prefixes"
+          aria-label="Group Prefixes JSON"
           className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
           placeholder='{ "act": { "I": "ai" }, "chapter": { "1": "ch1" } }'
           value={form.groupPrefixesJson}
@@ -408,7 +418,7 @@ export function VisualSystemDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange} aria-label="Visual System">
       <DialogContent className="max-w-2xl w-full">
         <DialogHeader>
           <DialogTitle>Visual System</DialogTitle>

--- a/apps/frontend/src/components/VisualSystemDialog.tsx
+++ b/apps/frontend/src/components/VisualSystemDialog.tsx
@@ -28,6 +28,12 @@ import {
   generateVisualName,
   type VisualSystemConfig,
 } from "@branchforge/shared";
+import {
+  INITIAL_VISUAL_SYSTEM_FORM,
+  parseGroupPrefixes,
+  toVisualSystemFormState,
+  type VisualSystemFormState,
+} from "@/components/visual-system.helpers";
 
 // ============================================================================
 // Types
@@ -39,16 +45,7 @@ export interface VisualSystemDialogProps {
   projectId: string;
 }
 
-interface VisualSystemFormState {
-  namingTemplate: string;
-  defaultGroupType: string;
-  labelPadding: 1 | 2;
-  counterPadding: 1 | 2;
-  jumpPrefixShared: string;
-  placeholderBaseUrl: string;
-  // Stringified JSON for editing; the dialog shows a textarea.
-  groupPrefixesJson: string;
-}
+export type { VisualSystemFormState };
 
 interface VisualSystemFormErrors {
   namingTemplate?: string;
@@ -62,93 +59,10 @@ interface VisualSystemFormErrors {
 // ============================================================================
 // Helpers
 // ============================================================================
-
-/** Build the form state from a server config. */
-function toFormState(config: VisualSystemConfig): VisualSystemFormState {
-  return {
-    namingTemplate: config.namingTemplate,
-    defaultGroupType: config.defaultGroupType ?? "",
-    labelPadding: config.labelPadding,
-    counterPadding: config.counterPadding,
-    jumpPrefixShared: config.jumpPrefixShared,
-    placeholderBaseUrl: config.placeholderBaseUrl ?? "",
-    groupPrefixesJson: config.groupPrefixes
-      ? JSON.stringify(config.groupPrefixes, null, 2)
-      : "{}",
-  };
-}
-
-const INITIAL_FORM: VisualSystemFormState = {
-  namingTemplate: "{route}{group}_{label}_{counter}_{slug}",
-  defaultGroupType: "",
-  labelPadding: 2,
-  counterPadding: 2,
-  jumpPrefixShared: "",
-  placeholderBaseUrl: "",
-  groupPrefixesJson: "{}",
-};
-
-/** Parse the groupPrefixes JSON textarea into a valid object, or null. */
-function parseGroupPrefixes(raw: string): {
-  value: Record<string, Record<string, string>> | null;
-  error?: string;
-} {
-  const trimmed = raw.trim();
-  if (trimmed === "" || trimmed === "{}") {
-    return { value: null };
-  }
-  try {
-    const parsed: unknown = JSON.parse(trimmed);
-    if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      Array.isArray(parsed)
-    ) {
-      return { value: null, error: "Group prefixes must be a JSON object" };
-    }
-    for (const [groupType, entries] of Object.entries(parsed)) {
-      if (typeof groupType !== "string" || groupType.length === 0) {
-        return {
-          value: null,
-          error: "Group type keys must be non-empty strings",
-        };
-      }
-      if (
-        typeof entries !== "object" ||
-        entries === null ||
-        Array.isArray(entries)
-      ) {
-        return {
-          value: null,
-          error: `Group "${groupType}" must map to an object of prefix entries`,
-        };
-      }
-      for (const [k, v] of Object.entries(entries as Record<string, unknown>)) {
-        // Trim before length check to match the server-side
-        // `.trim().min(1)` validation in visualSystemConfigSchema;
-        // a whitespace-only key/value would otherwise pass client-side
-        // validation and only fail at the API.
-        if (typeof k !== "string" || k.trim().length === 0) {
-          return {
-            value: null,
-            error: `Group "${groupType}" has an empty key`,
-          };
-        }
-        if (typeof v !== "string" || v.trim().length === 0) {
-          return {
-            value: null,
-            error: `Group "${groupType}" entry "${k}" must be a non-empty string`,
-          };
-        }
-      }
-    }
-    return {
-      value: parsed as Record<string, Record<string, string>>,
-    };
-  } catch {
-    return { value: null, error: "Group prefixes JSON is not valid" };
-  }
-}
+//
+// `toVisualSystemFormState`, `parseGroupPrefixes`, and
+// `INITIAL_VISUAL_SYSTEM_FORM` live in `./visual-system.helpers` so
+// both this dialog and the project-settings tab can share them.
 
 /** Validate the form and return a flat error object. */
 function validateForm(form: VisualSystemFormState): VisualSystemFormErrors {
@@ -198,21 +112,28 @@ interface VisualSystemFormContentProps {
   onClose: () => void;
 }
 
-function VisualSystemFormContent({
+/**
+ * The form body of the visual-system settings, with no dialog chrome
+ * around it. Used by `VisualSystemDialog` (standalone) and by
+ * `ProjectSettingsDialog` (as a tab panel).
+ */
+export function VisualSystemFormContent({
   initialConfig,
   isSaving,
   onSave,
   onClose,
 }: VisualSystemFormContentProps) {
   const [form, setForm] = useState<VisualSystemFormState>(
-    initialConfig ? toFormState(initialConfig) : INITIAL_FORM
+    initialConfig
+      ? toVisualSystemFormState(initialConfig)
+      : INITIAL_VISUAL_SYSTEM_FORM
   );
   const [errors, setErrors] = useState<VisualSystemFormErrors>({});
 
   // When the server config first arrives, hydrate the form.
   useEffect(() => {
     if (initialConfig) {
-      setForm(toFormState(initialConfig));
+      setForm(toVisualSystemFormState(initialConfig));
     }
   }, [initialConfig]);
 
@@ -274,203 +195,182 @@ function VisualSystemFormContent({
   }, [previewConfig, form.defaultGroupType]);
 
   return (
-    <>
-      <DialogHeader>
-        <DialogTitle>Visual System</DialogTitle>
-        <DialogDescription>
-          Configure how generated Ren'Py visual filenames are produced.
-        </DialogDescription>
-      </DialogHeader>
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <Label htmlFor="vs-naming-template" className="text-xs">
+          Naming Template *
+        </Label>
+        <Input
+          id="vs-naming-template"
+          type="text"
+          placeholder="{route}{group}_{label}_{counter}_{slug}"
+          value={form.namingTemplate}
+          onChange={(event) =>
+            handleChange("namingTemplate", event.target.value)
+          }
+          disabled={isSaving}
+        />
+        <p className="text-xs text-muted-foreground">
+          Tokens: <code>{`{route}`}</code>, <code>{`{group}`}</code>,{" "}
+          <code>{`{label}`}</code> (or legacy <code>{`{scene}`}</code>),{" "}
+          <code>{`{counter}`}</code>, <code>{`{slug}`}</code>
+        </p>
+        {errors.namingTemplate && (
+          <p className="text-xs text-destructive">{errors.namingTemplate}</p>
+        )}
+      </div>
 
-      <div className="space-y-4 mt-4">
+      <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1">
-          <Label htmlFor="vs-naming-template" className="text-xs">
-            Naming Template *
+          <Label htmlFor="vs-label-padding" className="text-xs">
+            Label Padding *
           </Label>
-          <Input
-            id="vs-naming-template"
-            type="text"
-            placeholder="{route}{group}_{label}_{counter}_{slug}"
-            value={form.namingTemplate}
-            onChange={(event) =>
-              handleChange("namingTemplate", event.target.value)
+          <Select
+            id="vs-label-padding"
+            value={String(form.labelPadding) as "1" | "2"}
+            onChange={(value) =>
+              handleChange("labelPadding", Number(value) as 1 | 2)
             }
             disabled={isSaving}
+            options={[
+              { value: "1", label: "1 (e.g. 1, 2, 3)" },
+              { value: "2", label: "2 (e.g. 01, 02, 03)" },
+            ]}
           />
-          <p className="text-xs text-muted-foreground">
-            Tokens: <code>{`{route}`}</code>, <code>{`{group}`}</code>,{" "}
-            <code>{`{label}`}</code> (or legacy <code>{`{scene}`}</code>),{" "}
-            <code>{`{counter}`}</code>, <code>{`{slug}`}</code>
-          </p>
-          {errors.namingTemplate && (
-            <p className="text-xs text-destructive">{errors.namingTemplate}</p>
+          {errors.labelPadding && (
+            <p className="text-xs text-destructive">{errors.labelPadding}</p>
           )}
         </div>
 
-        <div className="grid grid-cols-2 gap-3">
-          <div className="space-y-1">
-            <Label htmlFor="vs-label-padding" className="text-xs">
-              Label Padding *
-            </Label>
-            <Select
-              id="vs-label-padding"
-              value={String(form.labelPadding) as "1" | "2"}
-              onChange={(value) =>
-                handleChange("labelPadding", Number(value) as 1 | 2)
-              }
-              disabled={isSaving}
-              options={[
-                { value: "1", label: "1 (e.g. 1, 2, 3)" },
-                { value: "2", label: "2 (e.g. 01, 02, 03)" },
-              ]}
-            />
-            {errors.labelPadding && (
-              <p className="text-xs text-destructive">{errors.labelPadding}</p>
-            )}
-          </div>
-
-          <div className="space-y-1">
-            <Label htmlFor="vs-counter-padding" className="text-xs">
-              Counter Padding *
-            </Label>
-            <Select
-              id="vs-counter-padding"
-              value={String(form.counterPadding) as "1" | "2"}
-              onChange={(value) =>
-                handleChange("counterPadding", Number(value) as 1 | 2)
-              }
-              disabled={isSaving}
-              options={[
-                { value: "1", label: "1 (e.g. 1, 2, 3)" },
-                { value: "2", label: "2 (e.g. 01, 02, 03)" },
-              ]}
-            />
-            {errors.counterPadding && (
-              <p className="text-xs text-destructive">
-                {errors.counterPadding}
-              </p>
-            )}
-          </div>
-        </div>
-
         <div className="space-y-1">
-          <Label htmlFor="vs-jump-prefix" className="text-xs">
-            Shared Jump Prefix *
+          <Label htmlFor="vs-counter-padding" className="text-xs">
+            Counter Padding *
           </Label>
-          <Input
-            id="vs-jump-prefix"
-            type="text"
-            placeholder="shared_"
-            value={form.jumpPrefixShared}
-            onChange={(event) =>
-              handleChange("jumpPrefixShared", event.target.value)
+          <Select
+            id="vs-counter-padding"
+            value={String(form.counterPadding) as "1" | "2"}
+            onChange={(value) =>
+              handleChange("counterPadding", Number(value) as 1 | 2)
             }
             disabled={isSaving}
+            options={[
+              { value: "1", label: "1 (e.g. 1, 2, 3)" },
+              { value: "2", label: "2 (e.g. 01, 02, 03)" },
+            ]}
           />
-          {errors.jumpPrefixShared && (
-            <p className="text-xs text-destructive">
-              {errors.jumpPrefixShared}
-            </p>
+          {errors.counterPadding && (
+            <p className="text-xs text-destructive">{errors.counterPadding}</p>
           )}
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <div className="space-y-1">
-            <Label htmlFor="vs-default-group" className="text-xs">
-              Default Group Type
-            </Label>
-            <Input
-              id="vs-default-group"
-              type="text"
-              placeholder="act"
-              value={form.defaultGroupType}
-              onChange={(event) =>
-                handleChange("defaultGroupType", event.target.value)
-              }
-              disabled={isSaving}
-            />
-            <p className="text-xs text-muted-foreground">
-              Optional. e.g. <code>act</code>, <code>chapter</code>
-            </p>
-          </div>
-
-          <div className="space-y-1">
-            <Label htmlFor="vs-placeholder" className="text-xs">
-              Placeholder Base URL
-            </Label>
-            <Input
-              id="vs-placeholder"
-              type="text"
-              placeholder="https://example.com/img/"
-              value={form.placeholderBaseUrl}
-              onChange={(event) =>
-                handleChange("placeholderBaseUrl", event.target.value)
-              }
-              disabled={isSaving}
-            />
-            {errors.placeholderBaseUrl && (
-              <p className="text-xs text-destructive">
-                {errors.placeholderBaseUrl}
-              </p>
-            )}
-          </div>
-        </div>
-
-        <div className="space-y-1">
-          <Label htmlFor="vs-group-prefixes" className="text-xs">
-            Group Prefixes (JSON)
-          </Label>
-          <textarea
-            id="vs-group-prefixes"
-            className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-            placeholder='{ "act": { "I": "ai" }, "chapter": { "1": "ch1" } }'
-            value={form.groupPrefixesJson}
-            onChange={(event) =>
-              handleChange("groupPrefixesJson", event.target.value)
-            }
-            disabled={isSaving}
-            rows={4}
-          />
-          <p className="text-xs text-muted-foreground">
-            Map of group type to value→prefix. Empty or <code>{`{}`}</code> for
-            none.
-          </p>
-          {errors.groupPrefixesJson && (
-            <p className="text-xs text-destructive">
-              {errors.groupPrefixesJson}
-            </p>
-          )}
-        </div>
-
-        <div className="rounded-md border border-border/50 bg-muted/40 p-3 text-xs">
-          <div className="flex items-center gap-1.5 font-medium text-foreground">
-            <Wand2 className="size-3.5" />
-            Preview
-          </div>
-          <p className="mt-1 text-muted-foreground">
-            Sample generated name (route <code>hero</code>, group <code>I</code>
-            , label <code>1</code>, counter <code>1</code>, slug{" "}
-            <code>cafe</code>):
-          </p>
-          <p className="mt-1 font-mono text-foreground">{samplePreview}</p>
-        </div>
-
-        <div className="flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={onClose}
-            disabled={isSaving}
-          >
-            Cancel
-          </Button>
-          <Button type="button" onClick={handleSave} disabled={isSaving}>
-            {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
-            Save
-          </Button>
         </div>
       </div>
-    </>
+
+      <div className="space-y-1">
+        <Label htmlFor="vs-jump-prefix" className="text-xs">
+          Shared Jump Prefix *
+        </Label>
+        <Input
+          id="vs-jump-prefix"
+          type="text"
+          placeholder="shared_"
+          value={form.jumpPrefixShared}
+          onChange={(event) =>
+            handleChange("jumpPrefixShared", event.target.value)
+          }
+          disabled={isSaving}
+        />
+        {errors.jumpPrefixShared && (
+          <p className="text-xs text-destructive">{errors.jumpPrefixShared}</p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <Label htmlFor="vs-default-group" className="text-xs">
+            Default Group Type
+          </Label>
+          <Input
+            id="vs-default-group"
+            type="text"
+            placeholder="act"
+            value={form.defaultGroupType}
+            onChange={(event) =>
+              handleChange("defaultGroupType", event.target.value)
+            }
+            disabled={isSaving}
+          />
+          <p className="text-xs text-muted-foreground">
+            Optional. e.g. <code>act</code>, <code>chapter</code>
+          </p>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="vs-placeholder" className="text-xs">
+            Placeholder Base URL
+          </Label>
+          <Input
+            id="vs-placeholder"
+            type="text"
+            placeholder="https://example.com/img/"
+            value={form.placeholderBaseUrl}
+            onChange={(event) =>
+              handleChange("placeholderBaseUrl", event.target.value)
+            }
+            disabled={isSaving}
+          />
+          {errors.placeholderBaseUrl && (
+            <p className="text-xs text-destructive">
+              {errors.placeholderBaseUrl}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor="vs-group-prefixes" className="text-xs">
+          Group Prefixes (JSON)
+        </Label>
+        <textarea
+          id="vs-group-prefixes"
+          className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder='{ "act": { "I": "ai" }, "chapter": { "1": "ch1" } }'
+          value={form.groupPrefixesJson}
+          onChange={(event) =>
+            handleChange("groupPrefixesJson", event.target.value)
+          }
+          disabled={isSaving}
+          rows={4}
+        />
+        <p className="text-xs text-muted-foreground">
+          Map of group type to value→prefix. Empty or <code>{`{}`}</code> for
+          none.
+        </p>
+        {errors.groupPrefixesJson && (
+          <p className="text-xs text-destructive">{errors.groupPrefixesJson}</p>
+        )}
+      </div>
+
+      <div className="rounded-md border border-border/50 bg-muted/40 p-3 text-xs">
+        <div className="flex items-center gap-1.5 font-medium text-foreground">
+          <Wand2 className="size-3.5" />
+          Preview
+        </div>
+        <p className="mt-1 text-muted-foreground">
+          Sample generated name (route <code>hero</code>, group <code>I</code>,
+          label <code>1</code>, counter <code>1</code>, slug <code>cafe</code>):
+        </p>
+        <p className="mt-1 font-mono text-foreground">{samplePreview}</p>
+      </div>
+
+      <div className="flex justify-end gap-2">
+        {/* No Cancel button — the dialog's X / the outer Close
+            button (in `ProjectSettingsDialog`) is the equivalent.
+            Save persists; close discards unsaved changes. */}
+        <Button type="button" onClick={handleSave} disabled={isSaving}>
+          {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
+          Save
+        </Button>
+      </div>
+    </div>
   );
 }
 
@@ -510,16 +410,16 @@ export function VisualSystemDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl w-full">
+        <DialogHeader>
+          <DialogTitle>Visual System</DialogTitle>
+          <DialogDescription>
+            Configure how generated Ren'Py visual filenames are produced.
+          </DialogDescription>
+        </DialogHeader>
         {isLoading || !config ? (
-          <>
-            <DialogHeader>
-              <DialogTitle>Visual System</DialogTitle>
-              <DialogDescription>Loading...</DialogDescription>
-            </DialogHeader>
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="size-6 animate-spin" />
-            </div>
-          </>
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="size-6 animate-spin" />
+          </div>
         ) : (
           <VisualSystemFormContent
             key={`visual-system-${open}`}

--- a/apps/frontend/src/components/VisualSystemDialog.tsx
+++ b/apps/frontend/src/components/VisualSystemDialog.tsx
@@ -124,13 +124,17 @@ function parseGroupPrefixes(raw: string): {
         };
       }
       for (const [k, v] of Object.entries(entries as Record<string, unknown>)) {
-        if (typeof k !== "string" || k.length === 0) {
+        // Trim before length check to match the server-side
+        // `.trim().min(1)` validation in visualSystemConfigSchema;
+        // a whitespace-only key/value would otherwise pass client-side
+        // validation and only fail at the API.
+        if (typeof k !== "string" || k.trim().length === 0) {
           return {
             value: null,
             error: `Group "${groupType}" has an empty key`,
           };
         }
-        if (typeof v !== "string" || v.length === 0) {
+        if (typeof v !== "string" || v.trim().length === 0) {
           return {
             value: null,
             error: `Group "${groupType}" entry "${k}" must be a non-empty string`,
@@ -164,8 +168,12 @@ function validateForm(form: VisualSystemFormState): VisualSystemFormErrors {
   if (form.placeholderBaseUrl.trim()) {
     try {
       // URL constructor is permissive; ensure it has a protocol.
+      // Match the server's exact `===` check (`url.protocol === "http:"
+      // || url.protocol === "https:"`) so client validation rejects the
+      // same set of inputs — `startsWith("http")` would let `httpa:`
+      // and similar bogus schemes through.
       const url = new URL(form.placeholderBaseUrl.trim());
-      if (!url.protocol.startsWith("http")) {
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
         errors.placeholderBaseUrl = "Placeholder URL must use http or https";
       }
     } catch {

--- a/apps/frontend/src/components/VisualSystemDialog.tsx
+++ b/apps/frontend/src/components/VisualSystemDialog.tsx
@@ -1,0 +1,527 @@
+/**
+ * Visual System Dialog
+ *
+ * Modal for editing the per-project visual system configuration
+ * (template tokens, group prefixes, padding, shared jump prefix,
+ * placeholder base URL).
+ *
+ * The dialog previews how a sample visual name is generated with the
+ * current form values by feeding them into `generateVisualName()`,
+ * so the user gets immediate feedback on their template edits.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, Wand2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import { useVisualSystem } from "@/hooks/useVisualSystem";
+import {
+  generateVisualName,
+  type VisualSystemConfig,
+} from "@branchforge/shared";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface VisualSystemDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+}
+
+interface VisualSystemFormState {
+  namingTemplate: string;
+  defaultGroupType: string;
+  labelPadding: 1 | 2;
+  counterPadding: 1 | 2;
+  jumpPrefixShared: string;
+  placeholderBaseUrl: string;
+  // Stringified JSON for editing; the dialog shows a textarea.
+  groupPrefixesJson: string;
+}
+
+interface VisualSystemFormErrors {
+  namingTemplate?: string;
+  labelPadding?: string;
+  counterPadding?: string;
+  jumpPrefixShared?: string;
+  placeholderBaseUrl?: string;
+  groupPrefixesJson?: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Build the form state from a server config. */
+function toFormState(config: VisualSystemConfig): VisualSystemFormState {
+  return {
+    namingTemplate: config.namingTemplate,
+    defaultGroupType: config.defaultGroupType ?? "",
+    labelPadding: config.labelPadding,
+    counterPadding: config.counterPadding,
+    jumpPrefixShared: config.jumpPrefixShared,
+    placeholderBaseUrl: config.placeholderBaseUrl ?? "",
+    groupPrefixesJson: config.groupPrefixes
+      ? JSON.stringify(config.groupPrefixes, null, 2)
+      : "{}",
+  };
+}
+
+const INITIAL_FORM: VisualSystemFormState = {
+  namingTemplate: "{route}{group}_{label}_{counter}_{slug}",
+  defaultGroupType: "",
+  labelPadding: 2,
+  counterPadding: 2,
+  jumpPrefixShared: "",
+  placeholderBaseUrl: "",
+  groupPrefixesJson: "{}",
+};
+
+/** Parse the groupPrefixes JSON textarea into a valid object, or null. */
+function parseGroupPrefixes(raw: string): {
+  value: Record<string, Record<string, string>> | null;
+  error?: string;
+} {
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "{}") {
+    return { value: null };
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return { value: null, error: "Group prefixes must be a JSON object" };
+    }
+    for (const [groupType, entries] of Object.entries(parsed)) {
+      if (typeof groupType !== "string" || groupType.length === 0) {
+        return {
+          value: null,
+          error: "Group type keys must be non-empty strings",
+        };
+      }
+      if (
+        typeof entries !== "object" ||
+        entries === null ||
+        Array.isArray(entries)
+      ) {
+        return {
+          value: null,
+          error: `Group "${groupType}" must map to an object of prefix entries`,
+        };
+      }
+      for (const [k, v] of Object.entries(entries as Record<string, unknown>)) {
+        if (typeof k !== "string" || k.length === 0) {
+          return {
+            value: null,
+            error: `Group "${groupType}" has an empty key`,
+          };
+        }
+        if (typeof v !== "string" || v.length === 0) {
+          return {
+            value: null,
+            error: `Group "${groupType}" entry "${k}" must be a non-empty string`,
+          };
+        }
+      }
+    }
+    return {
+      value: parsed as Record<string, Record<string, string>>,
+    };
+  } catch {
+    return { value: null, error: "Group prefixes JSON is not valid" };
+  }
+}
+
+/** Validate the form and return a flat error object. */
+function validateForm(form: VisualSystemFormState): VisualSystemFormErrors {
+  const errors: VisualSystemFormErrors = {};
+  if (!form.namingTemplate.trim()) {
+    errors.namingTemplate = "Naming template is required";
+  }
+  if (form.labelPadding !== 1 && form.labelPadding !== 2) {
+    errors.labelPadding = "Label padding must be 1 or 2";
+  }
+  if (form.counterPadding !== 1 && form.counterPadding !== 2) {
+    errors.counterPadding = "Counter padding must be 1 or 2";
+  }
+  if (!form.jumpPrefixShared.trim()) {
+    errors.jumpPrefixShared = "Shared jump prefix is required";
+  }
+  if (form.placeholderBaseUrl.trim()) {
+    try {
+      // URL constructor is permissive; ensure it has a protocol.
+      const url = new URL(form.placeholderBaseUrl.trim());
+      if (!url.protocol.startsWith("http")) {
+        errors.placeholderBaseUrl = "Placeholder URL must use http or https";
+      }
+    } catch {
+      errors.placeholderBaseUrl = "Placeholder URL is not a valid URL";
+    }
+  }
+  const parsed = parseGroupPrefixes(form.groupPrefixesJson);
+  if (parsed.error) {
+    errors.groupPrefixesJson = parsed.error;
+  }
+  return errors;
+}
+
+// ============================================================================
+// Form content
+// ============================================================================
+
+interface VisualSystemFormContentProps {
+  initialConfig: VisualSystemConfig | null;
+  isSaving: boolean;
+  onSave: (form: VisualSystemFormState) => Promise<void>;
+  onClose: () => void;
+}
+
+function VisualSystemFormContent({
+  initialConfig,
+  isSaving,
+  onSave,
+  onClose,
+}: VisualSystemFormContentProps) {
+  const [form, setForm] = useState<VisualSystemFormState>(
+    initialConfig ? toFormState(initialConfig) : INITIAL_FORM
+  );
+  const [errors, setErrors] = useState<VisualSystemFormErrors>({});
+
+  // When the server config first arrives, hydrate the form.
+  useEffect(() => {
+    if (initialConfig) {
+      setForm(toFormState(initialConfig));
+    }
+  }, [initialConfig]);
+
+  const handleChange = <K extends keyof VisualSystemFormState>(
+    field: K,
+    value: VisualSystemFormState[K]
+  ) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setErrors((prev) => ({ ...prev, [field]: undefined }));
+  };
+
+  const handleSave = async () => {
+    const validation = validateForm(form);
+    if (Object.keys(validation).length > 0) {
+      setErrors(validation);
+      return;
+    }
+    try {
+      await onSave(form);
+      onClose();
+    } catch {
+      // Error handled by hook toast
+    }
+  };
+
+  // Build the live config for the preview. We re-parse the JSON
+  // textarea on every render so the preview always reflects the
+  // current form state, even if the JSON isn't yet valid.
+  const previewConfig: VisualSystemConfig = useMemo(() => {
+    const parsed = parseGroupPrefixes(form.groupPrefixesJson);
+    return {
+      namingTemplate: form.namingTemplate,
+      labelPadding: form.labelPadding,
+      counterPadding: form.counterPadding,
+      jumpPrefixShared: form.jumpPrefixShared,
+      ...(form.defaultGroupType.trim()
+        ? { defaultGroupType: form.defaultGroupType.trim() }
+        : {}),
+      ...(form.placeholderBaseUrl.trim()
+        ? { placeholderBaseUrl: form.placeholderBaseUrl.trim() }
+        : {}),
+      ...(parsed.value ? { groupPrefixes: parsed.value } : {}),
+    };
+  }, [form]);
+
+  const samplePreview = useMemo(() => {
+    try {
+      return generateVisualName(previewConfig, {
+        groupType: form.defaultGroupType.trim() || undefined,
+        groupValue: form.defaultGroupType.trim() ? "I" : undefined,
+        routeKey: "hero",
+        labelNumber: 1,
+        counter: 1,
+        slug: "cafe",
+      });
+    } catch {
+      return "—";
+    }
+  }, [previewConfig, form.defaultGroupType]);
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Visual System</DialogTitle>
+        <DialogDescription>
+          Configure how generated Ren'Py visual filenames are produced.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4 mt-4">
+        <div className="space-y-1">
+          <Label htmlFor="vs-naming-template" className="text-xs">
+            Naming Template *
+          </Label>
+          <Input
+            id="vs-naming-template"
+            type="text"
+            placeholder="{route}{group}_{label}_{counter}_{slug}"
+            value={form.namingTemplate}
+            onChange={(event) =>
+              handleChange("namingTemplate", event.target.value)
+            }
+            disabled={isSaving}
+          />
+          <p className="text-xs text-muted-foreground">
+            Tokens: <code>{`{route}`}</code>, <code>{`{group}`}</code>,{" "}
+            <code>{`{label}`}</code> (or legacy <code>{`{scene}`}</code>),{" "}
+            <code>{`{counter}`}</code>, <code>{`{slug}`}</code>
+          </p>
+          {errors.namingTemplate && (
+            <p className="text-xs text-destructive">{errors.namingTemplate}</p>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <Label htmlFor="vs-label-padding" className="text-xs">
+              Label Padding *
+            </Label>
+            <Select
+              id="vs-label-padding"
+              value={String(form.labelPadding) as "1" | "2"}
+              onChange={(value) =>
+                handleChange("labelPadding", Number(value) as 1 | 2)
+              }
+              disabled={isSaving}
+              options={[
+                { value: "1", label: "1 (e.g. 1, 2, 3)" },
+                { value: "2", label: "2 (e.g. 01, 02, 03)" },
+              ]}
+            />
+            {errors.labelPadding && (
+              <p className="text-xs text-destructive">{errors.labelPadding}</p>
+            )}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="vs-counter-padding" className="text-xs">
+              Counter Padding *
+            </Label>
+            <Select
+              id="vs-counter-padding"
+              value={String(form.counterPadding) as "1" | "2"}
+              onChange={(value) =>
+                handleChange("counterPadding", Number(value) as 1 | 2)
+              }
+              disabled={isSaving}
+              options={[
+                { value: "1", label: "1 (e.g. 1, 2, 3)" },
+                { value: "2", label: "2 (e.g. 01, 02, 03)" },
+              ]}
+            />
+            {errors.counterPadding && (
+              <p className="text-xs text-destructive">
+                {errors.counterPadding}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="vs-jump-prefix" className="text-xs">
+            Shared Jump Prefix *
+          </Label>
+          <Input
+            id="vs-jump-prefix"
+            type="text"
+            placeholder="shared_"
+            value={form.jumpPrefixShared}
+            onChange={(event) =>
+              handleChange("jumpPrefixShared", event.target.value)
+            }
+            disabled={isSaving}
+          />
+          {errors.jumpPrefixShared && (
+            <p className="text-xs text-destructive">
+              {errors.jumpPrefixShared}
+            </p>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <Label htmlFor="vs-default-group" className="text-xs">
+              Default Group Type
+            </Label>
+            <Input
+              id="vs-default-group"
+              type="text"
+              placeholder="act"
+              value={form.defaultGroupType}
+              onChange={(event) =>
+                handleChange("defaultGroupType", event.target.value)
+              }
+              disabled={isSaving}
+            />
+            <p className="text-xs text-muted-foreground">
+              Optional. e.g. <code>act</code>, <code>chapter</code>
+            </p>
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="vs-placeholder" className="text-xs">
+              Placeholder Base URL
+            </Label>
+            <Input
+              id="vs-placeholder"
+              type="text"
+              placeholder="https://example.com/img/"
+              value={form.placeholderBaseUrl}
+              onChange={(event) =>
+                handleChange("placeholderBaseUrl", event.target.value)
+              }
+              disabled={isSaving}
+            />
+            {errors.placeholderBaseUrl && (
+              <p className="text-xs text-destructive">
+                {errors.placeholderBaseUrl}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="vs-group-prefixes" className="text-xs">
+            Group Prefixes (JSON)
+          </Label>
+          <textarea
+            id="vs-group-prefixes"
+            className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            placeholder='{ "act": { "I": "ai" }, "chapter": { "1": "ch1" } }'
+            value={form.groupPrefixesJson}
+            onChange={(event) =>
+              handleChange("groupPrefixesJson", event.target.value)
+            }
+            disabled={isSaving}
+            rows={4}
+          />
+          <p className="text-xs text-muted-foreground">
+            Map of group type to value→prefix. Empty or <code>{`{}`}</code> for
+            none.
+          </p>
+          {errors.groupPrefixesJson && (
+            <p className="text-xs text-destructive">
+              {errors.groupPrefixesJson}
+            </p>
+          )}
+        </div>
+
+        <div className="rounded-md border border-border/50 bg-muted/40 p-3 text-xs">
+          <div className="flex items-center gap-1.5 font-medium text-foreground">
+            <Wand2 className="size-3.5" />
+            Preview
+          </div>
+          <p className="mt-1 text-muted-foreground">
+            Sample generated name (route <code>hero</code>, group <code>I</code>
+            , label <code>1</code>, counter <code>1</code>, slug{" "}
+            <code>cafe</code>):
+          </p>
+          <p className="mt-1 font-mono text-foreground">{samplePreview}</p>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={isSaving}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={isSaving}>
+            {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
+            Save
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ============================================================================
+// Public component
+// ============================================================================
+
+export function VisualSystemDialog({
+  open,
+  onOpenChange,
+  projectId,
+}: VisualSystemDialogProps) {
+  const { config, isLoading, isSaving, updateConfig } =
+    useVisualSystem(projectId);
+
+  const handleSave = async (form: VisualSystemFormState) => {
+    const parsed = parseGroupPrefixes(form.groupPrefixesJson);
+    // Always include all fields. The PATCH semantics on the server
+    // mean that *omitting* a key would leave the existing value
+    // untouched, so to *clear* optional fields we have to send the
+    // explicit empty-string / empty-object sentinel. The service
+    // converts these to NULL on write.
+    await updateConfig({
+      namingTemplate: form.namingTemplate.trim(),
+      labelPadding: form.labelPadding,
+      counterPadding: form.counterPadding,
+      jumpPrefixShared: form.jumpPrefixShared.trim(),
+      defaultGroupType: form.defaultGroupType.trim(),
+      placeholderBaseUrl: form.placeholderBaseUrl.trim(),
+      // `parsed.value` is `null` for empty input. The service treats
+      // `{}` as "clear to NULL", so always pass either the parsed
+      // object or `{}` (never `undefined`).
+      groupPrefixes: parsed.value ?? {},
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl w-full">
+        {isLoading || !config ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Visual System</DialogTitle>
+              <DialogDescription>Loading...</DialogDescription>
+            </DialogHeader>
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="size-6 animate-spin" />
+            </div>
+          </>
+        ) : (
+          <VisualSystemFormContent
+            key={`visual-system-${open}`}
+            initialConfig={config}
+            isSaving={isSaving}
+            onSave={handleSave}
+            onClose={() => onOpenChange(false)}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/__tests__/CharacterDialog.test.tsx
+++ b/apps/frontend/src/components/__tests__/CharacterDialog.test.tsx
@@ -326,7 +326,7 @@ describe("CharacterDialog", () => {
         { wrapper }
       );
 
-      await user.click(screen.getByRole("button", { name: /Close/i }));
+      await user.click(screen.getByRole("button", { name: "Close" }));
 
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });

--- a/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
+++ b/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
@@ -1,4 +1,10 @@
-import { useReducer, useEffect, useRef, useCallback } from "react";
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useReducer,
+  useRef,
+} from "react";
 import {
   BookOpen,
   SquarePen,
@@ -21,6 +27,10 @@ import { ZipImportProjectDialog } from "./ZipImportProjectDialog.lazy";
 import { FlowDialog } from "@/components/flow/FlowDialog";
 import { Select } from "@/components/ui/select";
 import { Logo } from "@/components/ui/logo";
+
+// ============================================================================
+// Types
+// ============================================================================
 
 interface ThemePaletteOption {
   name: string;
@@ -112,6 +122,423 @@ function modalReducer(state: ModalState, action: ModalAction): ModalState {
   }
 }
 
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+interface ModeSwitcherProps {
+  mode: "write" | "script";
+  setMode: (mode: "write" | "script") => void;
+  isCollapsed: boolean;
+  showLabel: boolean;
+}
+
+/** Write / Script mode toggle. Vertical when collapsed, horizontal when expanded. */
+function ModeSwitcher({
+  mode,
+  setMode,
+  isCollapsed,
+  showLabel,
+}: ModeSwitcherProps) {
+  return (
+    <div
+      className={`${
+        isCollapsed ? "flex-col gap-1" : "flex"
+      } bg-muted/50 rounded-md p-0.5`}
+    >
+      <button
+        type="button"
+        onClick={() => setMode("write")}
+        className={`flex ${
+          isCollapsed ? "w-full p-2.5" : "flex-1 px-2 py-1.5"
+        } items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-all ${
+          mode === "write"
+            ? "text-white bg-[var(--theme-color)]"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+        title="Write Mode"
+      >
+        <BookOpen className="size-4 flex-shrink-0" />
+        {showLabel && <span>Write</span>}
+      </button>
+      <button
+        type="button"
+        onClick={() => setMode("script")}
+        className={`flex ${
+          isCollapsed ? "w-full p-2.5" : "flex-1 px-2 py-1.5"
+        } items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-all ${
+          mode === "script"
+            ? "text-white bg-[var(--theme-color)]"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+        title="Script Mode"
+      >
+        <SquarePen className="size-4 flex-shrink-0" />
+        {showLabel && <span>Script</span>}
+      </button>
+    </div>
+  );
+}
+
+interface ProjectSelectorProps {
+  projectId?: string;
+  projects: Project[];
+  isLoadingProjects?: boolean;
+  setCurrentProject: (project: Project | null) => void;
+  isCollapsed: boolean;
+  isOpen: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+}
+
+/** Project picker. When collapsed, a button that opens a popover.
+ *  When expanded, a native Select. Click-outside dismisses the popover. */
+function ProjectSelector({
+  projectId,
+  projects,
+  isLoadingProjects,
+  setCurrentProject,
+  isCollapsed,
+  isOpen,
+  onToggle,
+  onClose,
+}: ProjectSelectorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // `onClose` is read inside the click-outside handler but isn't
+  // part of the effect's subscription surface — wrap it in
+  // `useEffectEvent` so the listener isn't re-bound on every
+  // parent render (React 19+).
+  const onCloseEffect = useEffectEvent(onClose);
+
+  useEffect(() => {
+    if (!isOpen || isCollapsed) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        onCloseEffect();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, isCollapsed]);
+
+  if (isCollapsed) {
+    return (
+      <div className="relative" ref={containerRef}>
+        <button
+          type="button"
+          onClick={onToggle}
+          disabled={isLoadingProjects}
+          className={`flex items-center justify-center p-2.5 rounded-md text-sm font-medium transition-colors ${
+            isOpen
+              ? "text-foreground bg-muted/50"
+              : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+          }`}
+          title="Select Project"
+        >
+          <FolderOpen className="size-4 flex-shrink-0" />
+        </button>
+        {isOpen && (
+          <div className="absolute left-full top-0 ml-2 bg-popover border border-border/70 rounded-lg shadow-xl shadow-black/25 ring-1 ring-white/5 min-w-[300px] max-w-[400px] z-50">
+            <div className="p-2 max-h-[400px] overflow-y-auto">
+              {isLoadingProjects ? (
+                <div className="px-3 py-2 text-sm text-muted-foreground">
+                  Loading…
+                </div>
+              ) : projects.length === 0 ? (
+                <div className="px-3 py-2 text-sm text-muted-foreground">
+                  No projects found. Create a new project to get started.
+                </div>
+              ) : (
+                projects.map((project) => (
+                  <button
+                    type="button"
+                    key={project.id}
+                    onClick={() => {
+                      setCurrentProject(project);
+                      onClose();
+                    }}
+                    className={`w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm text-left transition-colors ${
+                      projectId === project.id
+                        ? "bg-accent text-accent-foreground font-medium"
+                        : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                    }`}
+                  >
+                    {project.name}
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <Select
+        value={projectId ?? undefined}
+        onChange={(selectedProjectId) => {
+          const project = projects.find((p) => p.id === selectedProjectId);
+          if (project) setCurrentProject(project);
+        }}
+        disabled={isLoadingProjects || projects.length === 0}
+        placeholder={
+          isLoadingProjects
+            ? "Loading…"
+            : projects.length === 0
+              ? "No projects"
+              : "Select project"
+        }
+        options={projects.map((p) => ({
+          value: p.id,
+          label: p.name,
+        }))}
+      />
+    </div>
+  );
+}
+
+interface NavButtonsProps {
+  projectId?: string;
+  isCollapsed: boolean;
+  showLabel: boolean;
+  onOpenProjectSettings: () => void;
+  onOpenFlow: () => void;
+}
+
+/** Project Settings + Flow navigation entries. */
+function NavButtons({
+  projectId,
+  isCollapsed,
+  showLabel,
+  onOpenProjectSettings,
+  onOpenFlow,
+}: NavButtonsProps) {
+  const disabled = !projectId;
+  return (
+    <nav className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={onOpenProjectSettings}
+        disabled={disabled}
+        className={`flex items-center ${
+          isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+        } rounded-md text-sm font-medium transition-colors ${
+          disabled
+            ? "text-muted-foreground/50 cursor-not-allowed"
+            : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+        }`}
+        title="Project settings"
+      >
+        <SlidersHorizontal className="size-4 flex-shrink-0" />
+        {showLabel && <span>Settings</span>}
+      </button>
+      <button
+        type="button"
+        onClick={onOpenFlow}
+        disabled={disabled}
+        className={`flex items-center ${
+          isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+        } rounded-md text-sm font-medium transition-colors ${
+          disabled
+            ? "text-muted-foreground/50 cursor-not-allowed"
+            : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+        }`}
+        title="Flow Graph"
+      >
+        <Network className="size-4 flex-shrink-0" />
+        {showLabel && <span>Flow</span>}
+      </button>
+    </nav>
+  );
+}
+
+interface ThemeSwitcherProps {
+  theme: string;
+  setTheme: (theme: ThemePalette) => void;
+  themePalettes: ThemePaletteOption[];
+  isCollapsed: boolean;
+  isOpen: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+}
+
+/** Theme palette picker. When collapsed, a button that opens a popover.
+ *  When expanded, the palettes render inline. Click-outside dismisses the popover. */
+function ThemeSwitcher({
+  theme,
+  setTheme,
+  themePalettes,
+  isCollapsed,
+  isOpen,
+  onToggle,
+  onClose,
+}: ThemeSwitcherProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // `onClose` is read inside the click-outside handler but isn't
+  // part of the effect's subscription surface — wrap it in
+  // `useEffectEvent` so the listener isn't re-bound on every
+  // parent render (React 19+).
+  const onCloseEffect = useEffectEvent(onClose);
+
+  useEffect(() => {
+    if (!isOpen || isCollapsed) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        onCloseEffect();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, isCollapsed]);
+
+  if (isCollapsed) {
+    return (
+      <div className="relative" ref={containerRef}>
+        <button
+          type="button"
+          onClick={onToggle}
+          className={`flex items-center justify-center p-2.5 rounded-md text-sm font-medium transition-colors ${
+            isOpen
+              ? "text-foreground bg-muted/50"
+              : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+          }`}
+          title="Theme"
+        >
+          <Palette className="size-4 flex-shrink-0" />
+        </button>
+        {isOpen && (
+          <div className="absolute left-full top-0 ml-2 bg-popover border border-border/70 rounded-lg p-3 shadow-xl shadow-black/25 ring-1 ring-white/5 z-50">
+            <div className="flex gap-2">
+              {themePalettes.map((palette) => (
+                <button
+                  type="button"
+                  key={palette.key}
+                  onClick={() => {
+                    setTheme(palette.key);
+                    onClose();
+                  }}
+                  className={`size-7 rounded transition-all ${
+                    theme === palette.key
+                      ? "scale-110 ring-2 ring-white ring-offset-2 ring-offset-card"
+                      : "opacity-60 hover:opacity-100 hover:scale-105"
+                  }`}
+                  style={{ background: palette.color }}
+                  title={palette.name}
+                  aria-label={palette.name}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center p-2">
+      <div className="flex gap-1.5 flex-1">
+        {themePalettes.map((palette) => (
+          <button
+            type="button"
+            key={palette.key}
+            onClick={() => setTheme(palette.key)}
+            className={`flex-1 h-7 rounded transition-all ${
+              theme === palette.key
+                ? "scale-110 ring-2 ring-white ring-offset-2 ring-offset-card"
+                : "opacity-60 hover:opacity-100 hover:scale-105"
+            }`}
+            style={{ background: palette.color }}
+            title={palette.name}
+            aria-label={palette.name}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface CollapseButtonProps {
+  isCollapsed: boolean;
+  onToggle: () => void;
+}
+
+/** Sidebar expand/collapse toggle. */
+function CollapseButton({ isCollapsed, onToggle }: CollapseButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={`flex items-center ${
+        isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+      } rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors`}
+      title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+    >
+      {isCollapsed ? (
+        <ChevronsRight className="size-4 flex-shrink-0" />
+      ) : (
+        <>
+          <ChevronsLeft className="size-4 flex-shrink-0" />
+          {!isCollapsed && <span>Collapse</span>}
+        </>
+      )}
+    </button>
+  );
+}
+
+interface UserActionsProps {
+  isCollapsed: boolean;
+  showLabel: boolean;
+  onOpenSettings: () => void;
+  onLogout: () => void;
+}
+
+/** App-level settings + logout buttons. */
+function UserActions({
+  isCollapsed,
+  showLabel,
+  onOpenSettings,
+  onLogout,
+}: UserActionsProps) {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onOpenSettings}
+        className={`flex items-center ${
+          isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+        } rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors`}
+        title="Settings"
+      >
+        <Settings className="size-4 flex-shrink-0" />
+        {showLabel && <span>Settings</span>}
+      </button>
+      <button
+        type="button"
+        onClick={onLogout}
+        className={`flex items-center ${
+          isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+        } rounded-md text-sm font-medium text-muted-foreground hover:text-destructive-muted hover:bg-destructive/10 transition-colors`}
+        title="Logout"
+      >
+        <LogOut className="size-4 flex-shrink-0" />
+        {showLabel && <span>Logout</span>}
+      </button>
+    </>
+  );
+}
+
+// ============================================================================
+// Main component
+// ============================================================================
+
 export function LeftSidebar(props: LeftSidebarProps) {
   const {
     mode,
@@ -135,8 +562,6 @@ export function LeftSidebar(props: LeftSidebarProps) {
   const isSettingsOpenExternally = props.isSettingsOpenExternally;
   const onSettingsOpenChangeExternally = props.onSettingsOpenChangeExternally;
   const [modals, dispatchModal] = useReducer(modalReducer, initialModalState);
-  const themeDropdownRef = useRef<HTMLDivElement>(null);
-  const projectPopoverRef = useRef<HTMLDivElement>(null);
   const projectsRef = useRef(projects);
 
   const isSettingsOpen = isSettingsOpenExternally ?? modals.settings;
@@ -152,43 +577,13 @@ export function LeftSidebar(props: LeftSidebarProps) {
   );
 
   const handleToggleCollapse = () => {
-    const newState = !isCollapsed;
-    onCollapsedChange(newState);
+    onCollapsedChange(!isCollapsed);
   };
 
   // Keep projectsRef in sync with projects
   useEffect(() => {
     projectsRef.current = projects;
   }, [projects]);
-
-  // Close theme dropdown when clicking outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (
-        themeDropdownRef.current &&
-        !themeDropdownRef.current.contains(event.target as Node)
-      ) {
-        dispatchModal({ type: "CLOSE", key: "themeDropdown" });
-      }
-      if (
-        projectPopoverRef.current &&
-        !projectPopoverRef.current.contains(event.target as Node)
-      ) {
-        dispatchModal({ type: "CLOSE", key: "projectPopover" });
-      }
-    }
-
-    if (modals.themeDropdown || modals.projectPopover) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [modals.themeDropdown, modals.projectPopover]);
-
-  const width = isCollapsed ? "w-14" : "w-56";
-  const showLabel = !isCollapsed;
 
   // Helper for handling successful project imports
   const handleImportSuccess = useCallback(
@@ -226,6 +621,9 @@ export function LeftSidebar(props: LeftSidebarProps) {
     [refetchProjects, setCurrentProject]
   );
 
+  const width = isCollapsed ? "w-14" : "w-56";
+  const showLabel = !isCollapsed;
+
   return (
     <>
       <div
@@ -238,295 +636,69 @@ export function LeftSidebar(props: LeftSidebarProps) {
             <Logo compact={isCollapsed} size="sm" />
           </div>
 
-          {/* Mode Switcher - vertical when collapsed, horizontal when expanded */}
-          <div
-            className={`${
-              isCollapsed ? "flex-col gap-1" : "flex"
-            } bg-muted/50 rounded-md p-0.5`}
-          >
-            <button
-              type="button"
-              onClick={() => setMode("write")}
-              className={`flex ${
-                isCollapsed ? "w-full p-2.5" : "flex-1 px-2 py-1.5"
-              } items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-all ${
-                mode === "write"
-                  ? "text-white bg-[var(--theme-color)]"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-              title="Write Mode"
-            >
-              <BookOpen className="size-4 flex-shrink-0" />
-              {showLabel && <span>Write</span>}
-            </button>
-            <button
-              type="button"
-              onClick={() => setMode("script")}
-              className={`flex ${
-                isCollapsed ? "w-full p-2.5" : "flex-1 px-2 py-1.5"
-              } items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-all ${
-                mode === "script"
-                  ? "text-white bg-[var(--theme-color)]"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-              title="Script Mode"
-            >
-              <SquarePen className="size-4 flex-shrink-0" />
-              {showLabel && <span>Script</span>}
-            </button>
-          </div>
+          <ModeSwitcher
+            mode={mode}
+            setMode={setMode}
+            isCollapsed={isCollapsed}
+            showLabel={showLabel}
+          />
 
-          {/* Project Selector (only in script mode) */}
-          <div className="relative" ref={projectPopoverRef}>
-            {isCollapsed ? (
-              <>
-                {/* Collapsed: Icon button with popover */}
-                <button
-                  type="button"
-                  onClick={() =>
-                    dispatchModal({ type: "TOGGLE", key: "projectPopover" })
-                  }
-                  disabled={isLoadingProjects}
-                  className={`flex items-center justify-center p-2.5 rounded-md text-sm font-medium transition-colors ${
-                    modals.projectPopover
-                      ? "text-foreground bg-muted/50"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                  }`}
-                  title="Select Project"
-                >
-                  <FolderOpen className="size-4 flex-shrink-0" />
-                </button>
-
-                {modals.projectPopover && (
-                  <div className="absolute left-full top-0 ml-2 bg-popover border border-border/70 rounded-lg shadow-xl shadow-black/25 ring-1 ring-white/5 min-w-[300px] max-w-[400px] z-50">
-                    <div className="p-2 max-h-[400px] overflow-y-auto">
-                      {isLoadingProjects ? (
-                        <div className="px-3 py-2 text-sm text-muted-foreground">
-                          Loading…
-                        </div>
-                      ) : projects.length === 0 ? (
-                        <div className="px-3 py-2 text-sm text-muted-foreground">
-                          No projects found. Create a new project to get
-                          started.
-                        </div>
-                      ) : (
-                        projects.map((project) => (
-                          <button
-                            type="button"
-                            key={project.id}
-                            onClick={() => {
-                              setCurrentProject(project);
-                              dispatchModal({
-                                type: "CLOSE",
-                                key: "projectPopover",
-                              });
-                            }}
-                            className={`w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm text-left transition-colors ${
-                              projectId === project.id
-                                ? "bg-accent text-accent-foreground font-medium"
-                                : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                            }`}
-                          >
-                            {project.name}
-                          </button>
-                        ))
-                      )}
-                    </div>
-                  </div>
-                )}
-              </>
-            ) : (
-              <>
-                <Select
-                  value={projectId ?? undefined}
-                  onChange={(selectedProjectId) => {
-                    const project = projects.find(
-                      (p) => p.id === selectedProjectId
-                    );
-                    if (project) setCurrentProject(project);
-                  }}
-                  disabled={isLoadingProjects || projects.length === 0}
-                  placeholder={
-                    isLoadingProjects
-                      ? "Loading…"
-                      : projects.length === 0
-                        ? "No projects"
-                        : "Select project"
-                  }
-                  options={projects.map((p) => ({
-                    value: p.id,
-                    label: p.name,
-                  }))}
-                />
-              </>
-            )}
-          </div>
+          <ProjectSelector
+            projectId={projectId}
+            projects={projects}
+            isLoadingProjects={isLoadingProjects}
+            setCurrentProject={setCurrentProject}
+            isCollapsed={isCollapsed}
+            isOpen={modals.projectPopover}
+            onToggle={() =>
+              dispatchModal({ type: "TOGGLE", key: "projectPopover" })
+            }
+            onClose={() =>
+              dispatchModal({ type: "CLOSE", key: "projectPopover" })
+            }
+          />
 
           {/* Divider */}
           <div className="h-px bg-border/30 my-1" />
 
-          {/* Navigation Items */}
-          <nav className="flex flex-col gap-1">
-            {/* Project Settings (Characters, Routes, Visual System) */}
-            <button
-              type="button"
-              onClick={() =>
-                dispatchModal({ type: "OPEN", key: "projectSettings" })
-              }
-              disabled={!projectId}
-              className={`flex items-center ${
-                isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
-              } rounded-md text-sm font-medium transition-colors ${
-                !projectId
-                  ? "text-muted-foreground/50 cursor-not-allowed"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-              }`}
-              title="Project settings"
-            >
-              <SlidersHorizontal className="size-4 flex-shrink-0" />
-              {showLabel && <span>Settings</span>}
-            </button>
-
-            {/* Flow Graph */}
-            <button
-              type="button"
-              onClick={() => dispatchModal({ type: "OPEN", key: "flow" })}
-              disabled={!projectId}
-              className={`flex items-center ${
-                isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
-              } rounded-md text-sm font-medium transition-colors ${
-                !projectId
-                  ? "text-muted-foreground/50 cursor-not-allowed"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-              }`}
-              title="Flow Graph"
-            >
-              <Network className="size-4 flex-shrink-0" />
-              {showLabel && <span>Flow</span>}
-            </button>
-          </nav>
+          <NavButtons
+            projectId={projectId}
+            isCollapsed={isCollapsed}
+            showLabel={showLabel}
+            onOpenProjectSettings={() =>
+              dispatchModal({ type: "OPEN", key: "projectSettings" })
+            }
+            onOpenFlow={() => dispatchModal({ type: "OPEN", key: "flow" })}
+          />
         </div>
 
         {/* Bottom Section */}
         <div className="flex flex-col p-2 gap-1 border-t border-border/30">
-          {/* Collapse/Expand Toggle */}
-          <button
-            type="button"
-            onClick={handleToggleCollapse}
-            className={`flex items-center ${
-              isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
-            } rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors`}
-            title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-          >
-            {isCollapsed ? (
-              <ChevronsRight className="size-4 flex-shrink-0" />
-            ) : (
-              <>
-                <ChevronsLeft className="size-4 flex-shrink-0" />
-                {showLabel && <span>Collapse</span>}
-              </>
-            )}
-          </button>
+          <CollapseButton
+            isCollapsed={isCollapsed}
+            onToggle={handleToggleCollapse}
+          />
 
-          {/* Theme */}
-          <div className="relative" ref={themeDropdownRef}>
-            {isCollapsed ? (
-              <>
-                {/* Collapsed: Icon button with popover */}
-                <button
-                  type="button"
-                  onClick={() =>
-                    dispatchModal({ type: "TOGGLE", key: "themeDropdown" })
-                  }
-                  className={`flex items-center justify-center p-2.5 rounded-md text-sm font-medium transition-colors ${
-                    modals.themeDropdown
-                      ? "text-foreground bg-muted/50"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                  }`}
-                  title="Theme"
-                >
-                  <Palette className="size-4 flex-shrink-0" />
-                </button>
+          <ThemeSwitcher
+            theme={theme}
+            setTheme={setTheme}
+            themePalettes={themePalettes}
+            isCollapsed={isCollapsed}
+            isOpen={modals.themeDropdown}
+            onToggle={() =>
+              dispatchModal({ type: "TOGGLE", key: "themeDropdown" })
+            }
+            onClose={() =>
+              dispatchModal({ type: "CLOSE", key: "themeDropdown" })
+            }
+          />
 
-                {modals.themeDropdown && (
-                  <div className="absolute left-full top-0 ml-2 bg-popover border border-border/70 rounded-lg p-3 shadow-xl shadow-black/25 ring-1 ring-white/5 z-50">
-                    <div className="flex gap-2">
-                      {themePalettes.map((palette) => (
-                        <button
-                          type="button"
-                          key={palette.key}
-                          onClick={() => {
-                            setTheme(palette.key);
-                            dispatchModal({
-                              type: "CLOSE",
-                              key: "themeDropdown",
-                            });
-                          }}
-                          className={`size-7 rounded transition-all ${
-                            theme === palette.key
-                              ? "scale-110 ring-2 ring-white ring-offset-2 ring-offset-card"
-                              : "opacity-60 hover:opacity-100 hover:scale-105"
-                          }`}
-                          style={{ background: palette.color }}
-                          title={palette.name}
-                          aria-label={palette.name}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </>
-            ) : (
-              <>
-                {/* Expanded: Inline theme colors (no icon) */}
-                <div className="flex items-center p-2">
-                  <div className="flex gap-1.5 flex-1">
-                    {themePalettes.map((palette) => (
-                      <button
-                        type="button"
-                        key={palette.key}
-                        onClick={() => setTheme(palette.key)}
-                        className={`flex-1 h-7 rounded transition-all ${
-                          theme === palette.key
-                            ? "scale-110 ring-2 ring-white ring-offset-2 ring-offset-card"
-                            : "opacity-60 hover:opacity-100 hover:scale-105"
-                        }`}
-                        style={{ background: palette.color }}
-                        title={palette.name}
-                        aria-label={palette.name}
-                      />
-                    ))}
-                  </div>
-                </div>
-              </>
-            )}
-          </div>
-
-          {/* Settings */}
-          <button
-            type="button"
-            onClick={() => setSettingsOpen(true)}
-            className={`flex items-center ${
-              isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
-            } rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors`}
-            title="Settings"
-          >
-            <Settings className="size-4 flex-shrink-0" />
-            {showLabel && <span>Settings</span>}
-          </button>
-
-          {/* Logout */}
-          <button
-            type="button"
-            onClick={onLogout}
-            className={`flex items-center ${
-              isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
-            } rounded-md text-sm font-medium text-muted-foreground hover:text-destructive-muted hover:bg-destructive/10 transition-colors`}
-            title="Logout"
-          >
-            <LogOut className="size-4 flex-shrink-0" />
-            {showLabel && <span>Logout</span>}
-          </button>
+          <UserActions
+            isCollapsed={isCollapsed}
+            showLabel={showLabel}
+            onOpenSettings={() => setSettingsOpen(true)}
+            onLogout={onLogout}
+          />
         </div>
       </div>
 

--- a/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
+++ b/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
@@ -2,8 +2,6 @@ import { useReducer, useEffect, useRef, useCallback } from "react";
 import {
   BookOpen,
   SquarePen,
-  Route,
-  Users,
   Palette,
   Settings,
   LogOut,
@@ -11,13 +9,13 @@ import {
   ChevronsRight,
   FolderOpen,
   Network,
+  SlidersHorizontal,
 } from "lucide-react";
 import type { ThemePalette } from "@/contexts/ThemeContext";
 import type { Project, UpdateProjectBody } from "@/lib/api/projects";
 import type { Tab } from "./settings-types";
 import { SettingsModal } from "./SettingsModal";
-import { RouteSettingsDialog } from "./RouteSettingsDialog";
-import { CharacterDialog } from "@/components/CharacterDialog";
+import { ProjectSettingsDialog } from "@/components/ProjectSettingsDialog";
 import { GitLabImportDialog } from "./GitLabImportDialog.lazy";
 import { ZipImportProjectDialog } from "./ZipImportProjectDialog.lazy";
 import { FlowDialog } from "@/components/flow/FlowDialog";
@@ -70,8 +68,7 @@ export type LeftSidebarProps =
 type ModalKey =
   | "themeDropdown"
   | "settings"
-  | "routes"
-  | "characters"
+  | "projectSettings"
   | "projectPopover"
   | "gitLabImport"
   | "zipImport"
@@ -80,8 +77,7 @@ type ModalKey =
 interface ModalState {
   themeDropdown: boolean;
   settings: boolean;
-  routes: boolean;
-  characters: boolean;
+  projectSettings: boolean;
   projectPopover: boolean;
   gitLabImport: boolean;
   zipImport: boolean;
@@ -96,8 +92,7 @@ type ModalAction =
 const initialModalState: ModalState = {
   themeDropdown: false,
   settings: false,
-  routes: false,
-  characters: false,
+  projectSettings: false,
   projectPopover: false,
   gitLabImport: false,
   zipImport: false,
@@ -372,10 +367,12 @@ export function LeftSidebar(props: LeftSidebarProps) {
 
           {/* Navigation Items */}
           <nav className="flex flex-col gap-1">
-            {/* Routes */}
+            {/* Project Settings (Characters, Routes, Visual System) */}
             <button
               type="button"
-              onClick={() => dispatchModal({ type: "OPEN", key: "routes" })}
+              onClick={() =>
+                dispatchModal({ type: "OPEN", key: "projectSettings" })
+              }
               disabled={!projectId}
               className={`flex items-center ${
                 isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
@@ -384,28 +381,10 @@ export function LeftSidebar(props: LeftSidebarProps) {
                   ? "text-muted-foreground/50 cursor-not-allowed"
                   : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
               }`}
-              title="Routes"
+              title="Project settings"
             >
-              <Route className="size-4 flex-shrink-0" />
-              {showLabel && <span>Routes</span>}
-            </button>
-
-            {/* Characters */}
-            <button
-              type="button"
-              onClick={() => dispatchModal({ type: "OPEN", key: "characters" })}
-              disabled={!projectId}
-              className={`flex items-center ${
-                isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
-              } rounded-md text-sm font-medium transition-colors ${
-                !projectId
-                  ? "text-muted-foreground/50 cursor-not-allowed"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-              }`}
-              title="Characters"
-            >
-              <Users className="size-4 flex-shrink-0" />
-              {showLabel && <span>Characters</span>}
+              <SlidersHorizontal className="size-4 flex-shrink-0" />
+              {showLabel && <span>Settings</span>}
             </button>
 
             {/* Flow Graph */}
@@ -569,25 +548,16 @@ export function LeftSidebar(props: LeftSidebarProps) {
         initialTab={initialSettingsTab}
       />
       {projectId && (
-        <>
-          <RouteSettingsDialog
-            open={modals.routes}
-            onOpenChange={(open) =>
-              dispatchModal({ type: open ? "OPEN" : "CLOSE", key: "routes" })
-            }
-            projectId={projectId}
-          />
-          <CharacterDialog
-            open={modals.characters}
-            onOpenChange={(open: boolean) =>
-              dispatchModal({
-                type: open ? "OPEN" : "CLOSE",
-                key: "characters",
-              })
-            }
-            projectId={projectId}
-          />
-        </>
+        <ProjectSettingsDialog
+          open={modals.projectSettings}
+          onOpenChange={(open) =>
+            dispatchModal({
+              type: open ? "OPEN" : "CLOSE",
+              key: "projectSettings",
+            })
+          }
+          projectId={projectId}
+        />
       )}
 
       {/* GitLab Import Dialog */}

--- a/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
+++ b/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
@@ -211,7 +211,13 @@ function ProjectSelector({
   const onCloseEffect = useEffectEvent(onClose);
 
   useEffect(() => {
-    if (!isOpen || isCollapsed) return;
+    // The popover is only rendered in the collapsed branch below;
+    // expanded mode shows a native <Select> which manages its own
+    // open/close state. So we only need the click-outside handler
+    // when `isOpen` is true — the `isCollapsed` check is unnecessary
+    // (it was inverted, registering the handler only in the mode
+    // that has no popover to dismiss).
+    if (!isOpen) return;
     function handleClickOutside(event: MouseEvent) {
       if (
         containerRef.current &&
@@ -222,7 +228,7 @@ function ProjectSelector({
     }
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isOpen, isCollapsed]);
+  }, [isOpen]);
 
   if (isCollapsed) {
     return (
@@ -386,7 +392,11 @@ function ThemeSwitcher({
   const onCloseEffect = useEffectEvent(onClose);
 
   useEffect(() => {
-    if (!isOpen || isCollapsed) return;
+    // The theme popover is only rendered in the collapsed branch
+    // below. Expanded mode renders the palettes inline and doesn't
+    // need a click-outside handler. See the matching comment in
+    // `ProjectSelector` for context.
+    if (!isOpen) return;
     function handleClickOutside(event: MouseEvent) {
       if (
         containerRef.current &&
@@ -397,7 +407,7 @@ function ThemeSwitcher({
     }
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isOpen, isCollapsed]);
+  }, [isOpen]);
 
   if (isCollapsed) {
     return (

--- a/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
+++ b/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
@@ -335,7 +335,7 @@ function NavButtons({
         title="Project settings"
       >
         <SlidersHorizontal className="size-4 flex-shrink-0" />
-        {showLabel && <span>Settings</span>}
+        {showLabel && <span>Project Settings</span>}
       </button>
       <button
         type="button"
@@ -351,7 +351,7 @@ function NavButtons({
         title="Flow Graph"
       >
         <Network className="size-4 flex-shrink-0" />
-        {showLabel && <span>Flow</span>}
+        {showLabel && <span>Flow Graph</span>}
       </button>
     </nav>
   );

--- a/apps/frontend/src/components/ide-shared/RouteSettingsDialog.tsx
+++ b/apps/frontend/src/components/ide-shared/RouteSettingsDialog.tsx
@@ -1,11 +1,18 @@
-import { useState } from "react";
-import { Loader2, Plus } from "lucide-react";
+/**
+ * Route Settings Dialog
+ *
+ * Standalone wrapper that hosts the Routes settings inside a
+ * `DialogShell`. The body is provided by `RouteSettingsContent`,
+ * which is also used by the unified `ProjectSettingsDialog`.
+ *
+ * Currently no sidebar entry opens this directly — the unified
+ * modal is the primary entry. This component is kept so future
+ * call sites (e.g. a deep-link from the flow graph) can open
+ * just the Routes section without the full settings chrome.
+ */
+
 import { DialogShell } from "@/components/ui/DialogShell";
-import { InlineMessage } from "@/components/ui/inline-error";
-import { Button } from "@/components/ui/button";
-import { RouteList } from "@/components/RouteList";
-import { RouteEditDialog } from "@/components/RouteEditDialog.lazy";
-import { useRouteConfigs } from "@/hooks/useRouteConfigs";
+import { RouteSettingsContent } from "@/components/RouteSettingsContent";
 
 interface RouteSettingsDialogProps {
   open: boolean;
@@ -18,32 +25,6 @@ export function RouteSettingsDialog({
   onOpenChange,
   projectId,
 }: RouteSettingsDialogProps) {
-  const MODE_NEW = "__new__" as const;
-  type EditMode = null | typeof MODE_NEW | string;
-
-  const [editingRouteId, setEditingRouteId] = useState<EditMode>(null);
-
-  const {
-    routeConfigs,
-    isLoadingRouteConfigs,
-    routeConfigsError,
-    isCreatingRouteConfig,
-    isUpdatingRouteConfig,
-    isDeletingRouteConfig,
-    deleteRouteConfig,
-  } = useRouteConfigs(projectId);
-
-  const isSaving =
-    isCreatingRouteConfig || isUpdatingRouteConfig || isDeletingRouteConfig;
-
-  const handleDelete = async (routeId: string) => {
-    try {
-      await deleteRouteConfig(routeId);
-    } catch {
-      // Error handled by hook toast
-    }
-  };
-
   return (
     <DialogShell
       open={open}
@@ -52,64 +33,7 @@ export function RouteSettingsDialog({
       description="Configure route settings for your project."
       maxWidth="3xl"
     >
-      {isLoadingRouteConfigs ? (
-        <div className="flex items-center justify-center py-8">
-          <Loader2 className="size-6 animate-spin text-muted-foreground" />
-        </div>
-      ) : routeConfigsError ? (
-        <InlineMessage variant="error">
-          Failed to load route configurations
-        </InlineMessage>
-      ) : routeConfigs.length === 0 ? (
-        <div className="space-y-4">
-          <div className="p-8 border border-dashed border-border/30 rounded-md text-center">
-            <p className="text-sm text-muted-foreground">
-              No routes configured yet. Add your first route to get started.
-            </p>
-          </div>
-          <Button
-            type="button"
-            onClick={() => setEditingRouteId(MODE_NEW)}
-            disabled={isSaving}
-            className="w-full"
-          >
-            <Plus className="size-4 mr-2" />
-            Add Route
-          </Button>
-        </div>
-      ) : (
-        <div className="space-y-4">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => setEditingRouteId(MODE_NEW)}
-            disabled={isSaving}
-            className="w-full"
-          >
-            <Plus className="size-4 mr-2" />
-            Add Another Route
-          </Button>
-          <RouteList
-            routes={routeConfigs}
-            isSaving={isSaving}
-            onEdit={setEditingRouteId}
-            onDelete={handleDelete}
-          />
-        </div>
-      )}
-
-      <RouteEditDialog
-        open={editingRouteId !== null}
-        onOpenChange={(nextOpen) => {
-          if (!nextOpen) setEditingRouteId(null);
-        }}
-        projectId={projectId}
-        routeId={
-          editingRouteId === MODE_NEW
-            ? undefined
-            : (editingRouteId as string | undefined)
-        }
-      />
+      <RouteSettingsContent projectId={projectId} />
     </DialogShell>
   );
 }

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -56,7 +56,15 @@ export function Dialog({
   return (
     <dialog
       ref={syncDialogRef}
-      className="backdrop:bg-black/30 backdrop:backdrop-blur-sm m-auto border-0 p-0 bg-transparent text-[hsl(var(--foreground))]"
+      // Position the dialog at the viewport center, then pull it back
+      // by half its own size. This is the standard pattern for
+      // centering a fixed-positioned element whose size is determined
+      // by content. The earlier `m-auto` approach failed because
+      // `m-auto` only centers when the element has a constrained
+      // size; with `bg-transparent` and no explicit width, the
+      // dialog's intrinsic size wasn't being computed reliably,
+      // especially when opened on top of another open dialog.
+      className="backdrop:bg-black/30 backdrop:backdrop-blur-sm top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 m-0 border-0 p-0 bg-transparent text-[hsl(var(--foreground))]"
     >
       {children}
     </dialog>

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -7,6 +7,13 @@ interface DialogProps {
   onOpenChange?: (open: boolean) => void;
   children: React.ReactNode;
   closeOnBackdropClick?: boolean;
+  /**
+   * Accessible name for the dialog. Screen readers announce this
+   * when the dialog opens. Provide either `aria-label` or
+   * `aria-labelledby` (pointing at a heading inside the dialog).
+   */
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
 }
 
 export function Dialog({
@@ -14,6 +21,8 @@ export function Dialog({
   onOpenChange,
   children,
   closeOnBackdropClick = true,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
 }: DialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
@@ -56,6 +65,8 @@ export function Dialog({
   return (
     <dialog
       ref={syncDialogRef}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
       // Position the dialog at the viewport center, then pull it back
       // by half its own size. This is the standard pattern for
       // centering a fixed-positioned element whose size is determined

--- a/apps/frontend/src/components/ui/tabs.tsx
+++ b/apps/frontend/src/components/ui/tabs.tsx
@@ -25,14 +25,15 @@
 
 import {
   createContext,
+  use,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
+  type RefObject,
 } from "react";
 import { cn } from "@/lib/utils";
 
@@ -44,19 +45,24 @@ interface TabsContextValue {
   value: string;
   setValue: (next: string) => void;
   /**
-   * Register/unregister a tab value. Each `TabsTrigger` registers
-   * itself on mount so the TabsList can compute next/prev for
-   * arrow-key navigation. Stored in insertion order.
+   * Register/unregister a tab. `disabled` tabs are tracked but
+   * excluded from the navigation list — arrow keys skip them.
    */
-  registerTab: (value: string) => () => void;
-  /** Snapshot of the currently-registered tab values, in order. */
+  registerTab: (value: string, disabled: boolean) => () => void;
+  /** Snapshot of currently-registered, non-disabled tab values, in insertion order. */
   tabValues: string[];
+  /**
+   * Ref to the TabsList root element. Used by triggers to scope
+   * focus queries to the current tablist instance (so multiple
+   * Tabs on the same page don't cross-focus).
+   */
+  tablistRef: RefObject<HTMLDivElement | null>;
 }
 
 const TabsContext = createContext<TabsContextValue | null>(null);
 
 function useTabsContext(component: string): TabsContextValue {
-  const ctx = useContext(TabsContext);
+  const ctx = use(TabsContext);
   if (!ctx) {
     throw new Error(`<${component}> must be rendered inside <Tabs>.`);
   }
@@ -106,24 +112,61 @@ export function Tabs({
 
   // Tab values in insertion order. We use a ref + state pair so
   // registration is O(1) and re-renders only happen when the set
-  // of values actually changes.
+  // of values actually changes. Disabled tabs are tracked for
+  // re-registration (so toggling `disabled` updates the visible
+  // list) but excluded from the navigation order.
+  // (Suppressed: react-doctor flags useRef(new Map()) and
+  // useRef(new Set()) as rebuilding the value on every render.
+  // The rebuild cost is negligible for an empty Map/Set, and the
+  // alternative lazy-init pattern forces non-null assertions at
+  // every call site inside the closures below.)
   const tabOrderRef = useRef<string[]>([]);
+  // react-doctor-disable-next-line react-doctor/rerender-lazy-ref-init
+  const tabDisabledRef = useRef<Map<string, boolean>>(new Map());
   const [tabOrder, setTabOrder] = useState<string[]>([]);
+  // react-doctor-disable-next-line react-doctor/rerender-lazy-ref-init
   const tabSetRef = useRef<Set<string>>(new Set());
 
-  const registerTab = useCallback((value: string) => {
-    if (tabSetRef.current.has(value)) {
-      return () => undefined;
-    }
-    tabSetRef.current.add(value);
-    tabOrderRef.current = [...tabOrderRef.current, value];
-    setTabOrder(tabOrderRef.current);
-    return () => {
-      tabSetRef.current.delete(value);
-      tabOrderRef.current = tabOrderRef.current.filter((v) => v !== value);
-      setTabOrder(tabOrderRef.current);
-    };
+  // Ref to the TabsList root so triggers can scope their focus
+  // queries to the current tablist instance.
+  const tablistRef = useRef<HTMLDivElement | null>(null);
+
+  const recomputeTabOrder = useCallback(() => {
+    tabOrderRef.current = tabOrderRef.current.filter(
+      (v) => !tabDisabledRef.current.get(v)
+    );
+    setTabOrder([...tabOrderRef.current]);
   }, []);
+
+  const registerTab = useCallback(
+    (value: string, disabled: boolean) => {
+      tabDisabledRef.current.set(value, disabled);
+      if (tabSetRef.current.has(value)) {
+        // Already registered; the disabled flag may have flipped,
+        // so recompute the visible order.
+        recomputeTabOrder();
+        return () => undefined;
+      }
+      tabSetRef.current.add(value);
+      if (disabled) {
+        // Don't add to the visible order.
+        return () => {
+          tabSetRef.current.delete(value);
+          tabDisabledRef.current.delete(value);
+          recomputeTabOrder();
+        };
+      }
+      tabOrderRef.current = [...tabOrderRef.current, value];
+      setTabOrder([...tabOrderRef.current]);
+      return () => {
+        tabSetRef.current.delete(value);
+        tabDisabledRef.current.delete(value);
+        tabOrderRef.current = tabOrderRef.current.filter((v) => v !== value);
+        setTabOrder([...tabOrderRef.current]);
+      };
+    },
+    [recomputeTabOrder]
+  );
 
   const ctx = useMemo<TabsContextValue>(
     () => ({
@@ -131,6 +174,7 @@ export function Tabs({
       setValue,
       registerTab,
       tabValues: tabOrder,
+      tablistRef,
     }),
     [isControlled, value, internalValue, setValue, registerTab, tabOrder]
   );
@@ -154,8 +198,13 @@ interface TabsListProps {
 }
 
 export function TabsList({ children, className, ariaLabel }: TabsListProps) {
+  // The ref is set on the tablist root so TabsTrigger can scope
+  // focus queries (e.g. on arrow-key navigation) to the current
+  // tablist instance.
+  const { tablistRef } = useTabsContext("TabsList");
   return (
     <div
+      ref={tablistRef}
       role="tablist"
       aria-label={ariaLabel}
       className={cn(
@@ -190,20 +239,30 @@ export function TabsTrigger({
     setValue,
     registerTab,
     tabValues,
+    tablistRef,
   } = useTabsContext("TabsTrigger");
   const isActive = active === value;
   const buttonRef = useRef<HTMLButtonElement | null>(null);
 
   // Register this tab on mount so the TabsList can compute next/prev
-  // for arrow-key navigation. The returned cleanup unregisters on
-  // unmount.
-  useEffect(() => registerTab(value), [registerTab, value]);
+  // for arrow-key navigation. Disabled tabs are tracked but excluded
+  // from the navigation list (arrow keys skip them). The returned
+  // cleanup unregisters on unmount.
+  // (Suppressed: react-doctor flags this as 'data passed to parent via
+  // effect', but the registration callback is the standard pattern
+  // for child→parent enumeration — there's no way for the parent
+  // to statically know about TabsTrigger children.)
+  // react-doctor-disable-next-line react-doctor/no-pass-data-to-parent
+  useEffect(
+    () => registerTab(value, !!disabled),
+    [registerTab, value, disabled]
+  );
 
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
     if (disabled) return;
 
     const currentIndex = tabValues.indexOf(value);
-    if (currentIndex === -1) return;
+    if (currentIndex === -1 || tabValues.length === 0) return;
 
     const computeNextIndex = (): number => {
       switch (event.key) {
@@ -228,9 +287,11 @@ export function TabsTrigger({
     if (nextValue !== undefined) {
       setValue(nextValue);
       // Move focus to the newly-active tab so screen readers and
-      // keyboard users follow the selection.
+      // keyboard users follow the selection. Scope the query to
+      // the current tablist so multiple Tabs on the same page
+      // don't cross-focus.
       requestAnimationFrame(() => {
-        const el = document.querySelector<HTMLButtonElement>(
+        const el = tablistRef.current?.querySelector<HTMLButtonElement>(
           `[role="tab"][data-tab-value="${CSS.escape(nextValue)}"]`
         );
         el?.focus();

--- a/apps/frontend/src/components/ui/tabs.tsx
+++ b/apps/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,220 @@
+/**
+ * Tabs Primitive
+ *
+ * Minimal, state-based tabs (no Radix dep). Used by
+ * `ProjectSettingsDialog` to host the Characters, Routes, and
+ * Visual System settings under one modal.
+ *
+ * The pattern is:
+ *   <Tabs defaultValue="characters">
+ *     <TabsList>
+ *       <TabsTrigger value="characters">Characters</TabsTrigger>
+ *       <TabsTrigger value="routes">Routes</TabsTrigger>
+ *     </TabsList>
+ *     <TabsPanel value="characters">...</TabsPanel>
+ *     <TabsPanel value="routes">...</TabsPanel>
+ *   </Tabs>
+ *
+ * State is owned by the parent so consumers can reset the active
+ * tab when the modal opens (see ProjectSettingsDialog).
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+// ============================================================================
+// Context
+// ============================================================================
+
+interface TabsContextValue {
+  value: string;
+  setValue: (next: string) => void;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+function useTabsContext(component: string): TabsContextValue {
+  const ctx = useContext(TabsContext);
+  if (!ctx) {
+    throw new Error(`<${component}> must be rendered inside <Tabs>.`);
+  }
+  return ctx;
+}
+
+// ============================================================================
+// Tabs (root)
+// ============================================================================
+
+interface TabsProps {
+  /** The value of the tab that should be active on first render. Optional in controlled mode. */
+  defaultValue?: string;
+  /**
+   * Optional controlled value. If provided, the parent owns state and
+   * the `onValueChange` callback is fired when the user selects a tab.
+   */
+  value?: string;
+  onValueChange?: (next: string) => void;
+  children: ReactNode;
+  className?: string;
+}
+
+export function Tabs({
+  defaultValue,
+  value,
+  onValueChange,
+  children,
+  className,
+}: TabsProps) {
+  const isControlled = value !== undefined;
+  // Fall back to `value` (controlled) or `defaultValue` (uncontrolled)
+  // so the initial render has something to compare against. If
+  // neither is set, the first `TabsTrigger` will start inactive.
+  const initial = value ?? defaultValue ?? "";
+  const [internalValue, setInternalValue] = useState(initial);
+
+  const setValue = useCallback(
+    (next: string) => {
+      if (!isControlled) {
+        setInternalValue(next);
+      }
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange]
+  );
+
+  const ctx = useMemo<TabsContextValue>(
+    () => ({
+      value: isControlled ? (value as string) : internalValue,
+      setValue,
+    }),
+    [isControlled, value, internalValue, setValue]
+  );
+
+  return (
+    <TabsContext.Provider value={ctx}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+// ============================================================================
+// TabsList
+// ============================================================================
+
+interface TabsListProps {
+  children: ReactNode;
+  className?: string;
+  /** Accessible label for the tab list. */
+  ariaLabel?: string;
+}
+
+export function TabsList({ children, className, ariaLabel }: TabsListProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className={cn(
+        "flex gap-1 border-b border-border/30 px-6 -mx-6",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ============================================================================
+// TabsTrigger
+// ============================================================================
+
+interface TabsTriggerProps {
+  value: string;
+  children: ReactNode;
+  className?: string;
+  disabled?: boolean;
+}
+
+export function TabsTrigger({
+  value,
+  children,
+  className,
+  disabled,
+}: TabsTriggerProps) {
+  const { value: active, setValue } = useTabsContext("TabsTrigger");
+  const isActive = active === value;
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={isActive}
+      aria-controls={`tabpanel-${value}`}
+      id={`tab-${value}`}
+      tabIndex={isActive ? 0 : -1}
+      disabled={disabled}
+      onClick={() => {
+        if (!isActive) setValue(value);
+      }}
+      className={cn(
+        "px-3 py-2 text-sm font-medium transition-colors relative",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        isActive
+          ? "text-foreground"
+          : "text-muted-foreground hover:text-foreground",
+        "after:absolute after:left-0 after:right-0 after:bottom-0 after:h-0.5 after:transition-colors",
+        isActive ? "after:bg-[var(--theme-color)]" : "after:bg-transparent",
+        disabled && "opacity-50 cursor-not-allowed",
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ============================================================================
+// TabsPanel
+// ============================================================================
+
+interface TabsPanelProps {
+  value: string;
+  children: ReactNode;
+  className?: string;
+  /**
+   * When false, the panel is removed from the DOM (not just hidden).
+   * Defaults to true so the panel can preserve internal state (e.g.
+   * a half-filled form) when the user switches tabs and comes back.
+   */
+  forceMount?: boolean;
+}
+
+export function TabsPanel({
+  value,
+  children,
+  className,
+  forceMount = true,
+}: TabsPanelProps) {
+  const { value: active } = useTabsContext("TabsPanel");
+  const isActive = active === value;
+  if (!isActive && !forceMount) return null;
+  return (
+    <div
+      role="tabpanel"
+      id={`tabpanel-${value}`}
+      aria-labelledby={`tab-${value}`}
+      hidden={!isActive}
+      className={cn("focus-visible:outline-none", className)}
+      // tabIndex={0} only when active so the panel itself is not
+      // accidentally focusable when hidden.
+      tabIndex={isActive ? 0 : -1}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ui/tabs.tsx
+++ b/apps/frontend/src/components/ui/tabs.tsx
@@ -22,7 +22,7 @@
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useMemo,
   useState,
   type ReactNode,
@@ -41,7 +41,7 @@ interface TabsContextValue {
 const TabsContext = createContext<TabsContextValue | null>(null);
 
 function useTabsContext(component: string): TabsContextValue {
-  const ctx = useContext(TabsContext);
+  const ctx = use(TabsContext);
   if (!ctx) {
     throw new Error(`<${component}> must be rendered inside <Tabs>.`);
   }

--- a/apps/frontend/src/components/ui/tabs.tsx
+++ b/apps/frontend/src/components/ui/tabs.tsx
@@ -17,14 +17,21 @@
  *
  * State is owned by the parent so consumers can reset the active
  * tab when the modal opens (see ProjectSettingsDialog).
+ *
+ * Keyboard navigation follows the WAI-ARIA tabs pattern:
+ *   - ArrowRight / ArrowLeft: move between tabs (wrap around)
+ *   - Home / End: jump to first / last tab
  */
 
 import {
   createContext,
   useCallback,
-  use,
+  useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
 import { cn } from "@/lib/utils";
@@ -36,12 +43,20 @@ import { cn } from "@/lib/utils";
 interface TabsContextValue {
   value: string;
   setValue: (next: string) => void;
+  /**
+   * Register/unregister a tab value. Each `TabsTrigger` registers
+   * itself on mount so the TabsList can compute next/prev for
+   * arrow-key navigation. Stored in insertion order.
+   */
+  registerTab: (value: string) => () => void;
+  /** Snapshot of the currently-registered tab values, in order. */
+  tabValues: string[];
 }
 
 const TabsContext = createContext<TabsContextValue | null>(null);
 
 function useTabsContext(component: string): TabsContextValue {
-  const ctx = use(TabsContext);
+  const ctx = useContext(TabsContext);
   if (!ctx) {
     throw new Error(`<${component}> must be rendered inside <Tabs>.`);
   }
@@ -89,12 +104,35 @@ export function Tabs({
     [isControlled, onValueChange]
   );
 
+  // Tab values in insertion order. We use a ref + state pair so
+  // registration is O(1) and re-renders only happen when the set
+  // of values actually changes.
+  const tabOrderRef = useRef<string[]>([]);
+  const [tabOrder, setTabOrder] = useState<string[]>([]);
+  const tabSetRef = useRef<Set<string>>(new Set());
+
+  const registerTab = useCallback((value: string) => {
+    if (tabSetRef.current.has(value)) {
+      return () => undefined;
+    }
+    tabSetRef.current.add(value);
+    tabOrderRef.current = [...tabOrderRef.current, value];
+    setTabOrder(tabOrderRef.current);
+    return () => {
+      tabSetRef.current.delete(value);
+      tabOrderRef.current = tabOrderRef.current.filter((v) => v !== value);
+      setTabOrder(tabOrderRef.current);
+    };
+  }, []);
+
   const ctx = useMemo<TabsContextValue>(
     () => ({
       value: isControlled ? (value as string) : internalValue,
       setValue,
+      registerTab,
+      tabValues: tabOrder,
     }),
-    [isControlled, value, internalValue, setValue]
+    [isControlled, value, internalValue, setValue, registerTab, tabOrder]
   );
 
   return (
@@ -147,20 +185,74 @@ export function TabsTrigger({
   className,
   disabled,
 }: TabsTriggerProps) {
-  const { value: active, setValue } = useTabsContext("TabsTrigger");
+  const {
+    value: active,
+    setValue,
+    registerTab,
+    tabValues,
+  } = useTabsContext("TabsTrigger");
   const isActive = active === value;
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+  // Register this tab on mount so the TabsList can compute next/prev
+  // for arrow-key navigation. The returned cleanup unregisters on
+  // unmount.
+  useEffect(() => registerTab(value), [registerTab, value]);
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (disabled) return;
+
+    const currentIndex = tabValues.indexOf(value);
+    if (currentIndex === -1) return;
+
+    const computeNextIndex = (): number => {
+      switch (event.key) {
+        case "ArrowRight":
+          return (currentIndex + 1) % tabValues.length;
+        case "ArrowLeft":
+          return (currentIndex - 1 + tabValues.length) % tabValues.length;
+        case "Home":
+          return 0;
+        case "End":
+          return tabValues.length - 1;
+        default:
+          return -1;
+      }
+    };
+
+    const nextIndex = computeNextIndex();
+    if (nextIndex === -1) return;
+
+    event.preventDefault();
+    const nextValue = tabValues[nextIndex];
+    if (nextValue !== undefined) {
+      setValue(nextValue);
+      // Move focus to the newly-active tab so screen readers and
+      // keyboard users follow the selection.
+      requestAnimationFrame(() => {
+        const el = document.querySelector<HTMLButtonElement>(
+          `[role="tab"][data-tab-value="${CSS.escape(nextValue)}"]`
+        );
+        el?.focus();
+      });
+    }
+  };
+
   return (
     <button
+      ref={buttonRef}
       type="button"
       role="tab"
       aria-selected={isActive}
       aria-controls={`tabpanel-${value}`}
       id={`tab-${value}`}
+      data-tab-value={value}
       tabIndex={isActive ? 0 : -1}
       disabled={disabled}
       onClick={() => {
         if (!isActive) setValue(value);
       }}
+      onKeyDown={handleKeyDown}
       className={cn(
         "px-3 py-2 text-sm font-medium transition-colors relative",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",

--- a/apps/frontend/src/components/visual-system.helpers.ts
+++ b/apps/frontend/src/components/visual-system.helpers.ts
@@ -1,0 +1,123 @@
+/**
+ * Visual System form helpers
+ *
+ * Pure helpers shared between the standalone `VisualSystemDialog`
+ * and the "Visual System" tab inside `ProjectSettingsDialog`.
+ */
+
+import type { VisualSystemConfig } from "@branchforge/shared";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Wire shape for the form fields. Mirrors `VisualSystemConfig` with
+ *  `groupPrefixes` stringified to JSON for the textarea. */
+export interface VisualSystemFormState {
+  namingTemplate: string;
+  defaultGroupType: string;
+  labelPadding: 1 | 2;
+  counterPadding: 1 | 2;
+  jumpPrefixShared: string;
+  placeholderBaseUrl: string;
+  // Stringified JSON for editing; the dialog shows a textarea.
+  groupPrefixesJson: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Sensible defaults applied on first read of the config. */
+export const INITIAL_VISUAL_SYSTEM_FORM: VisualSystemFormState = {
+  namingTemplate: "{route}{group}_{label}_{counter}_{slug}",
+  defaultGroupType: "",
+  labelPadding: 2,
+  counterPadding: 2,
+  jumpPrefixShared: "",
+  placeholderBaseUrl: "",
+  groupPrefixesJson: "{}",
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Build the form state from a server config. */
+export function toVisualSystemFormState(
+  config: VisualSystemConfig
+): VisualSystemFormState {
+  return {
+    namingTemplate: config.namingTemplate,
+    defaultGroupType: config.defaultGroupType ?? "",
+    labelPadding: config.labelPadding,
+    counterPadding: config.counterPadding,
+    jumpPrefixShared: config.jumpPrefixShared,
+    placeholderBaseUrl: config.placeholderBaseUrl ?? "",
+    groupPrefixesJson: config.groupPrefixes
+      ? JSON.stringify(config.groupPrefixes, null, 2)
+      : "{}",
+  };
+}
+
+/** Parse the groupPrefixes JSON textarea into a valid object, or null. */
+export function parseGroupPrefixes(raw: string): {
+  value: Record<string, Record<string, string>> | null;
+  error?: string;
+} {
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "{}") {
+    return { value: null };
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return { value: null, error: "Group prefixes must be a JSON object" };
+    }
+    for (const [groupType, entries] of Object.entries(parsed)) {
+      if (typeof groupType !== "string" || groupType.trim().length === 0) {
+        return {
+          value: null,
+          error: "Group type keys must be non-empty strings",
+        };
+      }
+      if (
+        typeof entries !== "object" ||
+        entries === null ||
+        Array.isArray(entries)
+      ) {
+        return {
+          value: null,
+          error: `Group "${groupType}" must map to an object of prefix entries`,
+        };
+      }
+      for (const [k, v] of Object.entries(entries as Record<string, unknown>)) {
+        // Trim before length check to match the server-side
+        // `.trim().min(1)` validation in visualSystemConfigSchema;
+        // a whitespace-only key/value would otherwise pass client-side
+        // validation and only fail at the API.
+        if (typeof k !== "string" || k.trim().length === 0) {
+          return {
+            value: null,
+            error: `Group "${groupType}" has an empty key`,
+          };
+        }
+        if (typeof v !== "string" || v.trim().length === 0) {
+          return {
+            value: null,
+            error: `Group "${groupType}" entry "${k}" must be a non-empty string`,
+          };
+        }
+      }
+    }
+    return {
+      value: parsed as Record<string, Record<string, string>>,
+    };
+  } catch {
+    return { value: null, error: "Group prefixes JSON is not valid" };
+  }
+}

--- a/apps/frontend/src/hooks/useVisualSystem.ts
+++ b/apps/frontend/src/hooks/useVisualSystem.ts
@@ -1,0 +1,115 @@
+/**
+ * useVisualSystem Hook
+ *
+ * Provides the per-project visual system configuration using
+ * TanStack Query. Visual system config controls how generated
+ * Ren'Py visual filenames are produced.
+ *
+ * Pattern mirrors `useWritingGoals` (get + PATCH with optimistic
+ * updates and rollback on error).
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  visualSystemsApi,
+  type UpdateVisualSystemConfigBody,
+} from "@/lib/api/visual-systems";
+import { visualSystemKeys } from "@/lib/query-keys";
+import { useToast } from "@/contexts/ToastContext";
+import type { VisualSystemConfig } from "@branchforge/shared";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface UseVisualSystemReturn {
+  config: VisualSystemConfig | null;
+  isLoading: boolean;
+  isSaving: boolean;
+  updateConfig: (
+    patch: UpdateVisualSystemConfigBody
+  ) => Promise<VisualSystemConfig>;
+  refetch: () => void;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook to access and manage the visual system configuration for a project.
+ *
+ * The first call to `useQuery` lazily creates a default row on the
+ * server, so `config` may briefly be `null` while loading.
+ */
+export function useVisualSystem(projectId: string): UseVisualSystemReturn {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  const {
+    data: config = null,
+    isLoading,
+    refetch,
+  } = useQuery({
+    queryKey: visualSystemKeys.config(projectId),
+    queryFn: () => visualSystemsApi.getVisualSystemConfig(projectId),
+    enabled: !!projectId,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  // Update with optimistic merge + rollback
+  const updateMutation = useMutation({
+    mutationFn: (patch: UpdateVisualSystemConfigBody) =>
+      visualSystemsApi.updateVisualSystemConfig(projectId, patch),
+
+    onMutate: async (patch) => {
+      await queryClient.cancelQueries({
+        queryKey: visualSystemKeys.config(projectId),
+      });
+
+      const previousValue = queryClient.getQueryData<VisualSystemConfig>(
+        visualSystemKeys.config(projectId)
+      );
+
+      queryClient.setQueryData<VisualSystemConfig | undefined>(
+        visualSystemKeys.config(projectId),
+        (prev) => (prev ? { ...prev, ...patch } : prev)
+      );
+
+      return { previousValue };
+    },
+
+    onError: (_error, _variables, context) => {
+      if (context?.previousValue) {
+        queryClient.setQueryData(
+          visualSystemKeys.config(projectId),
+          context.previousValue
+        );
+      }
+      toast.error(
+        "Failed to update visual system settings. The original values have been restored.",
+        "Error"
+      );
+    },
+
+    onSuccess: () => {
+      toast.success("Visual system settings saved", "Saved");
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: visualSystemKeys.config(projectId),
+      });
+    },
+  });
+
+  return {
+    config,
+    isLoading,
+    isSaving: updateMutation.isPending,
+    updateConfig: (patch) => updateMutation.mutateAsync(patch),
+    refetch: () => {
+      void refetch();
+    },
+  };
+}

--- a/apps/frontend/src/hooks/useVisualSystem.ts
+++ b/apps/frontend/src/hooks/useVisualSystem.ts
@@ -25,6 +25,7 @@ import type { VisualSystemConfig } from "@branchforge/shared";
 export interface UseVisualSystemReturn {
   config: VisualSystemConfig | null;
   isLoading: boolean;
+  isError: boolean;
   isSaving: boolean;
   updateConfig: (
     patch: UpdateVisualSystemConfigBody
@@ -49,6 +50,7 @@ export function useVisualSystem(projectId: string): UseVisualSystemReturn {
   const {
     data: config = null,
     isLoading,
+    isError,
     refetch,
   } = useQuery({
     queryKey: visualSystemKeys.config(projectId),
@@ -106,6 +108,7 @@ export function useVisualSystem(projectId: string): UseVisualSystemReturn {
   return {
     config,
     isLoading,
+    isError,
     isSaving: updateMutation.isPending,
     updateConfig: (patch) => updateMutation.mutateAsync(patch),
     refetch: () => {

--- a/apps/frontend/src/lib/api/visual-systems.ts
+++ b/apps/frontend/src/lib/api/visual-systems.ts
@@ -1,0 +1,58 @@
+/**
+ * Visual Systems API Client
+ *
+ * Client for the per-project visual system configuration. The
+ * visual system controls how generated Ren'Py visual filenames
+ * are produced (template tokens, group prefixes, padding).
+ */
+
+import { request } from "./client";
+import type { VisualSystemConfig } from "@branchforge/shared";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Partial update payload. Every field is optional — the server
+ * PATCHes only what you send, leaving other fields alone.
+ */
+export type UpdateVisualSystemConfigBody = Partial<VisualSystemConfig>;
+
+// ============================================================================
+// Visual Systems API
+// ============================================================================
+
+export const visualSystemsApi = {
+  /**
+   * Get the visual system config for a project.
+   *
+   * Auto-creates a default row on first read.
+   */
+  async getVisualSystemConfig(projectId: string): Promise<VisualSystemConfig> {
+    return await request<VisualSystemConfig>(
+      `/projects/${encodeURIComponent(projectId)}/visual-system`,
+      {
+        method: "GET",
+      }
+    );
+  },
+
+  /**
+   * Update (PATCH) the visual system config for a project.
+   *
+   * Only the fields you include in the body are written.
+   */
+  async updateVisualSystemConfig(
+    projectId: string,
+    body: UpdateVisualSystemConfigBody
+  ): Promise<VisualSystemConfig> {
+    return await request<VisualSystemConfig>(
+      `/projects/${encodeURIComponent(projectId)}/visual-system`,
+      {
+        method: "PUT",
+        body: JSON.stringify(body),
+      }
+    );
+  },
+};

--- a/apps/frontend/src/lib/query-keys.ts
+++ b/apps/frontend/src/lib/query-keys.ts
@@ -117,6 +117,16 @@ export const routeConfigKeys = {
 } as const;
 
 // ============================================================================
+// Visual System Keys
+// ============================================================================
+
+export const visualSystemKeys = {
+  all: ["visualSystems"] as const,
+  config: (projectId: string) =>
+    ["visualSystems", projectId, "config"] as const,
+} as const;
+
+// ============================================================================
 // Variable Keys
 // ============================================================================
 


### PR DESCRIPTION
Closes #25

## What

Adds per-project visual system configuration: GET/PUT endpoints,
service layer, and a frontend dialog for editing the config that
controls how generated Ren'Py visual filenames are produced
(template tokens, group prefixes, padding, shared jump prefix,
placeholder base URL).

## How

**Backend** (Fastify + Drizzle)
- `GET /api/projects/:projectId/visual-system` returns the config;
  auto-creates a default row on first read.
- `PUT /api/projects/:projectId/visual-system` PATCHes a subset
  of fields. Sentinels (`""`, `{}`) clear optional fields back
  to `NULL`.
- New Zod `visualSystemConfigSchema` with http/https restriction
  on `placeholderBaseUrl` and explicit clearable semantics for
  `defaultGroupType`, `placeholderBaseUrl`, and `groupPrefixes`.
- New `VisualSystemsService` (default-on-first-read + PATCH
  upsert) enforces `requireProjectOwnership`.
- Integration tests: 18 cases covering auth, validation,
  clearing, `groupPrefixes` JSONB round-trip, default creation,
  non-http protocol rejection, unknown-field rejection.

**Frontend** (React + TanStack Query)
- API client, `useVisualSystem` hook (optimistic update with
  rollback), and `VisualSystemDialog` with a live preview that
  feeds the current form into `generateVisualName()`.
- New query keys under `visualSystemKeys`.

**DB mapping**
- DB column `scene_padding` is mapped to the shared API field
  `labelPadding` in the service layer (legacy column kept for
  backward compat with the existing schema/migration).

## How verified

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test:unit` — 1606 tests pass (no regressions)
- `pnpm test:integration` — 410 tests pass (18 new for visual
  systems, no regressions)

## @oracle verdict

Verdict: **ready** (after one round of fixes).

Round 1 review surfaced 3 must-fix + 2 should-fix + 1 nit.
All addressed:
- Dialog now always sends all clearable fields (no more
  un-clearable optional values).
- `defaultGroupType` schema accepts `""` as clear sentinel.
- `placeholderBaseUrl` schema restricts to http/https via
  custom `.refine()`.
- Service's defensive in-memory fallback now logs a warning
  before returning defaults.
- 3 new integration tests cover the clearing paths and the
  non-http protocol rejection.

Round 2 review returned "Verdict: ready".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-project Visual System configuration (GET/PUT) with automatic defaults, partial updates, and clear/normalize behavior.
  * Added Visual System editing inside the unified Project Settings modal, with live preview and validation.
* **UI Improvements**
  * Unified project settings entry with tabbed navigation; added reusable tab UI controls.
  * Added optional 1/2-column layouts for character and route lists.
  * Improved dialog accessibility and centering.
* **Tests**
  * Added Visual System GET/PUT integration tests covering auth/ownership and validation/clearing rules.
  * Updated CharacterDialog close-button test selector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->