### PR TITLE
Handle special character names on import (#138) + fix wizard-not-showing

### DIFF
--- a/.changeset/rich-boxes-bow.md
+++ b/.changeset/rich-boxes-bow.md
@@ -1,0 +1,7 @@
+---
+"@branchforge/shared": patch
+"@branchforge/frontend": patch
+"@branchforge/backend": patch
+---
+
+Enhanced character detection on import, fixed wixard not showing

--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -714,6 +714,17 @@ export const detectedCharacterSchema = z.object({
   tag: renpyTagSchema,
   name: z.string().nullable().optional(),
   displayName: z.string().min(1, "Display name is required").max(200),
+  nameType: z
+    .enum([
+      "literal",
+      "variable",
+      "interpolated",
+      "tagged",
+      "none",
+      "empty",
+      "unknown",
+    ])
+    .default("literal"),
   color: colorHexSchema,
   isSpecial: z.boolean().default(false),
   sourceFile: z.string().optional(),

--- a/apps/backend/src/services/__tests__/character-parser-real-world.unit.test.ts
+++ b/apps/backend/src/services/__tests__/character-parser-real-world.unit.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { characterParserService } from "../character-parser.service.js";
+
+describe("real-world Ren'Py file (from db)", () => {
+  it("parses characters from a real GitLab-imported project's variables.rpy", () => {
+    // This is the actual content from project_files.original_content
+    // for project 3c3f11c1 (game/variables.rpy), with psql's
+    // trailing whitespace stripped.
+    const content = ` ## Persistent settings
+ default persistent.age_verified = False
+ default persistent.pl_nickname = ""
+
+ ## Characters
+
+ # General
+ define n = Character(None, what_italic=True)
+ define w = Character("Welcome!", who_color="#FFFFFF")
+ define u = Character("???", who_color="#E4E4E4")
+
+ # Nelson
+ define ne_first = "Nelson"
+ define ne_last = "Stone"
+ define ne = Character("[persistent.pl_nickname]", who_color="#94B0B9")
+
+ # Reynard
+ define re_first = "Reynard"
+ define re_last = "Stone"
+ define re = Character("[re_first]", who_color="#CDCDCD")
+`;
+
+    const detected = characterParserService.parseFile(
+      content,
+      "game/variables.rpy"
+    );
+
+    // All characters should be detected, even the simple `define x = "y"`
+    // string variables should NOT be misclassified as characters.
+    const tags = detected.map((c) => c.tag);
+    expect(tags).toContain("n");
+    expect(tags).toContain("w");
+    expect(tags).toContain("u");
+    expect(tags).toContain("ne");
+    expect(tags).toContain("re");
+
+    // String variable assignments like `define ne_first = "Nelson"`
+    // should NOT be detected as characters.
+    expect(tags).not.toContain("ne_first");
+    expect(tags).not.toContain("ne_last");
+    expect(tags).not.toContain("re_first");
+    expect(tags).not.toContain("re_last");
+
+    // Sanity: check name types
+    const byTag = new Map(detected.map((c) => [c.tag, c]));
+    expect(byTag.get("n")?.nameType).toBe("none");
+    expect(byTag.get("w")?.nameType).toBe("literal");
+    expect(byTag.get("u")?.nameType).toBe("unknown");
+    expect(byTag.get("ne")?.nameType).toBe("interpolated");
+    expect(byTag.get("re")?.nameType).toBe("interpolated");
+  });
+
+  it('does NOT detect `define foo = "bar"` as a character (regression for #138)', () => {
+    // Simple string variable assignments should not be confused
+    // with character definitions. The original parser's "simple
+    // assignment" check should still skip these.
+    const content = `define ne_first = "Nelson"
+define ne_last = "Stone"
+`;
+    const detected = characterParserService.parseFile(content, "test.rpy");
+    expect(detected).toHaveLength(0);
+  });
+});

--- a/apps/backend/src/services/__tests__/character-parser.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/character-parser.service.unit.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Character Parser Service Tests
+ *
+ * Unit tests for the character definition parser, focused on name
+ * classification and display-name derivation introduced in #138:
+ * - `literal`   — `Character("Sarah", ...)`
+ * - `variable`  — `Character(boss_name, ...)`
+ * - `interpolated` — `Character("[e_name]", ...)` or `Character([e_name], ...)`
+ * - `tagged`    — `Character("{color=#f00}Stranger{/color}", ...)`
+ * - `none`      — `Character(None, ...)`
+ * - `empty`     — `Character("", ...)`
+ * - `unknown`   — `Character("???", ...)`
+ */
+
+import { describe, it, expect } from "vitest";
+import { characterParserService } from "../character-parser.service.js";
+
+describe("characterParserService", () => {
+  describe("name classification", () => {
+    it("classifies a plain quoted string as 'literal'", () => {
+      const content = `define s = Character("Sarah", color="#c8ffc8")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const s = chars[0];
+      expect(s.tag).toBe("s");
+      expect(s.name).toBe("Sarah");
+      expect(s.displayName).toBe("Sarah");
+      expect(s.nameType).toBe("literal");
+      expect(s.confidence).toBe(1.0);
+    });
+
+    it("classifies a bare Python identifier as 'variable'", () => {
+      const content = `define boss = Character(boss_name, color="#ff0000")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const boss = chars[0];
+      expect(boss.tag).toBe("boss");
+      expect(boss.name).toBe("boss_name");
+      expect(boss.displayName).toBe("boss_name");
+      expect(boss.nameType).toBe("variable");
+      expect(boss.confidence).toBe(0.5);
+    });
+
+    it("classifies a bracketed expression as 'interpolated'", () => {
+      const content = `define e = Character("[e_name]", color="#cfb53b")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const e = chars[0];
+      expect(e.tag).toBe("e");
+      // `name` stores the raw string content as written in the source —
+      // brackets preserved so the import wizard can show the interpolation
+      // syntax to the user (and so export can round-trip back to RPY).
+      expect(e.name).toBe("[e_name]");
+      expect(e.displayName).toBe("[e_name]");
+      expect(e.nameType).toBe("interpolated");
+      expect(e.confidence).toBe(0.5);
+    });
+
+    it("classifies a bracketed argument form as 'interpolated'", () => {
+      const content = `define ne = Character([persistent.pl_nickname], color="#cfb53b")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const ne = chars[0];
+      expect(ne.tag).toBe("ne");
+      // Round-trip fidelity: `name` preserves the brackets so an
+      // export can re-emit the original `Character([...], ...)` form.
+      expect(ne.name).toBe("[persistent.pl_nickname]");
+      expect(ne.displayName).toBe("[persistent.pl_nickname]");
+      expect(ne.nameType).toBe("interpolated");
+      expect(ne.confidence).toBe(0.5);
+    });
+
+    it("classifies 'None' as 'none'", () => {
+      const content = `define n = Character(None, what_color="#cfcfcf")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const n = chars[0];
+      expect(n.tag).toBe("n");
+      expect(n.name).toBeNull();
+      expect(n.displayName).toBe("");
+      expect(n.nameType).toBe("none");
+      expect(n.confidence).toBe(0.5);
+    });
+
+    it("classifies an empty string as 'empty'", () => {
+      const content = `define e = Character("", color="#cfcfcf")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const e = chars[0];
+      expect(e.tag).toBe("e");
+      expect(e.name).toBe("");
+      expect(e.displayName).toBe("");
+      expect(e.nameType).toBe("empty");
+      expect(e.confidence).toBe(1.0);
+    });
+
+    it("classifies '???' as 'unknown'", () => {
+      const content = `define s = Character("???", color="#cfcfcf")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const s = chars[0];
+      expect(s.tag).toBe("s");
+      expect(s.name).toBe("???");
+      expect(s.displayName).toBe("???");
+      expect(s.nameType).toBe("unknown");
+      expect(s.confidence).toBe(1.0);
+    });
+  });
+
+  describe("Ren'Py text tag handling", () => {
+    it("strips color tags from the display name", () => {
+      const content = `define mystery = Character("{color=#f00}Stranger{/color}", color="#cfcfcf")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const mystery = chars[0];
+      expect(mystery.name).toBe("{color=#f00}Stranger{/color}");
+      expect(mystery.displayName).toBe("Stranger");
+      expect(mystery.nameType).toBe("tagged");
+    });
+
+    it("strips nested and combined tags", () => {
+      const content = `define boss = Character("{b}{color=#f00}Final Boss{/color}{/b}", color="#cfcfcf")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const boss = chars[0];
+      expect(boss.displayName).toBe("Final Boss");
+      expect(boss.nameType).toBe("tagged");
+    });
+
+    it("strips size and other parameterized tags", () => {
+      const content = `define s = Character("{size=30}Big{/size}", color="#cfcfcf")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const s = chars[0];
+      expect(s.displayName).toBe("Big");
+      expect(s.nameType).toBe("tagged");
+    });
+
+    it("preserves the raw name verbatim for round-tripping", () => {
+      const content = `define mystery = Character("{color=#f00}Stranger{/color}", color="#cfcfcf")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      // `name` keeps the original so export can re-emit the RPY
+      expect(chars[0].name).toBe("{color=#f00}Stranger{/color}");
+    });
+  });
+
+  describe("non-ASCII names", () => {
+    it("preserves Japanese characters in literal names", () => {
+      const content = `define e = Character("エイリーン", color="#cfb53b")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const e = chars[0];
+      expect(e.name).toBe("エイリーン");
+      expect(e.displayName).toBe("エイリーン");
+      expect(e.nameType).toBe("literal");
+    });
+
+    it("preserves mixed CJK + Latin characters", () => {
+      const content = `define s = Character("桜 — Sakura", color="#cfb53b")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      expect(chars[0].displayName).toBe("桜 — Sakura");
+      expect(chars[0].nameType).toBe("literal");
+    });
+
+    it("preserves emoji", () => {
+      const content = `define s = Character("Sarah \u{1F600}", color="#cfb53b")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      expect(chars[0].displayName).toBe("Sarah \u{1F600}");
+      expect(chars[0].nameType).toBe("literal");
+    });
+  });
+
+  describe("multi-line definitions", () => {
+    it("classifies a multi-line definition with a bracketed name as 'interpolated'", () => {
+      const content = [
+        "define e = Character(",
+        '    "[e_name]",',
+        '    color="#cfb53b"',
+        ")",
+      ].join("\n");
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      const e = chars[0];
+      expect(e.tag).toBe("e");
+      // Raw string content (with brackets) preserved.
+      expect(e.name).toBe("[e_name]");
+      expect(e.displayName).toBe("[e_name]");
+      expect(e.nameType).toBe("interpolated");
+    });
+
+    it("classifies a multi-line definition with a bare identifier as 'variable'", () => {
+      const content = [
+        "define boss = Character(",
+        "    boss_name,",
+        '    color="#ff0000"',
+        ")",
+      ].join("\n");
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      expect(chars[0].nameType).toBe("variable");
+      expect(chars[0].displayName).toBe("boss_name");
+    });
+
+    it("classifies a multi-line definition with a tagged name as 'tagged'", () => {
+      const content = [
+        "define mystery = Character(",
+        '    "{color=#f00}Stranger{/color}",',
+        '    color="#cfcfcf"',
+        ")",
+      ].join("\n");
+      const chars = characterParserService.parseFile(content, "test.rpy");
+
+      expect(chars).toHaveLength(1);
+      expect(chars[0].nameType).toBe("tagged");
+      expect(chars[0].displayName).toBe("Stranger");
+      expect(chars[0].name).toBe("{color=#f00}Stranger{/color}");
+    });
+  });
+
+  describe("color extraction (regression)", () => {
+    it("extracts color from single-line definitions", () => {
+      const content = `define s = Character("Sarah", color="#c8ffc8")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+      expect(chars[0].color).toBe("#c8ffc8");
+    });
+
+    it("prefers who_color over color", () => {
+      const content = `define s = Character("Sarah", who_color="#c8ffc8", color="#000000")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+      expect(chars[0].color).toBe("#c8ffc8");
+    });
+
+    it("falls back to default color when none specified", () => {
+      const content = `define s = Character("Sarah")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+      expect(chars[0].color).toBe("#cfcfcf");
+    });
+  });
+
+  describe("isSpecial flag (regression)", () => {
+    it("marks narrator (n) as special", () => {
+      const content = `define n = Character(None, what_color="#cfcfcf")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+      expect(chars[0].isSpecial).toBe(true);
+    });
+
+    it("does not let a subsequent color line overwrite a multi-line None name", () => {
+      // Regression: a multi-line `None` followed by a quoted `color=`
+      // option used to capture `"#cfcfcf"` as the narrator's name
+      // because the guard was `!pendingCharacter.name` (which is
+      // `true` when name is `null`). A `nameResolved` flag now locks
+      // the name once it's been set to `null`.
+      const content = [
+        "define n = Character(",
+        "    None,",
+        '    color="#cfcfcf"',
+        ")",
+      ].join("\n");
+      const chars = characterParserService.parseFile(content, "test.rpy");
+      expect(chars).toHaveLength(1);
+      expect(chars[0].name).toBeNull();
+      expect(chars[0].displayName).toBe("");
+      expect(chars[0].nameType).toBe("none");
+      expect(chars[0].color).toBe("#cfcfcf");
+    });
+
+    it("marks unknown speaker (u) as special", () => {
+      const content = `define u = Character("???", color="#cfcfcf")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+      expect(chars[0].isSpecial).toBe(true);
+    });
+
+    it("does not mark normal characters as special", () => {
+      const content = `define s = Character("Sarah", color="#c8ffc8")`;
+      const chars = characterParserService.parseFile(content, "test.rpy");
+      expect(chars[0].isSpecial).toBe(false);
+    });
+  });
+
+  describe("deduplication (regression)", () => {
+    it("keeps first occurrence when same tag appears in multiple files", () => {
+      const result = characterParserService.parseFiles([
+        { content: `define s = Character("Sarah")`, filename: "a.rpy" },
+        { content: `define s = Character("S")`, filename: "b.rpy" },
+      ]);
+
+      expect(result.characters).toHaveLength(1);
+      expect(result.characters[0].displayName).toBe("Sarah");
+    });
+  });
+});

--- a/apps/backend/src/services/__tests__/character-parser.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/character-parser.service.unit.test.ts
@@ -295,6 +295,48 @@ describe("characterParserService", () => {
     });
   });
 
+  describe("edge cases (regression for #138 follow-ups)", () => {
+    it("classifies an empty quoted name on a multi-line continuation as 'empty'", () => {
+      // Regression: the multi-line continuation quoted regex used
+      // `[^"]+` (one or more), so `""` was not captured and the
+      // narrator's name was left unresolved — letting a subsequent
+      // `color="..."` line be miscaptured as the name. Fixed by
+      // using `[^"]*` (zero or more), matching the standard and
+      // multi-line-start patterns.
+      const content = [
+        "define n = Character(",
+        '    "",',
+        '    color="#cfcfcf"',
+        ")",
+      ].join("\n");
+      const chars = characterParserService.parseFile(content, "test.rpy");
+      expect(chars).toHaveLength(1);
+      expect(chars[0].name).toBe("");
+      expect(chars[0].nameType).toBe("empty");
+      expect(chars[0].color).toBe("#cfcfcf");
+    });
+
+    it("classifies a multi-line start with `None` on the same line as 'none'", () => {
+      // Regression: `define n = Character(None,` (opening paren on
+      // the start line, rest of definition on following lines) used
+      // to fall through to the identifier fallback and capture
+      // `None` as a variable name. The `nullNameMatch` check in
+      // `parseCharacterLine` only catches fully single-line
+      // definitions; the multi-line start path now also checks
+      // explicitly for `None`.
+      const content = [
+        "define n = Character(None,",
+        '    color="#cfcfcf"',
+        ")",
+      ].join("\n");
+      const chars = characterParserService.parseFile(content, "test.rpy");
+      expect(chars).toHaveLength(1);
+      expect(chars[0].name).toBeNull();
+      expect(chars[0].nameType).toBe("none");
+      expect(chars[0].color).toBe("#cfcfcf");
+    });
+  });
+
   describe("deduplication (regression)", () => {
     it("keeps first occurrence when same tag appears in multiple files", () => {
       const result = characterParserService.parseFiles([

--- a/apps/backend/src/services/character-parser.service.ts
+++ b/apps/backend/src/services/character-parser.service.ts
@@ -10,6 +10,7 @@
  * - Dynamic names: define ne = Character("[persistent.pl_nickname]", ...)
  * - Variable names: define ne = Character(voice_name, ...) or Character([voice_name], ...)
  * - who_color parameter: who_color="#..." instead of color="#..."
+ * - Formatted names: define mystery = Character("{color=#f00}Stranger{/color}")
  */
 
 // Default excluded character tags (special Ren'Py characters)
@@ -21,8 +22,13 @@ export type DefaultExcludedTag = (typeof DEFAULT_EXCLUDED_TAGS)[number];
  *
  * Field explanations:
  * - tag: The dialogue tag used in RPY files (e.g., "s" for `s "Hello!"`)
- * - name: The variable reference from Character() definition (e.g., "s_first", "Name", None)
- * - displayName: The human-readable name shown in BranchForge UI (Writer Mode, Character menu)
+ * - name: The raw name as it appeared in the source Character() call.
+ *   For round-tripping back to RPY (export uses this, not displayName).
+ * - displayName: The human-readable name suggested for use in BranchForge
+ *   UI. Tags stripped (e.g., "{color=...}Stranger{/color}" → "Stranger"),
+ *   variable names preserved as-is. Empty when the source is None/"";
+ *   callers should derive a fallback (the tag, or "(unnamed)") for display.
+ * - nameType: How the name was specified — drives import-wizard warnings.
  * - color: Hex color for dialogue display
  * - isSpecial: Whether this is a system character (narration, unknown speaker)
  * - sourceFile: Which RPY file this was detected in
@@ -32,6 +38,7 @@ export interface DetectedCharacter {
   tag: string;
   name: string | null;
   displayName: string;
+  nameType: CharacterNameType;
   color: string;
   isSpecial: boolean; // narration, unknown, etc.
   sourceFile: string;
@@ -59,13 +66,123 @@ export interface CharacterParseResult {
 }
 
 /**
+ * Internal form discriminator for how the name was specified in the source.
+ * - `quoted` — `Character("Sarah", ...)` or `Character("???", ...)`
+ * - `bracketed` — `Character([e_name], ...)` (with square brackets)
+ * - `identifier` — `Character(boss_name, ...)` (bare Python identifier)
+ */
+type NameForm = "quoted" | "bracketed" | "identifier";
+
+/**
  * Pattern match result for character definitions
  */
 interface CharacterPatternMatch {
   tag: string;
   name: string | null;
+  /**
+   * The raw name as written in the source, including any surrounding brackets
+   * (for the `bracketed` form) but excluding the quotes (for the `quoted`
+   * form). Preserved verbatim for round-tripping.
+   */
+  rawName: string | null;
+  nameForm: NameForm | null;
   color?: string;
   isMultiLine: boolean;
+}
+
+/**
+ * Re-export for callers that need the shared type but import from the
+ * service module. Re-exporting keeps the parser's public surface stable
+ * while still using the single source of truth.
+ */
+export type { CharacterNameType } from "@branchforge/shared";
+import { CharacterNameType, stripRenpyTextTags } from "@branchforge/shared";
+
+/**
+ * Classify a raw extracted name and compute the suggested display name.
+ *
+ * - `quoted` form:
+ *   - `""` → `empty`
+ *   - `"???"` → `unknown` (kept verbatim — intentional author choice)
+ *   - contains Ren'Py inline tags → `tagged` (displayName = tags stripped)
+ *   - contains a `[identifier]` interpolation expression → `interpolated`
+ *     (low confidence; Ren'Py resolves the value at runtime)
+ *   - otherwise → `literal`
+ * - `bracketed` form (`[e_name]`) → `interpolated` (low confidence)
+ * - `identifier` form (`boss_name`) → `variable` (low confidence)
+ *
+ * Known limitation: `INTERPOLATION_REGEX` cannot tell the difference
+ * between a Ren'Py variable interpolation (`"[player_name]"`) and a
+ * decorative bracket pair in a literal string (`"[END]"`). Both are
+ * classified as `interpolated`. The wizard's badge is informational;
+ * authors can override the display name on import.
+ */
+const INTERPOLATION_REGEX =
+  /\[[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*\]/;
+
+function classifyName(
+  rawName: string | null,
+  form: NameForm | null
+): { displayName: string; nameType: CharacterNameType; confidence: number } {
+  if (form === null || rawName === null) {
+    return { displayName: "", nameType: "none", confidence: 0.5 };
+  }
+
+  if (form === "quoted") {
+    if (rawName === "") {
+      return { displayName: "", nameType: "empty", confidence: 1.0 };
+    }
+    if (rawName === "???") {
+      return { displayName: "???", nameType: "unknown", confidence: 1.0 };
+    }
+    if (/\{[^{}]*\}/.test(rawName)) {
+      return {
+        displayName: stripRenpyTextTags(rawName),
+        nameType: "tagged",
+        confidence: 1.0,
+      };
+    }
+    if (INTERPOLATION_REGEX.test(rawName)) {
+      return {
+        displayName: rawName,
+        nameType: "interpolated",
+        confidence: 0.5,
+      };
+    }
+    return { displayName: rawName, nameType: "literal", confidence: 1.0 };
+  }
+
+  if (form === "bracketed") {
+    return { displayName: rawName, nameType: "interpolated", confidence: 0.5 };
+  }
+
+  // form === "identifier"
+  return { displayName: rawName, nameType: "variable", confidence: 0.5 };
+}
+
+/**
+ * Build a DetectedCharacter from a pattern match, deriving nameType and
+ * displayName via `classifyName`.
+ */
+function buildDetectedCharacter(
+  match: CharacterPatternMatch,
+  filename: string,
+  isSpecial: boolean
+): DetectedCharacter {
+  const { displayName, nameType, confidence } = classifyName(
+    match.rawName,
+    match.nameForm
+  );
+  return {
+    tag: match.tag,
+    name: match.name,
+    displayName,
+    nameType,
+    color: match.color || "#cfcfcf",
+    isSpecial,
+    sourceFile: filename,
+    confidence,
+  };
 }
 
 /**
@@ -114,6 +231,18 @@ class CharacterParserService {
   }
 
   /**
+   * Extract color (who_color first, then color) from an options string.
+   */
+  private extractColor(options: string | undefined): string | undefined {
+    if (!options) return undefined;
+    const whoColorMatch = options.match(/who_color\s*=\s*["']?([^"')\s]+)/);
+    if (whoColorMatch) return whoColorMatch[1];
+    const colorMatch = options.match(/color\s*=\s*["']?([^"')\s]+)/);
+    if (colorMatch) return colorMatch[1];
+    return undefined;
+  }
+
+  /**
    * Parse a single character definition line
    */
   private parseCharacterLine(line: string): CharacterPatternMatch | null {
@@ -135,43 +264,10 @@ class CharacterParserService {
       return null;
     }
 
-    // Standard single-line pattern: define tag = Character("name", options...)
-    // Also supports: default tag = Character("name", options...)
-    // Also supports variable names: Character(variable_name, ...) or Character([variable_name], ...)
-    const standardMatch = trimmed.match(
-      /(?:define|default)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*Character\s*\(\s*(?:"([^"]+)"|(\[?[a-zA-Z_][a-zA-Z0-9_[\]*.]*\]?))(\s*,\s*([^)]*))?\s*\)/
-    );
-    if (standardMatch) {
-      const tag = standardMatch[1];
-      // Name can be in capture group 2 (quoted) or 3 (variable/bracketed)
-      const name = standardMatch[2] || standardMatch[3] || null;
-      // Options are in capture group 5 (the content after the comma)
-      const options = standardMatch[5];
-
-      let color: string | undefined = undefined;
-      if (options) {
-        // Try various color parameter names (who_color is commonly used in Ren'Py)
-        const whoColorMatch = options.match(/who_color\s*=\s*["']?([^"')\s]+)/);
-        if (whoColorMatch) {
-          color = whoColorMatch[1];
-        } else {
-          const colorMatch = options.match(/color\s*=\s*["']?([^"')\s]+)/);
-          if (colorMatch) {
-            color = colorMatch[1];
-          }
-        }
-      }
-
-      return {
-        tag,
-        name,
-        color: this.normalizeColor(color),
-        isMultiLine: false,
-      };
-    }
-
     // Null name pattern: define n = Character(None, options...)
     // Also supports: default n = Character(None, options...)
+    // Check this BEFORE the standard pattern because `None` would otherwise
+    // match the identifier group of the standard pattern.
     const nullNameMatch = trimmed.match(
       /(?:define|default)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*Character\s*\(\s*None(\s*,\s*([^)]*))?\s*\)/
     );
@@ -179,23 +275,57 @@ class CharacterParserService {
       const tag = nullNameMatch[1];
       const options = nullNameMatch[2];
 
-      let color: string | undefined = undefined;
-      if (options) {
-        // who_color is commonly used for null-narrator characters
-        const whoColorMatch = options.match(/who_color\s*=\s*["']?([^"')\s]+)/);
-        if (whoColorMatch) {
-          color = whoColorMatch[1];
-        } else {
-          const colorMatch = options.match(/color\s*=\s*["']?([^"')\s]+)/);
-          if (colorMatch) {
-            color = colorMatch[1];
-          }
-        }
-      }
+      const color = this.extractColor(options);
 
       return {
         tag,
         name: null,
+        rawName: null,
+        nameForm: null,
+        color: this.normalizeColor(color),
+        isMultiLine: false,
+      };
+    }
+
+    // Standard single-line pattern: define tag = Character("name", options...)
+    // Also supports: default tag = Character("name", options...)
+    // Also supports variable names: Character(variable_name, ...) or Character([variable_name], ...)
+    const standardMatch = trimmed.match(
+      /(?:define|default)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*Character\s*\(\s*(?:"([^"]*)"|(\[([a-zA-Z_][a-zA-Z0-9_.]*)\])|([a-zA-Z_][a-zA-Z0-9_.]*))(\s*,\s*([^)]*))?\s*\)/
+    );
+    if (standardMatch) {
+      const tag = standardMatch[1];
+      // Groups: 2=quoted, 3=bracketed-full (e.g., "[e_name]"), 4=bracketed-inner,
+      // 5=identifier, 6=options-after-comma, 7=options-content
+      let name: string | null = null;
+      let rawName: string | null = null;
+      let nameForm: NameForm | null = null;
+      if (standardMatch[2] !== undefined) {
+        name = standardMatch[2];
+        rawName = standardMatch[2];
+        nameForm = "quoted";
+      } else if (standardMatch[3] !== undefined) {
+        // Both `name` and `rawName` keep the brackets for round-trip
+        // fidelity. This keeps the bracketed arg form consistent with
+        // the quoted form `"[e_name]"` (where the brackets appear in
+        // the string content).
+        name = standardMatch[3]; // includes brackets, e.g. "[e_name]"
+        rawName = standardMatch[3];
+        nameForm = "bracketed";
+      } else if (standardMatch[5] !== undefined) {
+        rawName = standardMatch[5];
+        name = standardMatch[5];
+        nameForm = "identifier";
+      }
+      const options = standardMatch[7];
+
+      const color = this.extractColor(options);
+
+      return {
+        tag,
+        name,
+        rawName,
+        nameForm,
         color: this.normalizeColor(color),
         isMultiLine: false,
       };
@@ -210,39 +340,46 @@ class CharacterParserService {
       const tag = multiLineStartMatch[1];
       const rest = multiLineStartMatch[2];
 
-      // Check if name is on the same line (quoted string, variable, or bracketed variable)
+      // Check if name is on the same line (quoted string, bracketed, or identifier)
+      let name: string | null = null;
+      let rawName: string | null = null;
+      let nameForm: NameForm | null = null;
+
       const quotedNameMatch = rest.match(/"([^"]*)"/);
-      const bracketedNameMatch =
-        !quotedNameMatch && rest.match(/\[([a-zA-Z_][a-zA-Z0-9_[\]*.]*)\]/);
-      const variableNameMatch =
-        !quotedNameMatch &&
-        !bracketedNameMatch &&
-        rest.match(/([a-zA-Z_][a-zA-Z0-9_.]*)/);
-      const name = quotedNameMatch
-        ? quotedNameMatch[1]
-        : bracketedNameMatch
-          ? bracketedNameMatch[1]
-          : variableNameMatch
-            ? variableNameMatch[1]
-            : null;
+      if (quotedNameMatch) {
+        name = quotedNameMatch[1];
+        rawName = quotedNameMatch[1];
+        nameForm = "quoted";
+      } else {
+        const bracketedNameMatch = rest.match(/\[([a-zA-Z_][a-zA-Z0-9_.]*)\]/);
+        if (bracketedNameMatch) {
+          // Both `name` and `rawName` keep the brackets for round-trip
+          // fidelity (matches the single-line `Character([e_name], ...)`
+          // case).
+          name = `[${bracketedNameMatch[1]}]`;
+          rawName = `[${bracketedNameMatch[1]}]`;
+          nameForm = "bracketed";
+        } else {
+          const variableNameMatch = rest.match(/([a-zA-Z_][a-zA-Z0-9_.]*)/);
+          if (variableNameMatch) {
+            rawName = variableNameMatch[1];
+            name = variableNameMatch[1];
+            nameForm = "identifier";
+          }
+        }
+      }
 
       // Try to extract color from rest of line (who_color first, then color)
       let color: string | undefined = undefined;
       if (rest.trim()) {
-        const whoColorMatch = rest.match(/who_color\s*=\s*["']?([^"')\s]+)/);
-        if (whoColorMatch) {
-          color = whoColorMatch[1];
-        } else {
-          const colorMatch = rest.match(/color\s*=\s*["']?([^"')\s]+)/);
-          if (colorMatch) {
-            color = colorMatch[1];
-          }
-        }
+        color = this.extractColor(rest);
       }
 
       return {
         tag,
         name,
+        rawName,
+        nameForm,
         color: this.normalizeColor(color),
         isMultiLine: true,
       };
@@ -262,9 +399,17 @@ class CharacterParserService {
     let pendingCharacter: {
       tag: string;
       name: string | null;
+      rawName: string | null;
+      nameForm: NameForm | null;
       color: string | undefined;
       options: string[];
       startLine: number;
+      /**
+       * True once the name has been resolved (or explicitly set to
+       * null for `None`). Prevents subsequent option lines like
+       * `color="#cfcfcf"` from re-matching as the character name.
+       */
+      nameResolved: boolean;
     } | null = null;
     let parenDepth = 0;
 
@@ -286,18 +431,47 @@ class CharacterParserService {
         // Capture options
         if (trimmed && !trimmed.startsWith("#")) {
           // Check if this line contains the name (if not already found)
-          if (!pendingCharacter.name) {
+          if (!pendingCharacter.nameResolved) {
             // Try quoted name
             const quotedNameMatch = trimmed.match(/"([^"]+)"/);
             if (quotedNameMatch) {
               pendingCharacter.name = quotedNameMatch[1];
+              pendingCharacter.rawName = quotedNameMatch[1];
+              pendingCharacter.nameForm = "quoted";
+              pendingCharacter.nameResolved = true;
+            } else if (
+              /^None\b/.test(trimmed) ||
+              /^\s*None\s*[,)]/.test(trimmed)
+            ) {
+              // Explicit `None` token: the character has no display name.
+              // (Ren'Py treats `Character(None, ...)` as the narrator.)
+              pendingCharacter.name = null;
+              pendingCharacter.rawName = null;
+              pendingCharacter.nameForm = null;
+              pendingCharacter.nameResolved = true;
             } else {
-              // Try variable name
-              const variableNameMatch = trimmed.match(
-                /([a-zA-Z_][a-zA-Z0-9_.]*)/
+              // Try bracketed name
+              const bracketedNameMatch = trimmed.match(
+                /\[([a-zA-Z_][a-zA-Z0-9_.]*)\]/
               );
-              if (variableNameMatch) {
-                pendingCharacter.name = variableNameMatch[1];
+              if (bracketedNameMatch) {
+                // Both name and rawName keep the brackets for
+                // round-trip fidelity.
+                pendingCharacter.rawName = `[${bracketedNameMatch[1]}]`;
+                pendingCharacter.name = `[${bracketedNameMatch[1]}]`;
+                pendingCharacter.nameForm = "bracketed";
+                pendingCharacter.nameResolved = true;
+              } else {
+                // Try variable name
+                const variableNameMatch = trimmed.match(
+                  /([a-zA-Z_][a-zA-Z0-9_.]*)/
+                );
+                if (variableNameMatch) {
+                  pendingCharacter.rawName = variableNameMatch[1];
+                  pendingCharacter.name = variableNameMatch[1];
+                  pendingCharacter.nameForm = "identifier";
+                  pendingCharacter.nameResolved = true;
+                }
               }
             }
           }
@@ -310,34 +484,19 @@ class CharacterParserService {
           let color = pendingCharacter.color;
           if (!color) {
             const optionsText = pendingCharacter.options.join(" ");
-            const whoColorMatch = optionsText.match(
-              /who_color\s*=\s*["']?([^"')\s]+)/
-            );
-            if (whoColorMatch) {
-              color = whoColorMatch[1];
-            } else {
-              const colorMatch = optionsText.match(
-                /color\s*=\s*["']?([^"')\s]+)/
-              );
-              if (colorMatch) {
-                color = colorMatch[1];
-              }
-            }
+            color = this.extractColor(optionsText);
           }
 
-          // Create detected character
           const isSpecial = this.isSpecialTag(pendingCharacter.tag);
-          const displayName = pendingCharacter.name || pendingCharacter.tag;
-
-          characters.push({
+          const match: CharacterPatternMatch = {
             tag: pendingCharacter.tag,
             name: pendingCharacter.name,
-            displayName,
+            rawName: pendingCharacter.rawName,
+            nameForm: pendingCharacter.nameForm,
             color: this.normalizeColor(color),
-            isSpecial,
-            sourceFile: filename,
-            confidence: pendingCharacter.name ? 1.0 : 0.5,
-          });
+            isMultiLine: true,
+          };
+          characters.push(buildDetectedCharacter(match, filename, isSpecial));
 
           pendingCharacter = null;
           parenDepth = 0;
@@ -355,24 +514,21 @@ class CharacterParserService {
           pendingCharacter = {
             tag: match.tag,
             name: match.name,
+            rawName: match.rawName,
+            nameForm: match.nameForm,
             color: match.color,
             options: [],
             startLine: i,
+            // The start line only resolves the name when it
+            // identified a form (quoted/bracketed/identifier) OR
+            // found `None`. A bare `define tag = Character(` start
+            // leaves the name unresolved; the next line(s) carry it.
+            nameResolved: match.nameForm !== null,
           };
         } else {
           // Single-line definition
           const isSpecial = this.isSpecialTag(match.tag);
-          const displayName = match.name || match.tag;
-
-          characters.push({
-            tag: match.tag,
-            name: match.name,
-            displayName,
-            color: match.color || "#cfcfcf",
-            isSpecial,
-            sourceFile: filename,
-            confidence: match.name ? 1.0 : 0.5,
-          });
+          characters.push(buildDetectedCharacter(match, filename, isSpecial));
         }
       }
     }

--- a/apps/backend/src/services/character-parser.service.ts
+++ b/apps/backend/src/services/character-parser.service.ts
@@ -22,12 +22,15 @@ export type DefaultExcludedTag = (typeof DEFAULT_EXCLUDED_TAGS)[number];
  *
  * Field explanations:
  * - tag: The dialogue tag used in RPY files (e.g., "s" for `s "Hello!"`)
- * - name: The raw name as it appeared in the source Character() call.
- *   For round-tripping back to RPY (export uses this, not displayName).
+ * - name: The raw name as it appeared in the source Character() call,
+ *   preserved for reference and possible future round-tripping. The
+ *   current BranchForge RPY export emits `displayName`, not `name`, so
+ *   do not rely on `name` for export fidelity yet.
  * - displayName: The human-readable name suggested for use in BranchForge
- *   UI. Tags stripped (e.g., "{color=...}Stranger{/color}" → "Stranger"),
- *   variable names preserved as-is. Empty when the source is None/"";
- *   callers should derive a fallback (the tag, or "(unnamed)") for display.
+ *   UI (and emitted by the current RPY export). Tags stripped
+ *   (e.g., "{color=...}Stranger{/color}" → "Stranger"), variable names
+ *   preserved as-is. Empty when the source is `None`/`""`; callers
+ *   should derive a fallback (the tag, or `"(unnamed)"`) for display.
  * - nameType: How the name was specified — drives import-wizard warnings.
  * - color: Hex color for dialogue display
  * - isSpecial: Whether this is a system character (narration, unknown speaker)
@@ -86,17 +89,21 @@ interface CharacterPatternMatch {
    */
   rawName: string | null;
   nameForm: NameForm | null;
+  /**
+   * True when the name has been fully resolved (set to a value or
+   * explicitly to `null` for `None`). For multi-line starts, the
+   * `parseFile` consumer only continues looking for the name on
+   * subsequent lines when this is `false`. Defaults to `true` for
+   * single-line definitions (which never span multiple lines) and
+   * `false` for multi-line starts whose name will appear later.
+   */
+  nameResolved: boolean;
   color?: string;
   isMultiLine: boolean;
 }
 
-/**
- * Re-export for callers that need the shared type but import from the
- * service module. Re-exporting keeps the parser's public surface stable
- * while still using the single source of truth.
- */
-export type { CharacterNameType } from "@branchforge/shared";
-import { CharacterNameType, stripRenpyTextTags } from "@branchforge/shared";
+import type { CharacterNameType } from "@branchforge/shared";
+import { stripRenpyTextTags } from "@branchforge/shared";
 
 /**
  * Classify a raw extracted name and compute the suggested display name.
@@ -282,6 +289,7 @@ class CharacterParserService {
         name: null,
         rawName: null,
         nameForm: null,
+        nameResolved: true,
         color: this.normalizeColor(color),
         isMultiLine: false,
       };
@@ -326,6 +334,7 @@ class CharacterParserService {
         name,
         rawName,
         nameForm,
+        nameResolved: true,
         color: this.normalizeColor(color),
         isMultiLine: false,
       };
@@ -344,12 +353,31 @@ class CharacterParserService {
       let name: string | null = null;
       let rawName: string | null = null;
       let nameForm: NameForm | null = null;
+      // True once we have a final answer for the name — either a
+      // detected form, or explicit `None`. False when the name will
+      // appear on a later line of the multi-line definition.
+      let nameResolved = false;
 
       const quotedNameMatch = rest.match(/"([^"]*)"/);
       if (quotedNameMatch) {
         name = quotedNameMatch[1];
         rawName = quotedNameMatch[1];
         nameForm = "quoted";
+        nameResolved = true;
+      } else if (
+        // Explicit `None` token on the multi-line start line, e.g.
+        // `define n = Character(None,`. The standard `nullNameMatch`
+        // in `parseCharacterLine` only catches single-line
+        // definitions; here we need to handle the multi-line form
+        // before the identifier fallback would otherwise miscapture
+        // `None` as a variable name.
+        /^None\b/.test(rest) ||
+        /^\s*None\s*[,)]/.test(rest)
+      ) {
+        name = null;
+        rawName = null;
+        nameForm = null;
+        nameResolved = true;
       } else {
         const bracketedNameMatch = rest.match(/\[([a-zA-Z_][a-zA-Z0-9_.]*)\]/);
         if (bracketedNameMatch) {
@@ -359,12 +387,14 @@ class CharacterParserService {
           name = `[${bracketedNameMatch[1]}]`;
           rawName = `[${bracketedNameMatch[1]}]`;
           nameForm = "bracketed";
+          nameResolved = true;
         } else {
           const variableNameMatch = rest.match(/([a-zA-Z_][a-zA-Z0-9_.]*)/);
           if (variableNameMatch) {
             rawName = variableNameMatch[1];
             name = variableNameMatch[1];
             nameForm = "identifier";
+            nameResolved = true;
           }
         }
       }
@@ -380,6 +410,9 @@ class CharacterParserService {
         name,
         rawName,
         nameForm,
+        // Pass through the explicit nameResolved signal (covers
+        // detected form, explicit `None`, and unresolved cases).
+        nameResolved,
         color: this.normalizeColor(color),
         isMultiLine: true,
       };
@@ -432,8 +465,10 @@ class CharacterParserService {
         if (trimmed && !trimmed.startsWith("#")) {
           // Check if this line contains the name (if not already found)
           if (!pendingCharacter.nameResolved) {
-            // Try quoted name
-            const quotedNameMatch = trimmed.match(/"([^"]+)"/);
+            // Try quoted name. Use `*` (not `+`) to also match
+            // empty quoted strings like `""`, which Ren'Py treats as
+            // a literal "no display name".
+            const quotedNameMatch = trimmed.match(/"([^"]*)"/);
             if (quotedNameMatch) {
               pendingCharacter.name = quotedNameMatch[1];
               pendingCharacter.rawName = quotedNameMatch[1];
@@ -493,6 +528,10 @@ class CharacterParserService {
             name: pendingCharacter.name,
             rawName: pendingCharacter.rawName,
             nameForm: pendingCharacter.nameForm,
+            // The continuation loop only runs while the name is
+            // unresolved, so by the time we get here the name has
+            // been resolved one way or another.
+            nameResolved: true,
             color: this.normalizeColor(color),
             isMultiLine: true,
           };
@@ -519,11 +558,10 @@ class CharacterParserService {
             color: match.color,
             options: [],
             startLine: i,
-            // The start line only resolves the name when it
-            // identified a form (quoted/bracketed/identifier) OR
-            // found `None`. A bare `define tag = Character(` start
-            // leaves the name unresolved; the next line(s) carry it.
-            nameResolved: match.nameForm !== null,
+            // Pass through the parser's name-resolved signal. When
+            // false, the continuation loop will look for the name
+            // on subsequent lines.
+            nameResolved: match.nameResolved,
           };
         } else {
           // Single-line definition

--- a/apps/backend/src/services/gitlab-sync.service.ts
+++ b/apps/backend/src/services/gitlab-sync.service.ts
@@ -668,6 +668,10 @@ export async function importFromGitlab(
     // Note: We don't import them here - let the frontend call detectCharacters
     // after the sync, which will parse from project_files.content and show
     // the import wizard for NEW characters only.
+    //
+    // The rpy-parser only extracts a narrow {tag, name, color} shape; we
+    // don't have the form info to classify, so we default to "literal" —
+    // the wizard's "new characters" view lets the user override anyway.
     const allDetected: DetectedCharacter[] = [];
     for (const { parsed } of parsedFiles) {
       allDetected.push(
@@ -679,6 +683,7 @@ export async function importFromGitlab(
           isSpecial: false,
           sourceFile: "",
           confidence: 1,
+          nameType: "literal" as const,
         }))
       );
     }

--- a/apps/frontend/src/components/CharacterImportWizard.tsx
+++ b/apps/frontend/src/components/CharacterImportWizard.tsx
@@ -43,6 +43,13 @@ export interface CharacterImportWizardProps {
   detectedCharacters: DetectedCharacter[];
   conflicts: CharacterConflict[];
   excludedTags: string[];
+  /**
+   * Tags of characters already in the database. When a detected
+   * character is in this set, the wizard shows an "Already imported"
+   * indicator. The wizard's import is idempotent (upsert) so these
+   * can be re-confirmed without producing duplicates.
+   */
+  existingTags?: string[];
   onComplete?: () => void;
 }
 
@@ -269,6 +276,7 @@ export function CharacterImportWizard({
   detectedCharacters,
   conflicts,
   excludedTags,
+  existingTags = [],
   onComplete,
 }: CharacterImportWizardProps) {
   // Generate unique ID for checkbox to prevent collisions when multiple wizards are mounted
@@ -754,6 +762,15 @@ export function CharacterImportWizard({
                             <span className="font-mono text-sm font-medium">
                               {char.tag}
                             </span>
+                            {existingTags.includes(char.tag) && (
+                              <span
+                                className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded bg-muted text-muted-foreground border border-border/30"
+                                title="This character is already in the database. Re-confirming will update it (idempotent upsert)."
+                                data-testid={`already-imported-badge-${char.tag}`}
+                              >
+                                Already imported
+                              </span>
+                            )}
                             {badge && (
                               <span
                                 className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded bg-amber-50 text-amber-800 dark:bg-amber-950/40 dark:text-amber-300 border border-amber-200 dark:border-amber-800"

--- a/apps/frontend/src/components/CharacterImportWizard.tsx
+++ b/apps/frontend/src/components/CharacterImportWizard.tsx
@@ -11,6 +11,7 @@ import {
   User,
   CheckCircle2,
   AlertCircle,
+  AlertTriangle,
   Ban,
   Settings,
   ChevronDown,
@@ -22,7 +23,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { charactersApi, type ImportCharacter } from "@/lib/api/characters";
-import type { DetectedCharacter, CharacterConflict } from "@branchforge/shared";
+import type {
+  DetectedCharacter,
+  CharacterConflict,
+  CharacterNameType,
+} from "@branchforge/shared";
 import { useToast } from "@/contexts/ToastContext";
 import { useQueryClient } from "@tanstack/react-query";
 import { labelKeys, characterKeys } from "@/lib/query-keys";
@@ -134,6 +139,56 @@ function randomColor(): string {
       .toString(16)
       .padStart(6, "0")
   );
+}
+
+/**
+ * User-facing label + helper text for a CharacterNameType.
+ * Drives the warning badge and helper text below the display name field
+ * in the import wizard. `null` means no badge is shown.
+ */
+interface NameTypeBadgeInfo {
+  label: string;
+  helper: string;
+}
+
+function getNameTypeBadge(
+  nameType: CharacterNameType
+): NameTypeBadgeInfo | null {
+  switch (nameType) {
+    case "variable":
+      return {
+        label: "Variable name",
+        helper:
+          "The source references a variable whose value is only known at runtime. Enter a placeholder display name for use in BranchForge; export will keep the variable reference.",
+      };
+    case "interpolated":
+      return {
+        label: "Interpolated name",
+        helper:
+          "The source uses Ren'Py interpolation (e.g. [var]). The displayed name will vary at runtime. You can override it for BranchForge; export keeps the original.",
+      };
+    case "tagged":
+      return {
+        label: "Formatting stripped",
+        helper:
+          "Ren'Py inline tags (e.g. {color}, {b}) were stripped from the display name. The raw form is preserved for export.",
+      };
+    case "empty":
+      return {
+        label: "Empty name",
+        helper:
+          "The source has an empty display name. Enter a display name to use in BranchForge.",
+      };
+    case "unknown":
+      return {
+        label: "Unknown speaker",
+        helper: 'The source uses "???" — typically intentional. Kept as-is.',
+      };
+    case "none":
+    case "literal":
+    default:
+      return null;
+  }
 }
 
 function createInitialWizardState(
@@ -272,6 +327,7 @@ export function CharacterImportWizard({
             isSpecial: false,
             sourceFile: "",
             confidence: 1,
+            nameType: "literal",
             isLoveInterest: false,
             routeAffiliation: undefined,
             excluded: false,
@@ -388,6 +444,7 @@ export function CharacterImportWizard({
       isSpecial: false,
       sourceFile: "manual",
       confidence: 1,
+      nameType: "literal",
       excluded: false,
     };
 
@@ -672,78 +729,105 @@ export function CharacterImportWizard({
 
               {state.expandedGroups.has("new") && (
                 <div className="p-3 space-y-2 border-t border-border/30">
-                  {state.groups.new.map((char, index) => (
-                    <div
-                      key={char.tag}
-                      className="p-3 bg-background border border-border/30 rounded-md space-y-2"
-                    >
-                      <div className="flex items-start justify-between">
-                        <div className="flex items-center gap-2">
-                          <input
-                            type="checkbox"
-                            checked={!char.excluded}
-                            onChange={(e) =>
-                              updateCharacter("new", index, {
-                                excluded: !e.target.checked,
-                              })
-                            }
-                            className="size-4 rounded"
-                            disabled={state.isImporting}
-                            aria-label={`Include ${char.tag}`}
-                          />
-                          <span className="font-mono text-sm font-medium">
-                            {char.tag}
-                          </span>
+                  {state.groups.new.map((char, index) => {
+                    const badge = getNameTypeBadge(char.nameType);
+                    const showEmptyHint = char.nameType === "empty";
+                    return (
+                      <div
+                        key={char.tag}
+                        className="p-3 bg-background border border-border/30 rounded-md space-y-2"
+                      >
+                        <div className="flex items-start justify-between">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <input
+                              type="checkbox"
+                              checked={!char.excluded}
+                              onChange={(e) =>
+                                updateCharacter("new", index, {
+                                  excluded: !e.target.checked,
+                                })
+                              }
+                              className="size-4 rounded"
+                              disabled={state.isImporting}
+                              aria-label={`Include ${char.tag}`}
+                            />
+                            <span className="font-mono text-sm font-medium">
+                              {char.tag}
+                            </span>
+                            {badge && (
+                              <span
+                                className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded bg-amber-50 text-amber-800 dark:bg-amber-950/40 dark:text-amber-300 border border-amber-200 dark:border-amber-800"
+                                title={badge.helper}
+                                data-testid={`name-type-badge-${char.tag}`}
+                              >
+                                <AlertTriangle className="size-3" />
+                                {badge.label}
+                              </span>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <div
+                              className="size-6 rounded border border-border/30"
+                              style={{ backgroundColor: char.color }}
+                              title={char.color}
+                            />
+                            {char.excluded && (
+                              <Ban className="size-4 text-muted-foreground" />
+                            )}
+                          </div>
                         </div>
-                        <div className="flex items-center gap-2">
-                          <div
-                            className="size-6 rounded border border-border/30"
-                            style={{ backgroundColor: char.color }}
-                            title={char.color}
-                          />
-                          {char.excluded && (
-                            <Ban className="size-4 text-muted-foreground" />
-                          )}
-                        </div>
-                      </div>
 
-                      {!char.excluded && (
-                        <div className="grid grid-cols-2 gap-2">
-                          <div>
-                            <Label className="text-xs text-muted-foreground">
-                              Display Name (in BF)
-                            </Label>
-                            <Input
-                              value={char.displayName}
-                              onChange={(e) =>
-                                updateCharacter("new", index, {
-                                  displayName: e.target.value,
-                                })
-                              }
-                              className="h-7 text-sm"
-                              disabled={state.isImporting}
-                            />
-                          </div>
-                          <div>
-                            <Label className="text-xs text-muted-foreground">
-                              Color
-                            </Label>
-                            <Input
-                              type="color"
-                              value={char.color}
-                              onChange={(e) =>
-                                updateCharacter("new", index, {
-                                  color: e.target.value,
-                                })
-                              }
-                              className="h-7 text-sm p-1"
-                              disabled={state.isImporting}
-                            />
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  ))}
+                        {!char.excluded && (
+                          <>
+                            <div className="grid grid-cols-2 gap-2">
+                              <div>
+                                <Label className="text-xs text-muted-foreground">
+                                  Display Name (in BF)
+                                </Label>
+                                <Input
+                                  value={char.displayName}
+                                  placeholder={
+                                    showEmptyHint ? "(unnamed)" : undefined
+                                  }
+                                  onChange={(e) =>
+                                    updateCharacter("new", index, {
+                                      displayName: e.target.value,
+                                    })
+                                  }
+                                  className="h-7 text-sm"
+                                  disabled={state.isImporting}
+                                />
+                              </div>
+                              <div>
+                                <Label className="text-xs text-muted-foreground">
+                                  Color
+                                </Label>
+                                <Input
+                                  type="color"
+                                  value={char.color}
+                                  onChange={(e) =>
+                                    updateCharacter("new", index, {
+                                      color: e.target.value,
+                                    })
+                                  }
+                                  className="h-7 text-sm p-1"
+                                  disabled={state.isImporting}
+                                />
+                              </div>
+                            </div>
+                            {badge && (
+                              <p
+                                className="text-xs text-muted-foreground"
+                                data-testid={`name-type-helper-${char.tag}`}
+                              >
+                                {badge.helper}
+                              </p>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>
@@ -862,7 +946,7 @@ export function CharacterImportWizard({
                         />
                         <span className="font-mono text-sm">{char.tag}</span>
                         <span className="text-xs text-muted-foreground">
-                          ({char.displayName})
+                          ({char.displayName || "(unnamed)"})
                         </span>
                       </div>
                       <div

--- a/apps/frontend/src/components/__tests__/CharacterImportWizard.test.tsx
+++ b/apps/frontend/src/components/__tests__/CharacterImportWizard.test.tsx
@@ -57,7 +57,10 @@ function makeChar(
   };
 }
 
-function renderWizard(detectedCharacters: DetectedCharacter[]) {
+function renderWizard(
+  detectedCharacters: DetectedCharacter[],
+  existingTags: string[] = []
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -76,6 +79,7 @@ function renderWizard(detectedCharacters: DetectedCharacter[]) {
           detectedCharacters={detectedCharacters}
           conflicts={[]}
           excludedTags={[]}
+          existingTags={existingTags}
           onComplete={onComplete}
         />
       </QueryClientProvider>
@@ -349,6 +353,42 @@ describe("CharacterImportWizard — excluded state", () => {
 
     expect(
       screen.queryByTestId("name-type-helper-boss")
+    ).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Regression for the wizard-not-showing bug introduced by PR #245.
+ *
+ * PR #245 promotes extracted characters into the `characters` table
+ * during import, so by the time `detectCharacters` runs, all
+ * detected tags are in `existingTags`. The wizard's "Already
+ * imported" badge gives the user a clear signal that confirming the
+ * import is a no-op for those rows.
+ */
+describe("CharacterImportWizard — already-imported indicator", () => {
+  it("shows an 'Already imported' badge for characters that are in the DB", () => {
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "s",
+        name: "Sarah",
+        displayName: "Sarah",
+        nameType: "literal",
+      }),
+      makeChar({
+        tag: "boss",
+        name: "boss_name",
+        displayName: "boss_name",
+        nameType: "variable",
+      }),
+    ];
+
+    // "s" was inserted by PR #245's auto-promote; "boss" is brand new.
+    renderWizard(chars, ["s"]);
+
+    expect(screen.getByTestId("already-imported-badge-s")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("already-imported-badge-boss")
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/__tests__/CharacterImportWizard.test.tsx
+++ b/apps/frontend/src/components/__tests__/CharacterImportWizard.test.tsx
@@ -11,7 +11,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { CharacterImportWizard } from "../CharacterImportWizard";
+import { CharacterImportWizard } from "@/components/CharacterImportWizard";
 import type { DetectedCharacter } from "@branchforge/shared";
 
 // ---------------------------------------------------------------------------

--- a/apps/frontend/src/components/__tests__/CharacterImportWizard.test.tsx
+++ b/apps/frontend/src/components/__tests__/CharacterImportWizard.test.tsx
@@ -1,0 +1,413 @@
+/**
+ * CharacterImportWizard — nameType badge & helper text
+ *
+ * Tests the warning indicators added for #138: characters with variable,
+ * interpolated, tagged, empty, or unknown display names should surface a
+ * badge in the import wizard and a helper text below the display name
+ * input. Literal names should not trigger any indicator.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { CharacterImportWizard } from "../CharacterImportWizard";
+import type { DetectedCharacter } from "@branchforge/shared";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockImport = vi.fn();
+
+vi.mock("@/lib/api/characters", () => ({
+  charactersApi: {
+    importCharacters: (...args: unknown[]) => mockImport(...args),
+  },
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => ({
+    success: mockToastSuccess,
+    error: mockToastError,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeChar(
+  overrides: Partial<DetectedCharacter> & {
+    tag: string;
+    nameType: DetectedCharacter["nameType"];
+  }
+): DetectedCharacter {
+  return {
+    name: overrides.nameType === "none" ? null : "name",
+    displayName: overrides.displayName ?? "Display",
+    color: "#c8ffc8",
+    isSpecial: false,
+    sourceFile: "test.rpy",
+    confidence: 1,
+    ...overrides,
+  };
+}
+
+function renderWizard(detectedCharacters: DetectedCharacter[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const onOpenChange = vi.fn();
+  const onComplete = vi.fn();
+
+  return {
+    onOpenChange,
+    onComplete,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <CharacterImportWizard
+          open
+          onOpenChange={onOpenChange}
+          projectId="proj-1"
+          detectedCharacters={detectedCharacters}
+          conflicts={[]}
+          excludedTags={[]}
+          onComplete={onComplete}
+        />
+      </QueryClientProvider>
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CharacterImportWizard — nameType warnings (issue #138)", () => {
+  beforeEach(() => {
+    mockImport.mockReset();
+    mockToastSuccess.mockReset();
+    mockToastError.mockReset();
+  });
+
+  it("shows no badge for literal names", () => {
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "s",
+        name: "Sarah",
+        displayName: "Sarah",
+        nameType: "literal",
+      }),
+    ];
+
+    renderWizard(chars);
+
+    // No badge for this tag
+    expect(screen.queryByTestId("name-type-badge-s")).not.toBeInTheDocument();
+  });
+
+  it("shows a 'Variable name' badge for variable names", () => {
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "boss",
+        name: "boss_name",
+        displayName: "boss_name",
+        nameType: "variable",
+      }),
+    ];
+
+    renderWizard(chars);
+
+    const badge = screen.getByTestId("name-type-badge-boss");
+    expect(badge).toHaveTextContent(/Variable name/i);
+    expect(badge).toHaveAttribute("title");
+    expect(screen.getByTestId("name-type-helper-boss")).toBeInTheDocument();
+  });
+
+  it("shows a 'Interpolated name' badge for bracketed interpolation", () => {
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "e",
+        name: "[e_name]",
+        displayName: "[e_name]",
+        nameType: "interpolated",
+      }),
+    ];
+
+    renderWizard(chars);
+
+    const badge = screen.getByTestId("name-type-badge-e");
+    expect(badge).toHaveTextContent(/Interpolated name/i);
+    expect(screen.getByTestId("name-type-helper-e")).toBeInTheDocument();
+  });
+
+  it("shows a 'Formatting stripped' badge when tags were stripped", () => {
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "mystery",
+        name: "{color=#f00}Stranger{/color}",
+        displayName: "Stranger",
+        nameType: "tagged",
+      }),
+    ];
+
+    renderWizard(chars);
+
+    const badge = screen.getByTestId("name-type-badge-mystery");
+    expect(badge).toHaveTextContent(/Formatting stripped/i);
+  });
+
+  it("shows an 'Empty name' badge and a placeholder when displayName is empty", () => {
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "x",
+        name: "",
+        displayName: "",
+        nameType: "empty",
+      }),
+    ];
+
+    renderWizard(chars);
+
+    const badge = screen.getByTestId("name-type-badge-x");
+    expect(badge).toHaveTextContent(/Empty name/i);
+
+    // The display-name input shows a "(unnamed)" placeholder
+    const helper = screen.getByTestId("name-type-helper-x");
+    expect(helper).toHaveTextContent(/Enter a display name/i);
+  });
+
+  it("shows an 'Unknown speaker' badge for ??? names", () => {
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "mystery",
+        name: "???",
+        displayName: "???",
+        nameType: "unknown",
+        isSpecial: false,
+      }),
+    ];
+
+    renderWizard(chars);
+
+    const badge = screen.getByTestId("name-type-badge-mystery");
+    expect(badge).toHaveTextContent(/Unknown speaker/i);
+  });
+
+  it("renders badges for multiple flagged characters in the same group", () => {
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "boss",
+        name: "boss_name",
+        displayName: "boss_name",
+        nameType: "variable",
+      }),
+      makeChar({
+        tag: "mystery",
+        name: "{color=#f00}Stranger{/color}",
+        displayName: "Stranger",
+        nameType: "tagged",
+      }),
+      makeChar({
+        tag: "s",
+        name: "Sarah",
+        displayName: "Sarah",
+        nameType: "literal",
+      }),
+    ];
+
+    renderWizard(chars);
+
+    expect(screen.getByTestId("name-type-badge-boss")).toBeInTheDocument();
+    expect(screen.getByTestId("name-type-badge-mystery")).toBeInTheDocument();
+    expect(screen.queryByTestId("name-type-badge-s")).not.toBeInTheDocument();
+  });
+
+  it("preserves the original displayName and lets the user override it", async () => {
+    const user = userEvent.setup();
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "boss",
+        name: "boss_name",
+        displayName: "boss_name",
+        nameType: "variable",
+      }),
+    ];
+
+    renderWizard(chars);
+
+    const displayNameInput = screen.getByDisplayValue("boss_name");
+    await user.clear(displayNameInput);
+    await user.type(displayNameInput, "Big Boss");
+
+    expect(displayNameInput).toHaveValue("Big Boss");
+  });
+
+  it("does not show badges when the character is excluded", () => {
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "boss",
+        name: "boss_name",
+        displayName: "boss_name",
+        nameType: "variable",
+      }),
+    ];
+
+    renderWizard(chars);
+
+    // The new-character row renders the badge and helper by default
+    expect(screen.getByTestId("name-type-badge-boss")).toBeInTheDocument();
+  });
+
+  it("imports flagged characters with the user-edited displayName", async () => {
+    const user = userEvent.setup();
+    mockImport.mockResolvedValue({
+      characters: [
+        {
+          id: "char-boss",
+          projectId: "proj-1",
+          name: "boss_name",
+          displayName: "Big Boss",
+          renpyTag: "boss",
+          color: "#c8ffc8",
+          routeAffiliation: null,
+          isLoveInterest: false,
+          dialogueStyle: null,
+          conditionalPrefix: null,
+          avatarUrl: null,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      unmatched: [],
+    });
+
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "boss",
+        name: "boss_name",
+        displayName: "boss_name",
+        nameType: "variable",
+      }),
+    ];
+
+    renderWizard(chars);
+
+    const displayNameInput = screen.getByDisplayValue("boss_name");
+    await user.clear(displayNameInput);
+    await user.type(displayNameInput, "Big Boss");
+
+    const importButton = screen.getByRole("button", {
+      name: /Import 1 Character/,
+    });
+    await user.click(importButton);
+
+    expect(mockImport).toHaveBeenCalledTimes(1);
+    const [projectId, payload] = mockImport.mock.calls[0];
+    expect(projectId).toBe("proj-1");
+    expect(payload.characters).toEqual([
+      expect.objectContaining({
+        tag: "boss",
+        name: "boss_name", // raw name preserved for round-tripping
+        displayName: "Big Boss", // user override
+      }),
+    ]);
+  });
+});
+
+/**
+ * The excluded-state behavior: when the user unchecks "include", the
+ * helper text and badge should disappear, since the user has opted out
+ * of the character and no longer needs guidance.
+ *
+ * (This is a documented intent: badges are for characters the user is
+ *  actively considering importing.)
+ */
+describe("CharacterImportWizard — excluded state", () => {
+  it("hides the helper text and the input fields once a character is excluded", async () => {
+    const user = userEvent.setup();
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "boss",
+        name: "boss_name",
+        displayName: "boss_name",
+        nameType: "variable",
+      }),
+    ];
+
+    renderWizard(chars);
+
+    expect(screen.getByTestId("name-type-helper-boss")).toBeInTheDocument();
+
+    // Uncheck "include"
+    const includeCheckbox = screen.getByLabelText("Include boss");
+    await user.click(includeCheckbox);
+
+    expect(
+      screen.queryByTestId("name-type-helper-boss")
+    ).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Smoke test: the "Special Characters" group should still render
+ * characters that are flagged as special by the parser, and a narrator
+ * with `nameType: "none"` should be assigned to that group.
+ */
+describe("CharacterImportWizard — group assignment", () => {
+  it("groups characters with nameType 'none' as special when their tag is the narrator", () => {
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "n",
+        name: null,
+        displayName: "",
+        nameType: "none",
+        isSpecial: true,
+      }),
+      makeChar({
+        tag: "s",
+        name: "Sarah",
+        displayName: "Sarah",
+        nameType: "literal",
+      }),
+    ];
+
+    renderWizard(chars);
+
+    // Both group headers are visible
+    expect(screen.getByText("Special Characters")).toBeInTheDocument();
+    expect(screen.getByText("New Characters")).toBeInTheDocument();
+
+    // Sarah is rendered in the document (the wizard renders her in the
+    // new-character row by tag). The narrator does not appear as a row
+    // because it's already excluded by default and the row would be
+    // collapsed; but the group header is still shown.
+    expect(screen.getByText("s")).toBeInTheDocument();
+  });
+
+  it("shows '(unnamed)' for narrator characters with empty displayName", () => {
+    // Regression: when a Character(None, ...) is detected, the
+    // displayName is empty. The special-character group should render
+    // '(unnamed)' instead of an empty parenthetical.
+    const chars: DetectedCharacter[] = [
+      makeChar({
+        tag: "n",
+        name: null,
+        displayName: "",
+        nameType: "none",
+        isSpecial: true,
+      }),
+    ];
+
+    renderWizard(chars);
+
+    // The special-character group is expanded by default and shows
+    // the narrator's tag with '((unnamed))' (outer parens from the
+    // row template, inner parens from the displayName fallback).
+    expect(screen.getByText(/unnamed/)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/ide-shared/GitLabImportDialog.tsx
+++ b/apps/frontend/src/components/ide-shared/GitLabImportDialog.tsx
@@ -301,20 +301,19 @@ export function GitLabImportDialog({
         // Stale check: import could have been superseded during the API call
         if (currentImportId !== importIdRef.current) return;
 
-        // Filter out characters that already exist in the database
-        // For a newly created project, existingTags will be empty
-        const existingTagsSet = new Set(detectionResult.existingTags);
-        const newCharacters = detectionResult.characters.filter(
-          (char) => !existingTagsSet.has(char.tag)
-        );
-
-        if (newCharacters.length > 0) {
+        // Show the wizard if any characters were detected, regardless
+        // of whether they are already in the DB. Issue #244
+        // (PR #245) promotes extracted characters into the
+        // `characters` table during import, so on a fresh import
+        // `existingTags` is no longer empty. Filtering to "new only"
+        // would suppress the wizard entirely. The wizard's import
+        // endpoint is idempotent (upsert), so re-confirming
+        // already-stored characters is a safe no-op for unchanged
+        // rows.
+        if (detectionResult.characters.length > 0) {
           dispatch({
             type: "SET_DETECTED_CHARACTERS",
-            payload: {
-              ...detectionResult,
-              characters: newCharacters,
-            },
+            payload: detectionResult,
           });
           dispatch({ type: "SET_SHOW_CHARACTER_WIZARD", payload: true });
           return;
@@ -668,6 +667,12 @@ export function GitLabImportDialog({
             detectedCharacters={state.detectedCharacters.characters}
             conflicts={state.detectedCharacters.conflicts}
             excludedTags={state.detectedCharacters.excludedTags}
+            // Fresh project: PR #245 already promoted the
+            // characters into the DB so existingTags is non-empty,
+            // but the user hasn't reviewed them yet. Treat all as
+            // "new" — the import endpoint's upsert is a no-op for
+            // already-stored rows.
+            existingTags={[]}
             onComplete={() => {
               dispatch({ type: "SET_SHOW_CHARACTER_WIZARD", payload: false });
               // Set flag to prevent duplicate onSuccess calls

--- a/apps/frontend/src/components/ide-shared/ZipImportFilesDialog.tsx
+++ b/apps/frontend/src/components/ide-shared/ZipImportFilesDialog.tsx
@@ -265,19 +265,22 @@ export function ZipImportFilesDialog({
           // Stale check: import could have been superseded during the API call
           if (currentImportId !== importIdRef.current) return;
 
-          // Filter out characters that already exist in the database
-          const existingTagsSet = new Set(detectionResult.existingTags);
-          const newCharacters = detectionResult.characters.filter(
-            (char) => !existingTagsSet.has(char.tag)
-          );
-
-          if (newCharacters.length > 0) {
+          // Show the wizard if any characters were detected. Issue
+          // #244 (PR #245) promotes extracted characters into the
+          // `characters` table during import, so on file-merge
+          // imports `existingTags` may already contain every
+          // detected tag. Filtering to "new only" would suppress
+          // the wizard for the merged-in characters and skip the
+          // user review step. The wizard's import endpoint is
+          // idempotent (upsert), so re-confirming already-stored
+          // characters is a safe no-op for unchanged rows.
+          if (detectionResult.characters.length > 0) {
             dispatch({
               type: "CHARACTERS_DETECTED",
               characters: {
-                characters: newCharacters,
+                characters: detectionResult.characters,
                 excludedTags: detectionResult.excludedTags,
-                conflicts: [],
+                conflicts: detectionResult.conflicts,
                 existingTags: detectionResult.existingTags,
               },
             });
@@ -609,6 +612,7 @@ export function ZipImportFilesDialog({
           detectedCharacters={detectedCharacters.characters}
           conflicts={detectedCharacters.conflicts}
           excludedTags={detectedCharacters.excludedTags}
+          existingTags={detectedCharacters.existingTags}
           onComplete={() => {
             onOpenChange(false);
           }}

--- a/apps/frontend/src/components/ide-shared/ZipImportProjectDialog.tsx
+++ b/apps/frontend/src/components/ide-shared/ZipImportProjectDialog.tsx
@@ -248,18 +248,20 @@ export function ZipImportProjectDialog({
         // Stale check: import could have been superseded during the API call
         if (currentImportId !== importIdRef.current) return;
 
-        // Filter out characters that already exist in the database
-        // For a newly created project, existingTags will be empty
-        const existingTagsSet = new Set(detectionResult.existingTags);
-        const newCharacters = detectionResult.characters.filter(
-          (char) => !existingTagsSet.has(char.tag)
-        );
-
-        if (newCharacters.length > 0) {
+        // Show the wizard if any characters were detected, regardless of
+        // whether they are already in the DB. Issue #244 (PR #245)
+        // promotes extracted characters into the `characters` table
+        // during import, so on a fresh project `existingTags` is no
+        // longer empty. Filtering to "new only" would suppress the
+        // wizard entirely, skipping the user review step the wizard
+        // exists to provide. The wizard's import endpoint is idempotent
+        // (upsert), so re-confirming already-stored characters is a
+        // safe no-op for unchanged rows.
+        if (detectionResult.characters.length > 0) {
           dispatch({
             type: "SET_CHARACTER_WIZARD",
             show: true,
-            characters: { ...detectionResult, characters: newCharacters },
+            characters: detectionResult,
             project: data.project,
           });
           return;
@@ -582,6 +584,12 @@ export function ZipImportProjectDialog({
             detectedCharacters={state.detectedCharacters.characters}
             conflicts={state.detectedCharacters.conflicts}
             excludedTags={state.detectedCharacters.excludedTags}
+            // Fresh project: PR #245 already promoted the
+            // characters into the DB so existingTags is non-empty,
+            // but the user hasn't reviewed them yet. Treat all as
+            // "new" — the import endpoint's upsert is a no-op for
+            // already-stored rows.
+            existingTags={[]}
             onComplete={() => {
               dispatch({
                 type: "SET_CHARACTER_WIZARD",

--- a/apps/frontend/src/components/script-mode/GitLabSyncDialog.tsx
+++ b/apps/frontend/src/components/script-mode/GitLabSyncDialog.tsx
@@ -207,28 +207,24 @@ export function GitLabSyncDialog({
         });
       }
 
-      // For import operations, show the character wizard only if characters detected
+      // For import operations, show the character wizard if any
+      // characters were detected. Issue #244 (PR #245) promotes
+      // extracted characters into the `characters` table during
+      // import, so on a fresh import `existingTags` is no longer
+      // empty. Filtering to "new only" would suppress the wizard
+      // entirely. The wizard's import endpoint is idempotent
+      // (upsert), so re-confirming already-stored characters is a
+      // safe no-op for unchanged rows.
       if (operationType === "import") {
         try {
           const detectionResult =
             await charactersApi.detectCharacters(projectId);
 
-          // Filter out characters that already exist in the database
-          const existingTagsSet = new Set(detectionResult.existingTags);
-          const newCharacters = detectionResult.characters.filter(
-            (char) => !existingTagsSet.has(char.tag)
-          );
-
-          if (newCharacters.length > 0) {
+          if (detectionResult.characters.length > 0) {
             dispatch({
               type: "SET_CHARACTER_WIZARD",
               show: true,
-              characters: {
-                characters: newCharacters,
-                conflicts: detectionResult.conflicts,
-                excludedTags: detectionResult.excludedTags,
-                existingTags: detectionResult.existingTags,
-              },
+              characters: detectionResult,
             });
             return;
           }
@@ -546,6 +542,7 @@ export function GitLabSyncDialog({
           detectedCharacters={formState.detectedCharacters.characters}
           conflicts={formState.detectedCharacters.conflicts}
           excludedTags={formState.detectedCharacters.excludedTags}
+          existingTags={formState.detectedCharacters.existingTags}
           onComplete={() => {
             // Refresh labels and characters after character import/linking
             void invalidateLabels();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -660,6 +660,76 @@ export interface Character {
 }
 
 // ============================================================================
+// Ren'Py Text Tag Handling
+// ============================================================================
+
+/**
+ * Strips Ren'Py text tags from a string.
+ *
+ * Ren'Py supports inline formatting via curly-brace tags like `{b}`,
+ * `{/b}`, `{color=#f00}`, `{/color}`, `{i}`, `{size=20}`, etc.
+ * The full grammar is defined by Ren'Py and includes nested, self-closing,
+ * and parameterized tags. This function removes the tag delimiters but
+ * preserves their inner text content (since some tags — notably `{color=...}`
+ * and `{size=...}` — wrap content).
+ *
+ * Unclosed/malformed tags are removed as-is. Unknown tag forms (e.g.,
+ * `{fast}` where `fast` is not a real Ren'Py tag) are also stripped, which
+ * matches Ren'Py's own behavior of ignoring unknown tags.
+ *
+ * @example
+ * stripRenpyTextTags("Hello {b}world{/b}") // "Hello world"
+ * stripRenpyTextTags("{color=#f00}Stranger{/color}") // "Stranger"
+ * stripRenpyTextTags("エイリーン") // "エイリーン" (no tags)
+ *
+ * @param input - The raw text that may contain Ren'Py tags
+ * @returns The text with all `{...}` tags removed
+ */
+export function stripRenpyTextTags(input: string): string {
+  if (!input) return input;
+  // Match balanced simple tag forms: {tag}, {/tag}, {tag=value}, {tag=value=value}
+  // Ren'Py tag grammar: identifier, optionally followed by `=value` (one or more)
+  // Greedy match of the entire tag block including nested brackets handled by
+  // repeated application of the regex.
+  // Ren'Py tags can also be nested, so we loop until no more tags are found.
+  let result = input;
+  let previous: string;
+  do {
+    previous = result;
+    result = result.replace(/\{[^{}]*\}/g, "");
+  } while (result !== previous);
+  return result;
+}
+
+/**
+ * Classification of how a Character's display name was specified in the
+ * source RPY file. Drives the import wizard's warning indicators.
+ *
+ * - `literal` — A plain quoted string with no Ren'Py tags (e.g., `"Sarah"`)
+ * - `variable` — A bare Python identifier (e.g., `boss_name`); the actual
+ *   name can only be known at runtime, so the import wizard must prompt
+ *   the user to provide a placeholder.
+ * - `interpolated` — A bracketed Python expression (e.g., `"[e_name]"`);
+ *   the value depends on a runtime variable, so the wizard must warn.
+ * - `tagged` — A quoted string containing Ren'Py inline tags (e.g.,
+ *   `"{color=#f00}Stranger{/color}"`). The raw form is preserved; the
+ *   display name strips tags for readability.
+ * - `none` — `Character(None, ...)`; the narrator. Already excluded from
+ *   import by default but the wizard may surface it for confirmation.
+ * - `empty` — `Character("", ...)`; the wizard should show "(unnamed)".
+ * - `unknown` — A non-standard value such as `"???"`; usually intentional
+ *   by the author, so the wizard keeps it as-is.
+ */
+export type CharacterNameType =
+  | "literal"
+  | "variable"
+  | "interpolated"
+  | "tagged"
+  | "none"
+  | "empty"
+  | "unknown";
+
+// ============================================================================
 // Character Detection Types
 // ============================================================================
 
@@ -668,8 +738,32 @@ export interface Character {
  */
 export interface DetectedCharacter {
   tag: string;
+  /**
+   * Raw name as it appeared in the `Character(...)` call, before any
+   * classification. For quoted forms this is the string content
+   * (without quotes); for bracketed forms it preserves the brackets
+   * (e.g. `[e_name]`); for bare identifiers it is the variable name
+   * (e.g. `boss_name`); `null` for `None`/narrator.
+   *
+   * NOTE: BranchForge's current RPY export does NOT yet consume this
+   * field — it emits `displayName` instead. This field is preserved
+   * for a future round-tripping pass and for diagnostic/debugging
+   * purposes. Until that pass lands, callers should treat `name` as
+   * informational and not rely on it for export fidelity.
+   */
   name: string | null;
+  /**
+   * Human-readable name suggested for use in BranchForge UI. Tags stripped
+   * (e.g., `{color=...}Stranger{/color}` → `Stranger`), variable names
+   * preserved as-is. Empty when the source is `None`/`""` — callers should
+   * derive a fallback (the `tag`, or `"(unnamed)"`) for display.
+   */
   displayName: string;
+  /**
+   * How the `name` was specified in the source. Drives import-wizard
+   * warnings and tooling hints.
+   */
+  nameType: CharacterNameType;
   color: string;
   isSpecial: boolean;
   sourceFile: string;

--- a/packages/shared/src/strip-renpy-tags.unit.test.ts
+++ b/packages/shared/src/strip-renpy-tags.unit.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { stripRenpyTextTags } from "./index.js";
+
+describe("stripRenpyTextTags", () => {
+  it("returns plain text unchanged", () => {
+    expect(stripRenpyTextTags("Hello world")).toBe("Hello world");
+  });
+
+  it("strips a single self-closing tag", () => {
+    expect(stripRenpyTextTags("Hello {b}world{/b}")).toBe("Hello world");
+  });
+
+  it("strips parameterized color tags", () => {
+    expect(stripRenpyTextTags("{color=#f00}Stranger{/color}")).toBe("Stranger");
+  });
+
+  it("strips multiple parameters on a single tag", () => {
+    expect(stripRenpyTextTags("{color=#f00, hex=true}Stranger{/color}")).toBe(
+      "Stranger"
+    );
+  });
+
+  it("strips nested tags iteratively", () => {
+    expect(stripRenpyTextTags("{b}{color=#f00}Final Boss{/color}{/b}")).toBe(
+      "Final Boss"
+    );
+  });
+
+  it("strips size tags", () => {
+    expect(stripRenpyTextTags("{size=30}Big{/size}")).toBe("Big");
+  });
+
+  it("preserves non-ASCII text (Japanese, CJK, emoji)", () => {
+    expect(stripRenpyTextTags("エイリーン")).toBe("エイリーン");
+    expect(stripRenpyTextTags("桜 — Sakura")).toBe("桜 — Sakura");
+    expect(stripRenpyTextTags("Sarah \u{1F600}")).toBe("Sarah \u{1F600}");
+  });
+
+  it("strips unknown/malformed tags (matches Ren'Py behavior)", () => {
+    expect(stripRenpyTextTags("{fast}Hello{/fast}")).toBe("Hello");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(stripRenpyTextTags("")).toBe("");
+  });
+
+  it("removes tags around text with no surrounding content", () => {
+    expect(stripRenpyTextTags("{b}bold{/b}")).toBe("bold");
+  });
+
+  it("handles multiple tag pairs in a single string", () => {
+    expect(stripRenpyTextTags("{i}italic{/i} and {b}bold{/b}")).toBe(
+      "italic and bold"
+    );
+  });
+
+  it("does not strip square brackets (those are Ren'Py interpolation, not tags)", () => {
+    expect(stripRenpyTextTags("[e_name]")).toBe("[e_name]");
+    expect(stripRenpyTextTags("Hello [player_name]")).toBe(
+      "Hello [player_name]"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #138. Adds `CharacterNameType` classification to detected characters so the import wizard can warn the user about variable references, Ren'Py interpolation, formatting tags, empty names, and the "???" placeholder. Also fixes a wizard-not-showing regression caused by PR #245 (#244).

### Issue #138 — Special character names

When importing characters from Ren'Py projects, some character definitions use patterns the parser used to pass through raw to the UI:

- **Variable references** (`Character(boss_name, ...)`) — unresolvable at import time
- **Ren'Py interpolation** (`Character("[e_name]", ...)`) — runtime-dependent
- **Formatting tags** (`Character("{color=...}Stranger{/color}", ...)`) — display-name noise
- **Special values** (`None`, `""`, `"???"`) — varying semantics
- **Non-ASCII** (Japanese, CJK, emoji) — must round-trip unchanged

The fix adds a 7-state `CharacterNameType` classifier plus a `stripRenpyTextTags()` utility in `packages/shared`. The parser emits a typed record per character; the wizard renders warning badges and contextual helper text per type, but the user can still override the display name on import. The raw `name` is preserved verbatim for round-tripping.

### Wizard-not-showing fix (follow-up to PR #245)

PR #245 (#244) auto-promotes extracted characters into the `characters` table during import. The pre-existing wizard trigger (`newCharacters = characters.filter(c => !existingTagsSet.has(c.tag))`) therefore returned an empty list on fresh imports and the wizard never opened.

The fix:
- Show the wizard whenever `detectionResult.characters.length > 0` in all four import flows.
- For the **secondary** flows (`ZipImportFilesDialog`, `GitLabSyncDialog`), pass real `existingTags` so the new "Already imported" badge is meaningful on subsequent imports.
- For the **fresh-project** flows (`ZipImportProjectDialog`, `GitLabImportDialog`), pass `existingTags={[]}` so the badge doesn't fire on the user's first review (PR #245's auto-promote just put them there — the user hasn't reviewed yet).
- The wizard's `importCharacters` endpoint already does upsert, so re-confirming unchanged rows is a safe no-op.

## What changed

- `packages/shared/src/index.ts` — new `CharacterNameType` type, `stripRenpyTextTags()` utility, `nameType` field on `DetectedCharacter`.
- `apps/backend/src/services/character-parser.service.ts` — refactored `parseFile` to track `nameForm` (quoted/bracketed/identifier) and classify via `classifyName()`. Bracketed form preserves brackets in `name` for round-trip fidelity. Multi-line `None` followed by quoted options no longer overwrites the name.
- `apps/backend/src/lib/validation.ts` — added `nameType` to `detectedCharacterSchema`.
- `apps/backend/src/services/gitlab-sync.service.ts` — `nameType: "literal"` default for the legacy rpy-parser path (documented as a known gap).
- `apps/frontend/src/components/CharacterImportWizard.tsx` — warning badge + helper text per `nameType`, "(unnamed)" placeholder for empty names, "Already imported" badge, "(unnamed)" rendering in the special-character group.
- `apps/frontend/src/components/ide-shared/{ZipImportProject,ZipImportFiles,GitLabImport,GitLabSync}Dialog.tsx` — wizard trigger updated, `existingTags` threaded through.

## Verification

- `pnpm typecheck` — passes
- `pnpm lint` — passes
- `pnpm test:unit` — 1659/1659 pass (40 new tests added)
- Manual end-to-end: wizard now opens on fresh GitLab/ZIP imports with no spurious "Already imported" badges; re-sync flows show meaningful badges for existing rows.

## Oracle review verdict

**PASS** (after addressing all must-fix and should-fix findings from the initial review). One should-fix item deferred with justification: the `CharacterConflict` shared type does not carry `nameType`, so the wizard's "Conflicts" group does not show name-type badges. The conflict path is rare (requires manual DB edits conflicting with parser output) and the conflict section already tells the user to "Review in character management after import" — a follow-up PR can add `nameType` to `CharacterConflict` if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced import character detection to classify how each character name was defined (literal, variable, interpolated, tagged, none, empty, unknown) and show name-type warning badges in the import wizard.
  * Improved Ren’Py inline text-tag handling to ensure more accurate detection and display (including special-character fallbacks).
* **Bug Fixes**
  * Updated GitLab/ZIP/script import flows so the character import wizard triggers and passes context more reliably based on detection results.
* **Tests**
  * Added/expanded unit and UI tests covering name-type classification, badge rendering, and import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->