### PR TITLE
feat(theme): add switchable dark/light mode toggle

### DIFF
--- a/.changeset/goofy-wolves-love.md
+++ b/.changeset/goofy-wolves-love.md
@@ -1,0 +1,5 @@
+---
+"@branchforge/frontend": minor
+---
+
+Added dark/light mode toggle, tuned color tokens

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
           >
             <Suspense
               fallback={
-                <div className="flex items-center justify-center h-screen text-slate-400">
+                <div className="flex items-center justify-center h-screen text-muted-foreground">
                   Loading…
                 </div>
               }

--- a/apps/frontend/src/components/CharacterList.tsx
+++ b/apps/frontend/src/components/CharacterList.tsx
@@ -89,7 +89,7 @@ export function CharacterList({
                     </span>
                   )}
                   {character.routeAffiliation && (
-                    <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                    <span className="text-xs px-2 py-0.5 rounded-full bg-secondary text-secondary-foreground">
                       {character.routeAffiliation}
                     </span>
                   )}

--- a/apps/frontend/src/components/RouteList.tsx
+++ b/apps/frontend/src/components/RouteList.tsx
@@ -68,7 +68,7 @@ export function RouteList({
                 <span className="text-xs font-mono text-muted-foreground">
                   {route.routeKey}
                 </span>
-                <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                <span className="text-xs px-2 py-0.5 rounded-full bg-secondary text-secondary-foreground">
                   {route.isShared ? "Shared" : "Exclusive"}
                 </span>
               </div>

--- a/apps/frontend/src/components/VariablesList.tsx
+++ b/apps/frontend/src/components/VariablesList.tsx
@@ -74,7 +74,7 @@ export function VariablesList({
                         {variable.key}
                       </span>
                       {variable.category && (
-                        <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                        <span className="text-xs px-2 py-0.5 rounded-full bg-secondary text-secondary-foreground">
                           {variable.category}
                         </span>
                       )}

--- a/apps/frontend/src/components/ide-shared/CollapsibleSection.tsx
+++ b/apps/frontend/src/components/ide-shared/CollapsibleSection.tsx
@@ -17,7 +17,7 @@ export function CollapsibleSection({
   const [isOpen, setIsOpen] = useState(defaultOpen);
   return (
     <div className="border-b border-border/40 last:border-b-0">
-      <div className="w-full flex items-center justify-between px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider hover:bg-muted/30 transition-colors">
+      <div className="w-full flex items-center justify-between px-3 py-2 text-xs font-semibold text-foreground/70 uppercase tracking-wider hover:bg-muted/30 transition-colors">
         <button
           type="button"
           onClick={() => setIsOpen(!isOpen)}

--- a/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
+++ b/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
@@ -441,7 +441,7 @@ function ThemeSwitcher({
                   }}
                   className={`size-7 rounded transition-all ${
                     theme === palette.key
-                      ? "scale-110 ring-2 ring-white ring-offset-2 ring-offset-card"
+                      ? "scale-110 ring-2 ring-foreground/30 ring-offset-2 ring-offset-background"
                       : "opacity-60 hover:opacity-100 hover:scale-105"
                   }`}
                   style={{ background: palette.color }}
@@ -466,7 +466,7 @@ function ThemeSwitcher({
             onClick={() => setTheme(palette.key)}
             className={`flex-1 h-7 rounded transition-all ${
               theme === palette.key
-                ? "scale-110 ring-2 ring-white ring-offset-2 ring-offset-card"
+                ? "scale-110 ring-2 ring-foreground/30 ring-offset-2 ring-offset-background"
                 : "opacity-60 hover:opacity-100 hover:scale-105"
             }`}
             style={{ background: palette.color }}

--- a/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
+++ b/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
@@ -16,6 +16,8 @@ import {
   FolderOpen,
   Network,
   SlidersHorizontal,
+  Sun,
+  Moon,
 } from "lucide-react";
 import type { ThemePalette } from "@/contexts/ThemeContext";
 import type { Project, UpdateProjectBody } from "@/lib/api/projects";
@@ -44,6 +46,8 @@ interface LeftSidebarPropsBase {
   theme: string;
   setTheme: (theme: ThemePalette) => void;
   themePalettes: ThemePaletteOption[];
+  isDarkMode: boolean;
+  onToggleDarkMode: () => void;
   onLogout: () => void;
   projectId?: string;
   projects: Project[];
@@ -503,6 +507,41 @@ function CollapseButton({ isCollapsed, onToggle }: CollapseButtonProps) {
   );
 }
 
+interface DarkModeToggleProps {
+  isDarkMode: boolean;
+  onToggle: () => void;
+  isCollapsed: boolean;
+  showLabel: boolean;
+}
+
+/** Dark/light mode toggle. Icon and label reflect the active mode. */
+function DarkModeToggle({
+  isDarkMode,
+  onToggle,
+  isCollapsed,
+  showLabel,
+}: DarkModeToggleProps) {
+  const label = isDarkMode ? "Dark" : "Light";
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
+      title={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
+      className={`flex items-center ${
+        isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+      } rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors`}
+    >
+      {isDarkMode ? (
+        <Moon className="size-4 flex-shrink-0" />
+      ) : (
+        <Sun className="size-4 flex-shrink-0" />
+      )}
+      {showLabel && <span>{label}</span>}
+    </button>
+  );
+}
+
 interface UserActionsProps {
   isCollapsed: boolean;
   showLabel: boolean;
@@ -556,6 +595,8 @@ export function LeftSidebar(props: LeftSidebarProps) {
     theme,
     setTheme,
     themePalettes,
+    isDarkMode,
+    onToggleDarkMode,
     onLogout,
     projectId,
     projects,
@@ -687,6 +728,13 @@ export function LeftSidebar(props: LeftSidebarProps) {
           <CollapseButton
             isCollapsed={isCollapsed}
             onToggle={handleToggleCollapse}
+          />
+
+          <DarkModeToggle
+            isDarkMode={isDarkMode}
+            onToggle={onToggleDarkMode}
+            isCollapsed={isCollapsed}
+            showLabel={showLabel}
           />
 
           <ThemeSwitcher

--- a/apps/frontend/src/components/script-mode/ScriptReferencePanel.tsx
+++ b/apps/frontend/src/components/script-mode/ScriptReferencePanel.tsx
@@ -36,6 +36,91 @@ const panelVariants = cva(
   }
 );
 
+interface CharacterNodeProps {
+  character: Character;
+  failedAvatars: Record<string, boolean>;
+  onAvatarError: (characterId: string) => void;
+  canEdit: boolean;
+  onEdit?: (characterId: string) => void;
+}
+
+function CharacterNode({
+  character,
+  failedAvatars,
+  onAvatarError,
+  canEdit,
+  onEdit,
+}: CharacterNodeProps) {
+  const inner = (
+    <>
+      {/* Avatar: image or colored circle */}
+      {character.avatarUrl ? (
+        <>
+          <img
+            src={character.avatarUrl}
+            alt={character.displayName}
+            className={cn(
+              "size-8 rounded-full shrink-0 object-cover",
+              failedAvatars[character.id] && "hidden"
+            )}
+            onError={() => onAvatarError(character.id)}
+          />
+          {failedAvatars[character.id] && (
+            <div
+              className="size-8 rounded-full flex items-center justify-center text-white text-[10px] font-medium shrink-0 shadow-sm"
+              style={{
+                backgroundColor: character.color ?? "var(--theme-color)",
+              }}
+            >
+              {character.displayName[0] || "?"}
+            </div>
+          )}
+        </>
+      ) : (
+        <div
+          className="size-8 rounded-full flex items-center justify-center text-white text-[10px] font-medium shrink-0 shadow-sm"
+          style={{
+            backgroundColor: character.color ?? "var(--theme-color)",
+          }}
+        >
+          {character.displayName[0] || "?"}
+        </div>
+      )}
+
+      {/* Name and tag */}
+      <div className="min-w-0 flex-1 ml-1.5">
+        <p className="text-xs font-medium truncate">{character.displayName}</p>
+        <span className="font-mono text-[10px] text-foreground/70 font-semibold">
+          {character.renpyTag}
+        </span>
+      </div>
+
+      {/* Love interest indicator */}
+      {character.isLoveInterest && (
+        <Heart className="size-2.5 text-pink-400 fill-pink-400 shrink-0 opacity-70" />
+      )}
+    </>
+  );
+
+  if (canEdit && onEdit) {
+    return (
+      <button
+        type="button"
+        onClick={() => onEdit(character.id)}
+        className="flex items-center gap-2 p-1.5 rounded-md hover:bg-muted transition-colors group cursor-pointer w-full text-left"
+      >
+        {inner}
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 p-1.5 rounded-md w-full text-left">
+      {inner}
+    </div>
+  );
+}
+
 export function ScriptReferencePanel({
   projectId,
   projectCharacters,
@@ -118,85 +203,18 @@ export function ScriptReferencePanel({
                 </div>
               ) : (
                 <div className="space-y-1">
-                  {sortedCharacters.map((character) => {
-                    const characterNode = (
-                      <>
-                        {/* Avatar: image or colored circle */}
-                        {character.avatarUrl ? (
-                          <>
-                            <img
-                              src={character.avatarUrl}
-                              alt={character.displayName}
-                              className={cn(
-                                "size-8 rounded-full shrink-0 object-cover",
-                                failedAvatars[character.id] && "hidden"
-                              )}
-                              onError={() => {
-                                setFailedAvatars((prev) => ({
-                                  ...prev,
-                                  [character.id]: true,
-                                }));
-                              }}
-                            />
-                            {failedAvatars[character.id] && (
-                              <div
-                                className="size-8 rounded-full flex items-center justify-center text-white text-[10px] font-medium shrink-0 shadow-sm"
-                                style={{
-                                  backgroundColor:
-                                    character.color ?? "var(--theme-color)",
-                                }}
-                              >
-                                {character.displayName[0] || "?"}
-                              </div>
-                            )}
-                          </>
-                        ) : (
-                          <div
-                            className="size-8 rounded-full flex items-center justify-center text-white text-[10px] font-medium shrink-0 shadow-sm"
-                            style={{
-                              backgroundColor:
-                                character.color ?? "var(--theme-color)",
-                            }}
-                          >
-                            {character.displayName[0] || "?"}
-                          </div>
-                        )}
-
-                        {/* Name and tag */}
-                        <div className="min-w-0 flex-1 ml-1.5">
-                          <p className="text-xs font-medium truncate">
-                            {character.displayName}
-                          </p>
-                          <span className="font-mono text-[10px] text-foreground/70 font-semibold">
-                            {character.renpyTag}
-                          </span>
-                        </div>
-
-                        {/* Love interest indicator */}
-                        {character.isLoveInterest && (
-                          <Heart className="size-2.5 text-pink-400 fill-pink-400 shrink-0 opacity-70" />
-                        )}
-                      </>
-                    );
-
-                    return onCharacterEdit ? (
-                      <button
-                        key={character.id}
-                        type="button"
-                        onClick={() => onCharacterEdit(character.id)}
-                        className="flex items-center gap-2 p-1.5 rounded-md hover:bg-muted transition-colors group cursor-pointer w-full text-left"
-                      >
-                        {characterNode}
-                      </button>
-                    ) : (
-                      <div
-                        key={character.id}
-                        className="flex items-center gap-2 p-1.5 rounded-md w-full text-left"
-                      >
-                        {characterNode}
-                      </div>
-                    );
-                  })}
+                  {sortedCharacters.map((character) => (
+                    <CharacterNode
+                      key={character.id}
+                      character={character}
+                      failedAvatars={failedAvatars}
+                      onAvatarError={(id) => {
+                        setFailedAvatars((prev) => ({ ...prev, [id]: true }));
+                      }}
+                      canEdit={!!onCharacterEdit}
+                      onEdit={onCharacterEdit}
+                    />
+                  ))}
                 </div>
               )}
             </CollapsibleSection>

--- a/apps/frontend/src/components/script-mode/ScriptReferencePanel.tsx
+++ b/apps/frontend/src/components/script-mode/ScriptReferencePanel.tsx
@@ -25,7 +25,7 @@ interface ScriptReferencePanelProps {
 }
 
 const panelVariants = cva(
-  "min-h-0 shrink-0 rounded-lg border border-border bg-card/50 overflow-hidden mt-3 transition-all duration-300 ease-out",
+  "min-h-0 shrink-0 rounded-lg border border-border bg-panel-tinted overflow-hidden mt-3 transition-all duration-300 ease-out",
   {
     variants: {
       collapsed: {

--- a/apps/frontend/src/components/ui/logo.tsx
+++ b/apps/frontend/src/components/ui/logo.tsx
@@ -23,7 +23,7 @@ export function Logo({
       className={`font-display tracking-wide leading-tight pb-2 ${className} ${sizeClasses[size]}`}
       style={{
         background:
-          "linear-gradient(135deg, var(--theme-color) 0%, white 50%, var(--theme-color) 100%)",
+          "linear-gradient(135deg, var(--theme-color) 0%, var(--logo-gradient-mid) 50%, var(--theme-color) 100%)",
         WebkitBackgroundClip: "text",
         WebkitTextFillColor: "transparent",
         backgroundClip: "text",

--- a/apps/frontend/src/components/write-mode/DialogueLine.tsx
+++ b/apps/frontend/src/components/write-mode/DialogueLine.tsx
@@ -789,7 +789,7 @@ export const DialogueLine = memo(function DialogueLine({
                   ? "Dialogue..."
                   : "Narration..."
             }
-            className={`min-h-[2.5rem] w-full p-0 pr-7 resize-none overflow-hidden bg-transparent border-0 outline-none focus-visible:outline-none focus-visible:ring-0 font-light tracking-normal leading-8 placeholder:text-muted-foreground/50 ${
+            className={`min-h-[2.5rem] w-full p-0 pr-7 resize-none overflow-hidden bg-transparent border-0 outline-none focus-visible:outline-none focus-visible:ring-0 font-light tracking-normal leading-8 placeholder:text-muted-foreground/70 ${
               isFocused
                 ? "opacity-100 pointer-events-auto"
                 : "opacity-0 pointer-events-none"
@@ -859,7 +859,7 @@ export const DialogueLine = memo(function DialogueLine({
       {/* Destination indicator for CHOICE entries — placed below the text row */}
       {isChoice && choiceTargetName && (
         <span
-          className={`text-xs text-muted-foreground/50 flex items-center gap-1 ${
+          className={`text-xs text-muted-foreground/70 flex items-center gap-1 ${
             isStacked ? "" : "ml-[172px]"
           }`}
         >

--- a/apps/frontend/src/components/write-mode/LabelPropertiesPanel.tsx
+++ b/apps/frontend/src/components/write-mode/LabelPropertiesPanel.tsx
@@ -16,7 +16,7 @@ import {
 import { FormattedCondition } from "@/components/write-mode/FormattedCondition";
 
 const panelVariants = cva(
-  "min-h-0 shrink-0 rounded-lg border border-border bg-card/50 overflow-hidden mt-3 transition-all duration-300 ease-out",
+  "min-h-0 shrink-0 rounded-lg border border-border bg-panel-tinted overflow-hidden mt-3 transition-all duration-300 ease-out",
   {
     variants: {
       collapsed: {

--- a/apps/frontend/src/components/write-mode/LabelPropertiesPanel.tsx
+++ b/apps/frontend/src/components/write-mode/LabelPropertiesPanel.tsx
@@ -33,6 +33,72 @@ const STATUS_COLORS = {
   DRAFT: "var(--theme-draft-color)",
 } as const;
 
+interface OutgoingJumpItemProps {
+  jump: {
+    targetLabelId: string;
+    targetLabelName: string;
+    jumpType: "MENU_CHOICE" | "AUTOMATIC";
+    choiceText: string;
+    conditionFlags?: string[];
+    effects?: Record<string, number>;
+  };
+  statByKey: Map<string, Stat>;
+  index: number;
+}
+
+function OutgoingJumpItem({ jump, statByKey, index }: OutgoingJumpItemProps) {
+  return (
+    <div
+      key={`${jump.targetLabelId}-${jump.choiceText}-${index}`}
+      className="p-2 rounded-lg bg-muted/30 border border-border/50 text-xs"
+    >
+      <div className="font-medium text-foreground truncate">
+        {jump.targetLabelName}
+      </div>
+      <div className="flex items-center gap-2 mt-1 text-muted-foreground">
+        {jump.jumpType === "MENU_CHOICE" ? (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-600">
+            Choice
+          </span>
+        ) : (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-green-500/10 text-green-600">
+            Auto
+          </span>
+        )}
+        <span className="truncate flex-1">{jump.choiceText}</span>
+      </div>
+      {jump.conditionFlags && jump.conditionFlags.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {jump.conditionFlags.map((flag) => (
+            <span
+              key={flag}
+              className="inline-flex items-center px-1.5 py-0.5 rounded bg-muted/80 border border-border/50 font-mono text-muted-foreground"
+            >
+              {flag}
+            </span>
+          ))}
+        </div>
+      )}
+      {jump.effects && Object.keys(jump.effects).length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {Object.entries(jump.effects).map(([statKey, value]) => {
+            const stat = statByKey.get(statKey);
+            return (
+              <span
+                key={statKey}
+                className="inline-flex items-center px-1.5 py-0.5 rounded bg-muted/80 border border-border/50 font-mono text-muted-foreground"
+              >
+                {stat?.name ?? statKey} {value > 0 ? "+" : ""}
+                {value}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 interface LabelPropertiesPanelProps {
   activeLabel: LabelDetail | undefined;
   characters: Character[];
@@ -423,61 +489,12 @@ export function LabelPropertiesPanel({
                   ) : (
                     <div className="space-y-2">
                       {outgoingJumps.map((jump, i) => (
-                        <div
+                        <OutgoingJumpItem
                           key={`${jump.targetLabelId}-${jump.choiceText}-${i}`}
-                          className="p-2 rounded-lg bg-muted/30 border border-border/50 text-xs"
-                        >
-                          <div className="font-medium text-foreground truncate">
-                            {jump.targetLabelName}
-                          </div>
-                          <div className="flex items-center gap-2 mt-1 text-muted-foreground">
-                            {jump.jumpType === "MENU_CHOICE" ? (
-                              <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-600">
-                                Choice
-                              </span>
-                            ) : (
-                              <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-green-500/10 text-green-600">
-                                Auto
-                              </span>
-                            )}
-                            <span className="truncate flex-1">
-                              {jump.choiceText}
-                            </span>
-                          </div>
-                          {jump.conditionFlags &&
-                            jump.conditionFlags.length > 0 && (
-                              <div className="mt-1.5 flex flex-wrap gap-1">
-                                {jump.conditionFlags.map((flag) => (
-                                  <span
-                                    key={flag}
-                                    className="inline-flex items-center px-1.5 py-0.5 rounded bg-muted/80 border border-border/50 font-mono text-muted-foreground"
-                                  >
-                                    {flag}
-                                  </span>
-                                ))}
-                              </div>
-                            )}
-                          {jump.effects &&
-                            Object.keys(jump.effects).length > 0 && (
-                              <div className="mt-1.5 flex flex-wrap gap-1">
-                                {Object.entries(jump.effects).map(
-                                  ([statKey, value]) => {
-                                    const stat = statByKey.get(statKey);
-                                    return (
-                                      <span
-                                        key={statKey}
-                                        className="inline-flex items-center px-1.5 py-0.5 rounded bg-muted/80 border border-border/50 font-mono text-muted-foreground"
-                                      >
-                                        {stat?.name ?? statKey}{" "}
-                                        {value > 0 ? "+" : ""}
-                                        {value}
-                                      </span>
-                                    );
-                                  }
-                                )}
-                              </div>
-                            )}
-                        </div>
+                          jump={jump}
+                          statByKey={statByKey}
+                          index={i}
+                        />
                       ))}
                     </div>
                   )}

--- a/apps/frontend/src/components/write-mode/RenderedLine.tsx
+++ b/apps/frontend/src/components/write-mode/RenderedLine.tsx
@@ -143,7 +143,7 @@ function renderTokens(tokens: RenpyToken[]): React.ReactNode[] {
             key={key}
             style={{
               ...computeStyle(stack),
-              color: "hsl(var(--muted-foreground))",
+              color: "var(--variable)",
             }}
             title={`Variable: ${t.name}`}
             data-raw-start={rawStart}

--- a/apps/frontend/src/components/write-mode/RenderedLine.tsx
+++ b/apps/frontend/src/components/write-mode/RenderedLine.tsx
@@ -136,8 +136,9 @@ function renderTokens(tokens: RenpyToken[]): React.ReactNode[] {
 
       case "interpolation":
         // Visible — variable references are content, not formatting.
-        // Uses the theme's --muted-foreground color (darker than the body
-        // text) so it reads as a subdued reference rather than syntax noise.
+        // Rendered with var(--variable), a theme token for variable-name
+        // coloring (distinct from body text), so references are visually
+        // identifiable without being overly loud.
         nodes.push(
           <span
             key={key}

--- a/apps/frontend/src/components/write-mode/__tests__/RenderedLine.test.tsx
+++ b/apps/frontend/src/components/write-mode/__tests__/RenderedLine.test.tsx
@@ -162,16 +162,14 @@ describe("RenderedLine", () => {
   });
 
   describe("interpolation (visible)", () => {
-    it("renders [name] with muted foreground color", () => {
+    it("renders [name] with the variable color token", () => {
       const { container } = renderTokens("Hello [name]!");
       expect(container.textContent).toBe("Hello [name]!");
       const spans = getSpans(container);
       const interp = spans.find((s) => s.textContent === "[name]");
-      // Uses the design-system --muted-foreground token so it reads as
-      // a subdued reference (darker than body text) and adapts to the
-      // active theme. Assert on the token name rather than a literal
-      // value so the test doesn't break when the palette changes.
-      expect(interp?.style.color).toContain("--muted-foreground");
+      // Uses the design-system --variable token so it reads as a syntax
+      // reference and adapts to the active palette + light/dark mode.
+      expect(interp?.style.color).toBe("var(--variable)");
     });
 
     it("interpolation inside formatting tags inherits style", () => {

--- a/apps/frontend/src/contexts/ThemeContext.tsx
+++ b/apps/frontend/src/contexts/ThemeContext.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useMemo, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { ThemeContext, type ThemePalette, type ThemeColors } from "./useTheme";
-import { useLocalStorage } from "@/hooks/useLocalStorage";
+import {
+  useLocalStorage,
+  useLocalStorageBoolean,
+} from "@/hooks/useLocalStorage";
 import { useUserSettings } from "@/hooks/useUserSettings";
 import { isValidTheme } from "@branchforge/shared";
 
@@ -28,6 +31,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       validate: isValidTheme,
     }
   );
+
+  // Dark/light mode preference. Defaults to dark (true) for existing users so
+  // current behavior is unchanged. Stored separately from the color palette.
+  const [isDarkMode, setIsDarkMode] = useLocalStorageBoolean("dark-mode", true);
 
   const { settings, updateProfile } = useUserSettings();
 
@@ -75,6 +82,24 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     root.style.setProperty("--theme-final-color", STATUS_COLORS.final);
   }, [theme, colors]);
 
+  // Apply dark/light mode. `.dark` activates Tailwind `dark:` utilities and the
+  // `:root` dark CSS variables; `.light` swaps in the light CSS variables.
+  // Exactly one class is present at a time.
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle("dark", isDarkMode);
+    root.classList.toggle("light", !isDarkMode);
+  }, [isDarkMode]);
+
+  const setDarkMode = useCallback(
+    (dark: boolean) => setIsDarkMode(dark),
+    [setIsDarkMode]
+  );
+  const toggleDarkMode = useCallback(
+    () => setIsDarkMode((prev) => !prev),
+    [setIsDarkMode]
+  );
+
   const contextValue = useMemo(
     () => ({
       theme,
@@ -83,8 +108,19 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
         updateProfile({ theme: newTheme }, { silent: true }).catch(() => {});
       },
       colors,
+      isDarkMode,
+      setDarkMode,
+      toggleDarkMode,
     }),
-    [theme, setLocalThemeState, updateProfile, colors]
+    [
+      theme,
+      setLocalThemeState,
+      updateProfile,
+      colors,
+      isDarkMode,
+      setDarkMode,
+      toggleDarkMode,
+    ]
   );
 
   return (

--- a/apps/frontend/src/contexts/ThemeContext.tsx
+++ b/apps/frontend/src/contexts/ThemeContext.tsx
@@ -91,6 +91,28 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     root.classList.toggle("light", !isDarkMode);
   }, [isDarkMode]);
 
+  // Palette-tinted surfaces for light mode. In light mode we layer a subtle
+  // theme-color wash over card backgrounds so the chrome feels branded (matching
+  // dark mode's tinted atmosphere) instead of flat white. In dark mode these
+  // are transparent so behavior is unchanged.
+  useEffect(() => {
+    const root = document.documentElement;
+    const rgb = hexToRgb(colors.primary);
+    if (!isDarkMode && rgb) {
+      root.style.setProperty(
+        "--surface-tint",
+        `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.04)`
+      );
+      root.style.setProperty(
+        "--surface-tint-strong",
+        `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.08)`
+      );
+    } else {
+      root.style.setProperty("--surface-tint", "transparent");
+      root.style.setProperty("--surface-tint-strong", "transparent");
+    }
+  }, [theme, colors, isDarkMode]);
+
   const setDarkMode = useCallback(
     (dark: boolean) => setIsDarkMode(dark),
     [setIsDarkMode]

--- a/apps/frontend/src/contexts/ThemeContext.tsx
+++ b/apps/frontend/src/contexts/ThemeContext.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  type ReactNode,
+} from "react";
 import { ThemeContext, type ThemePalette, type ThemeColors } from "./useTheme";
 import {
   useLocalStorage,
@@ -84,8 +90,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   // Apply dark/light mode. `.dark` activates Tailwind `dark:` utilities and the
   // `:root` dark CSS variables; `.light` swaps in the light CSS variables.
-  // Exactly one class is present at a time.
-  useEffect(() => {
+  // Exactly one class is present at a time. useLayoutEffect avoids a one-frame
+  // dark flash for returning light-mode users before `.light` is applied.
+  useLayoutEffect(() => {
     const root = document.documentElement;
     root.classList.toggle("dark", isDarkMode);
     root.classList.toggle("light", !isDarkMode);

--- a/apps/frontend/src/contexts/ToastContext.tsx
+++ b/apps/frontend/src/contexts/ToastContext.tsx
@@ -4,8 +4,10 @@ import {
   useState,
   useCallback,
   useMemo,
+  useEffect,
   ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 
 type ToastVariant = "default" | "success" | "destructive";
 
@@ -24,6 +26,49 @@ interface ToastContextType {
 }
 
 const ToastContext = createContext<ToastContextType | null>(null);
+
+function getToastPortalContainer(): HTMLElement {
+  // Native `<dialog showModal>` content lives in the browser top layer, so
+  // fixed-position toasts on `document.body` render behind the backdrop blur.
+  // Portal into the topmost open dialog (last in document order) when one
+  // is open, matching the tooltip/select fix.
+  const dialogs = document.querySelectorAll("dialog[open]");
+  const topmost = dialogs[dialogs.length - 1];
+  if (topmost instanceof HTMLElement) return topmost;
+  return document.body;
+}
+
+function useToastPortalContainer(): HTMLElement | null {
+  const [container, setContainer] = useState<HTMLElement | null>(() =>
+    typeof document !== "undefined" ? getToastPortalContainer() : null
+  );
+
+  useEffect(() => {
+    const update = () => {
+      if (typeof document === "undefined") return;
+      setContainer(getToastPortalContainer());
+    };
+
+    update();
+
+    const observer = new MutationObserver(update);
+    observer.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["open"],
+    });
+
+    document.addEventListener("close", update, true);
+
+    return () => {
+      observer.disconnect();
+      document.removeEventListener("close", update, true);
+    };
+  }, []);
+
+  return container;
+}
 
 export function useToast() {
   const context = use(ToastContext);
@@ -112,7 +157,11 @@ function getToastClasses(variant: ToastVariant): string {
 }
 
 function ToastContainer({ toasts, onRemove }: ToastContainerProps) {
-  return (
+  const portalContainer = useToastPortalContainer();
+
+  if (!portalContainer) return null;
+
+  return createPortal(
     <div
       data-testid="toast-container"
       className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 pointer-events-none"
@@ -147,6 +196,7 @@ function ToastContainer({ toasts, onRemove }: ToastContainerProps) {
           </div>
         </div>
       ))}
-    </div>
+    </div>,
+    portalContainer
   );
 }

--- a/apps/frontend/src/contexts/ToastContext.tsx
+++ b/apps/frontend/src/contexts/ToastContext.tsx
@@ -39,9 +39,7 @@ function getToastPortalContainer(): HTMLElement {
 }
 
 function useToastPortalContainer(): HTMLElement | null {
-  const [container, setContainer] = useState<HTMLElement | null>(() =>
-    typeof document !== "undefined" ? getToastPortalContainer() : null
-  );
+  const [container, setContainer] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
     const update = () => {
@@ -51,10 +49,30 @@ function useToastPortalContainer(): HTMLElement | null {
 
     update();
 
-    const observer = new MutationObserver(update);
-    observer.observe(document.body, {
+    // Only react to dialog-relevant mutations: new / removed dialog
+    // elements as direct body children, and open-attribute toggles on
+    // any dialog in the subtree (showModal / close).
+    const childListObserver = new MutationObserver((mutations) => {
+      const relevant = mutations.some(
+        (m) =>
+          Array.from(m.addedNodes).some(
+            (n) => n instanceof HTMLDialogElement
+          ) ||
+          Array.from(m.removedNodes).some((n) => n instanceof HTMLDialogElement)
+      );
+      if (relevant) update();
+    });
+    childListObserver.observe(document.body, { childList: true });
+
+    const attrObserver = new MutationObserver((mutations) => {
+      const relevant = mutations.some(
+        (m) =>
+          m.target instanceof HTMLDialogElement && m.attributeName === "open"
+      );
+      if (relevant) update();
+    });
+    attrObserver.observe(document.body, {
       subtree: true,
-      childList: true,
       attributes: true,
       attributeFilter: ["open"],
     });
@@ -62,7 +80,8 @@ function useToastPortalContainer(): HTMLElement | null {
     document.addEventListener("close", update, true);
 
     return () => {
-      observer.disconnect();
+      childListObserver.disconnect();
+      attrObserver.disconnect();
       document.removeEventListener("close", update, true);
     };
   }, []);

--- a/apps/frontend/src/contexts/ToastContext.tsx
+++ b/apps/frontend/src/contexts/ToastContext.tsx
@@ -103,11 +103,11 @@ interface ToastContainerProps {
 function getToastClasses(variant: ToastVariant): string {
   switch (variant) {
     case "success":
-      return "border-green-500/30 bg-green-50/80 dark:bg-green-900/30 dark:border-green-500/50";
+      return "border-[var(--toast-success-border)] bg-[var(--toast-success-bg)]";
     case "destructive":
-      return "border-red-500/30 bg-red-50/80 dark:bg-red-900/30 dark:border-red-500/50";
+      return "border-[var(--toast-destructive-border)] bg-[var(--toast-destructive-bg)]";
     default:
-      return "border-blue-500/30 bg-blue-50/80 dark:bg-blue-900/30 dark:border-blue-500/50";
+      return "border-[var(--toast-info-border)] bg-[var(--toast-info-bg)]";
   }
 }
 

--- a/apps/frontend/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/ThemeContext.test.tsx
@@ -67,6 +67,8 @@ describe("ThemeContext", () => {
     document.documentElement.style.removeProperty("--theme-color-rgb");
     document.documentElement.style.removeProperty("--theme-border");
     document.documentElement.style.removeProperty("--theme-border-subtle");
+    document.documentElement.style.removeProperty("--surface-tint");
+    document.documentElement.style.removeProperty("--surface-tint-strong");
   };
 
   const removeModeClasses = () => {
@@ -493,6 +495,74 @@ describe("ThemeContext", () => {
       const el = document.querySelector("[data-theme='forest']");
       expect(el).toBeInTheDocument();
       expect(el).toHaveAttribute("data-dark", "false");
+    });
+
+    it("should set transparent surface tints in dark mode", () => {
+      render(
+        <ThemeProvider>
+          <DarkModeTestComponent />
+        </ThemeProvider>,
+        { wrapper: createWrapper() }
+      );
+
+      expect(
+        document.documentElement.style.getPropertyValue("--surface-tint")
+      ).toBe("transparent");
+      expect(
+        document.documentElement.style.getPropertyValue("--surface-tint-strong")
+      ).toBe("transparent");
+    });
+
+    it("should set palette-tinted surface vars in light mode", async () => {
+      render(
+        <ThemeProvider>
+          <DarkModeTestComponent />
+        </ThemeProvider>,
+        { wrapper: createWrapper() }
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Set Light" }));
+
+      await waitFor(() => {
+        const tint =
+          document.documentElement.style.getPropertyValue("--surface-tint");
+        // Should be an rgba value using the periwinkle theme color (not transparent)
+        expect(tint).toContain("rgba(");
+        expect(tint).not.toBe("transparent");
+      });
+
+      const tintStrong = document.documentElement.style.getPropertyValue(
+        "--surface-tint-strong"
+      );
+      expect(tintStrong).toContain("rgba(");
+      expect(tintStrong).not.toBe("transparent");
+    });
+
+    it("should clear surface tints when switching back to dark mode", async () => {
+      localStorage.setItem("branchforge:dark-mode", "false");
+
+      render(
+        <ThemeProvider>
+          <DarkModeTestComponent />
+        </ThemeProvider>,
+        { wrapper: createWrapper() }
+      );
+
+      // Starts in light mode — tint is set
+      await waitFor(() => {
+        expect(
+          document.documentElement.style.getPropertyValue("--surface-tint")
+        ).not.toBe("transparent");
+      });
+
+      // Switch to dark
+      fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
+
+      await waitFor(() => {
+        expect(
+          document.documentElement.style.getPropertyValue("--surface-tint")
+        ).toBe("transparent");
+      });
     });
   });
 });

--- a/apps/frontend/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/ThemeContext.test.tsx
@@ -69,16 +69,22 @@ describe("ThemeContext", () => {
     document.documentElement.style.removeProperty("--theme-border-subtle");
   };
 
+  const removeModeClasses = () => {
+    document.documentElement.classList.remove("dark", "light");
+  };
+
   beforeEach(() => {
     localStorage.clear();
     // Clear CSS custom properties
     removeCSSProperties();
+    removeModeClasses();
   });
 
   afterEach(() => {
     localStorage.clear();
     // Clear CSS custom properties
     removeCSSProperties();
+    removeModeClasses();
   });
 
   // Helper component to test the hook
@@ -356,6 +362,137 @@ describe("ThemeContext", () => {
       }).toThrow("useTheme must be used within ThemeProvider");
 
       consoleError.mockRestore();
+    });
+  });
+
+  describe("Dark/Light Mode", () => {
+    function DarkModeTestComponent() {
+      const { isDarkMode, toggleDarkMode, setDarkMode } = useTheme();
+      return (
+        <div data-testid="mode" data-dark={String(isDarkMode)}>
+          <button onClick={toggleDarkMode}>Toggle</button>
+          <button onClick={() => setDarkMode(false)}>Set Light</button>
+        </div>
+      );
+    }
+
+    it("should default to dark mode", () => {
+      render(
+        <ThemeProvider>
+          <DarkModeTestComponent />
+        </ThemeProvider>,
+        { wrapper: createWrapper() }
+      );
+
+      expect(screen.getByTestId("mode")).toHaveAttribute("data-dark", "true");
+    });
+
+    it("should apply .dark class to <html> and not .light by default", () => {
+      render(
+        <ThemeProvider>
+          <DarkModeTestComponent />
+        </ThemeProvider>,
+        { wrapper: createWrapper() }
+      );
+
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+      expect(document.documentElement.classList.contains("light")).toBe(false);
+    });
+
+    it("should apply .light class and remove .dark when switching to light", async () => {
+      render(
+        <ThemeProvider>
+          <DarkModeTestComponent />
+        </ThemeProvider>,
+        { wrapper: createWrapper() }
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Set Light" }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("mode")).toHaveAttribute(
+          "data-dark",
+          "false"
+        );
+      });
+
+      expect(document.documentElement.classList.contains("light")).toBe(true);
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+    });
+
+    it("should toggle between dark and light", async () => {
+      render(
+        <ThemeProvider>
+          <DarkModeTestComponent />
+        </ThemeProvider>,
+        { wrapper: createWrapper() }
+      );
+
+      expect(screen.getByTestId("mode")).toHaveAttribute("data-dark", "true");
+
+      fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
+      await waitFor(() => {
+        expect(screen.getByTestId("mode")).toHaveAttribute(
+          "data-dark",
+          "false"
+        );
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
+      await waitFor(() => {
+        expect(screen.getByTestId("mode")).toHaveAttribute("data-dark", "true");
+      });
+    });
+
+    it("should persist dark/light preference to localStorage", async () => {
+      render(
+        <ThemeProvider>
+          <DarkModeTestComponent />
+        </ThemeProvider>,
+        { wrapper: createWrapper() }
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Set Light" }));
+
+      await waitFor(() => {
+        expect(localStorage.getItem("branchforge:dark-mode")).toBe("false");
+      });
+    });
+
+    it("should load saved light preference from localStorage", () => {
+      localStorage.setItem("branchforge:dark-mode", "false");
+
+      render(
+        <ThemeProvider>
+          <DarkModeTestComponent />
+        </ThemeProvider>,
+        { wrapper: createWrapper() }
+      );
+
+      expect(screen.getByTestId("mode")).toHaveAttribute("data-dark", "false");
+      expect(document.documentElement.classList.contains("light")).toBe(true);
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+    });
+
+    it("should keep dark/light mode independent of the color palette", async () => {
+      localStorage.setItem("branchforge:theme", "forest");
+      localStorage.setItem("branchforge:dark-mode", "false");
+
+      function CombinedComponent() {
+        const { theme, isDarkMode } = useTheme();
+        return <div data-theme={theme} data-dark={String(isDarkMode)} />;
+      }
+
+      render(
+        <ThemeProvider>
+          <CombinedComponent />
+        </ThemeProvider>,
+        { wrapper: createWrapper() }
+      );
+
+      const el = document.querySelector("[data-theme='forest']");
+      expect(el).toBeInTheDocument();
+      expect(el).toHaveAttribute("data-dark", "false");
     });
   });
 });

--- a/apps/frontend/src/contexts/__tests__/ToastContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/ToastContext.test.tsx
@@ -388,7 +388,11 @@ describe("ToastContext", () => {
         const { success } = useToast();
 
         return (
-          <dialog open data-testid="settings-dialog">
+          <dialog
+            open
+            aria-label="Settings dialog"
+            data-testid="settings-dialog"
+          >
             <button onClick={() => success("Saved", "Settings saved")}>
               Save settings
             </button>

--- a/apps/frontend/src/contexts/__tests__/ToastContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/ToastContext.test.tsx
@@ -382,5 +382,31 @@ describe("ToastContext", () => {
       expect(toastTexts[1]).toHaveTextContent("Error message");
       expect(toastTexts[2]).toHaveTextContent("Info message");
     });
+
+    it("should portal toasts into the topmost open dialog", () => {
+      function DialogToastTest() {
+        const { success } = useToast();
+
+        return (
+          <dialog open data-testid="settings-dialog">
+            <button onClick={() => success("Saved", "Settings saved")}>
+              Save settings
+            </button>
+          </dialog>
+        );
+      }
+
+      render(
+        <ToastProvider>
+          <DialogToastTest />
+        </ToastProvider>
+      );
+
+      fireEvent.click(screen.getByText("Save settings"));
+
+      const toastContainer = screen.getByTestId("toast-container");
+      const dialog = screen.getByTestId("settings-dialog");
+      expect(dialog).toContainElement(toastContainer);
+    });
   });
 });

--- a/apps/frontend/src/contexts/useTheme.ts
+++ b/apps/frontend/src/contexts/useTheme.ts
@@ -12,6 +12,10 @@ interface ThemeContextType {
   theme: ThemePalette;
   setTheme: (theme: ThemePalette) => void;
   colors: ThemeColors;
+  /** Whether dark mode is active. Independent of the color palette. */
+  isDarkMode: boolean;
+  setDarkMode: (dark: boolean) => void;
+  toggleDarkMode: () => void;
 }
 
 export const ThemeContext = createContext<ThemeContextType | undefined>(

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -38,18 +38,21 @@
     /* Prose editor defaults */
     --prose-editor-font-family: var(--font-sans);
 
+    /* Logo gradient midpoint — white in dark mode, black in light mode */
+    --logo-gradient-mid: white;
+
     /* Ren'Py syntax highlighting colors (dark theme) */
-    --keyword: hsl(280, 70%, 65%);
-    --string: hsl(150, 60%, 60%);
-    --comment: hsl(0, 0%, 45%);
-    --number: hsl(180, 80%, 60%);
-    --variable: hsl(190, 50%, 65%);
-    --atom: hsl(30, 80%, 60%);
-    --property: hsl(200, 50%, 65%);
-    --operator: hsl(0, 0%, 75%);
-    --punctuation: hsl(0, 0%, 65%);
-    --config-keyword: hsl(258, 60%, 60%);
-    --audio-keyword: hsl(200, 70%, 60%);
+    --keyword: var(--keyword-dark, hsl(280, 70%, 65%));
+    --string: var(--string-dark, hsl(150, 60%, 60%));
+    --comment: var(--comment-dark, hsl(0, 0%, 45%));
+    --number: var(--number-dark, hsl(180, 80%, 60%));
+    --variable: var(--variable-dark, hsl(190, 50%, 65%));
+    --atom: var(--atom-dark, hsl(30, 80%, 60%));
+    --property: var(--property-dark, hsl(200, 50%, 65%));
+    --operator: var(--operator-dark, hsl(0, 0%, 75%));
+    --punctuation: var(--punctuation-dark, hsl(0, 0%, 65%));
+    --config-keyword: var(--config-keyword-dark, hsl(258, 60%, 60%));
+    --audio-keyword: var(--audio-keyword-dark, hsl(200, 70%, 60%));
 
     /* Toast tints - dark mode (subtle tint + colored border per variant) */
     --toast-success-bg: hsl(142 71% 45% / 0.14);
@@ -61,40 +64,44 @@
   }
 
   .light {
-    /* Light theme */
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
+    /* Light theme — warm neutral off-whites with subtle blue tint for depth.
+       Surfaces are not flat white; muted-foreground is dark enough for WCAG AA
+       on these tinted backgrounds. Mirrors dark mode's tinted structure. */
+    --background: 220 20% 97%;
+    --foreground: 222 47% 11%;
+    --card: 220 25% 99%;
+    --card-foreground: 222 47% 11%;
+    --popover: 220 25% 99%;
+    --popover-foreground: 222 47% 11%;
+    --primary: 222 47% 11%;
     --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
+    --secondary: 220 16% 92%;
+    --secondary-foreground: 222 47% 11%;
+    --muted: 220 15% 93%;
+    --muted-foreground: 220 10% 38%;
+    --accent: 220 30% 94%;
+    --accent-foreground: 222 47% 11%;
+    --destructive: 0 84% 60%;
     --destructive-foreground: 210 40% 98%;
     --destructive-muted: 0 75% 45%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --border: 214 20% 88%;
+    --input: 214 20% 88%;
+    --ring: 222 47% 11%;
+
+    --logo-gradient-mid: black;
 
     /* Ren'Py syntax highlighting colors (light theme - dynamic from palette) */
-    --keyword: var(--keyword-light, hsl(280, 60%, 45%));
-    --string: var(--string-light, hsl(150, 70%, 35%));
-    --comment: var(--comment-light, hsl(220, 10%, 45%));
-    --number: var(--number-light, hsl(180, 70%, 35%));
-    --variable: var(--variable-light, hsl(190, 60%, 40%));
-    --atom: var(--atom-light, hsl(30, 70%, 40%));
-    --property: var(--property-light, hsl(200, 60%, 45%));
-    --operator: var(--operator-light, hsl(0, 0%, 30%));
-    --punctuation: var(--punctuation-light, hsl(0, 0%, 40%));
-    --config-keyword: var(--config-keyword-light, hsl(180, 60%, 35%));
-    --audio-keyword: var(--audio-keyword-light, hsl(200, 70%, 40%));
+    --keyword: var(--keyword-light, hsl(280, 65%, 28%));
+    --string: var(--string-light, hsl(150, 75%, 27%));
+    --comment: var(--comment-light, hsl(220, 12%, 38%));
+    --number: var(--number-light, hsl(180, 75%, 26%));
+    --variable: var(--variable-light, hsl(190, 65%, 28%));
+    --atom: var(--atom-light, hsl(30, 75%, 28%));
+    --property: var(--property-light, hsl(200, 65%, 28%));
+    --operator: var(--operator-light, hsl(0, 0%, 28%));
+    --punctuation: var(--punctuation-light, hsl(0, 0%, 32%));
+    --config-keyword: var(--config-keyword-light, hsl(180, 65%, 26%));
+    --audio-keyword: var(--audio-keyword-light, hsl(200, 75%, 28%));
 
     /* Toast tints - light mode (darker hues for good contrast on white) */
     --toast-success-bg: hsl(142 71% 35% / 0.12);
@@ -458,6 +465,33 @@
   .cm-editor .cm-panel.cm-search .-search-row-secondary input[name="replace"] {
     flex: 1 1 100%;
     max-width: none;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   Light-mode CodeMirror overrides
+   The base theme in renpy-theme.ts is tuned for dark backgrounds. These rules
+   raise gutter/active-line contrast and switch the active-line tint to the
+   theme accent so light mode matches dark mode's branded highlight rhythm.
+   ------------------------------------------------------------------------- */
+.light .cm-gutters {
+  color: hsl(var(--muted-foreground) / 0.65);
+}
+
+.light .cm-activeLine {
+  background-color: rgba(var(--theme-color-rgb), 0.06);
+}
+
+/* Surface tint utilities — layer a subtle theme-color wash over the card
+   background. --surface-tint is set to transparent in dark mode by
+   ThemeContext, so these are no-ops there. */
+@layer utilities {
+  .bg-panel-tinted {
+    background-color: hsl(var(--card));
+    background-image: linear-gradient(
+      var(--surface-tint, transparent),
+      var(--surface-tint, transparent)
+    );
   }
 }
 

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -50,6 +50,14 @@
     --punctuation: hsl(0, 0%, 65%);
     --config-keyword: hsl(258, 60%, 60%);
     --audio-keyword: hsl(200, 70%, 60%);
+
+    /* Toast tints - dark mode (subtle tint + colored border per variant) */
+    --toast-success-bg: hsl(142 71% 45% / 0.14);
+    --toast-success-border: hsl(142 71% 45% / 0.45);
+    --toast-destructive-bg: hsl(0 72% 51% / 0.14);
+    --toast-destructive-border: hsl(0 72% 51% / 0.45);
+    --toast-info-bg: hsl(217 91% 60% / 0.14);
+    --toast-info-border: hsl(217 91% 60% / 0.45);
   }
 
   .light {
@@ -87,6 +95,14 @@
     --punctuation: var(--punctuation-light, hsl(0, 0%, 40%));
     --config-keyword: var(--config-keyword-light, hsl(180, 60%, 35%));
     --audio-keyword: var(--audio-keyword-light, hsl(200, 70%, 40%));
+
+    /* Toast tints - light mode (darker hues for good contrast on white) */
+    --toast-success-bg: hsl(142 71% 35% / 0.12);
+    --toast-success-border: hsl(142 71% 35% / 0.4);
+    --toast-destructive-bg: hsl(0 74% 40% / 0.12);
+    --toast-destructive-border: hsl(0 74% 40% / 0.4);
+    --toast-info-bg: hsl(217 91% 45% / 0.12);
+    --toast-info-border: hsl(217 91% 45% / 0.4);
   }
 }
 
@@ -102,6 +118,15 @@
       transparent 0
     );
     background-size: 24px 24px;
+  }
+
+  /* Light mode uses dark dots so the texture stays visible on white */
+  .light body {
+    background-image: radial-gradient(
+      circle at 1px 1px,
+      rgba(0, 0, 0, 0.04) 2px,
+      transparent 0
+    );
   }
 
   /* Custom scrollbar styles */

--- a/apps/frontend/src/lib/codemirror/__tests__/palettes.unit.test.ts
+++ b/apps/frontend/src/lib/codemirror/__tests__/palettes.unit.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  deriveLightColor,
+  parseHSL,
+  PALETTES,
+  applyPalette,
+} from "../palettes";
+
+/**
+ * Helper to extract lightness from an hsl string
+ */
+function extractLightness(hslString: string): number {
+  return parseHSL(hslString).l;
+}
+
+/**
+ * Helper to extract saturation from an hsl string
+ */
+function extractSaturation(hslString: string): number {
+  return parseHSL(hslString).s;
+}
+
+describe("parseHSL", () => {
+  it('parses "hsl(150, 53%, 49%)" -> {h:150, s:53, l:49}', () => {
+    const result = parseHSL("hsl(150, 53%, 49%)");
+    expect(result).toEqual({ h: 150, s: 53, l: 49 });
+  });
+
+  it('parses "hsl(0, 0%, 82%)" -> {h:0, s:0, l:82}', () => {
+    const result = parseHSL("hsl(0, 0%, 82%)");
+    expect(result).toEqual({ h: 0, s: 0, l: 82 });
+  });
+
+  it('parses "hsl(225, 85%, 66%)" -> {h:225, s:85, l:66}', () => {
+    const result = parseHSL("hsl(225, 85%, 66%)");
+    expect(result).toEqual({ h: 225, s: 85, l: 66 });
+  });
+
+  it('parses "hsl(140, 60%, 92%)" -> {h:140, s:60, l:92}', () => {
+    const result = parseHSL("hsl(140, 60%, 92%)");
+    expect(result).toEqual({ h: 140, s: 60, l: 92 });
+  });
+
+  it("returns fallback {h:0, s:0, l:50} for invalid format", () => {
+    const result = parseHSL("invalid");
+    expect(result).toEqual({ h: 0, s: 0, l: 50 });
+  });
+});
+
+describe("deriveLightColor three tiers", () => {
+  describe("Tier 1: High lightness (> 70)", () => {
+    it("high lightness grey: hsl(0, 0%, 82%) -> lightness in [22,32], saturation stays 0", () => {
+      const result = deriveLightColor("hsl(0, 0%, 82%)");
+      const l = extractLightness(result);
+      const s = extractSaturation(result);
+
+      expect(l).toBeGreaterThanOrEqual(22);
+      expect(l).toBeLessThanOrEqual(32);
+      expect(s).toBe(0);
+    });
+
+    it("high lightness with hue: hsl(140, 60%, 92%) -> lightness <= 32, saturation > original (boosted)", () => {
+      const result = deriveLightColor("hsl(140, 60%, 92%)");
+      const l = extractLightness(result);
+      const s = extractSaturation(result);
+
+      expect(l).toBeLessThanOrEqual(32);
+      expect(s).toBeGreaterThan(60); // boosted from 60
+      expect(s).toBeLessThanOrEqual(100);
+    });
+
+    it("high lightness pale atom: hsl(240, 33%, 95%) -> lightness in [22,32], saturation boosted", () => {
+      const result = deriveLightColor("hsl(240, 33%, 95%)");
+      const l = extractLightness(result);
+      const s = extractSaturation(result);
+
+      expect(l).toBeGreaterThanOrEqual(22);
+      expect(l).toBeLessThanOrEqual(32);
+      expect(s).toBeGreaterThan(33); // boosted from 33
+      expect(s).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe("Tier 2: Medium lightness (50-70)", () => {
+    it("medium tone: hsl(225, 85%, 66%) -> resulting lightness = 28", () => {
+      const result = deriveLightColor("hsl(225, 85%, 66%)");
+      const l = extractLightness(result);
+
+      expect(l).toBe(28); // 66 - 38 = 28
+    });
+
+    it("medium tone with low saturation: hsl(210, 11%, 65%) -> saturation boosted", () => {
+      const result = deriveLightColor("hsl(210, 11%, 65%)");
+      const l = extractLightness(result);
+      const s = extractSaturation(result);
+
+      expect(l).toBe(27); // 65 - 38 = 27
+      expect(s).toBe(26); // 11 + 15 = 26 (boosted because s < 70)
+    });
+
+    it("medium tone with high saturation: hsl(150, 73%, 63%) -> saturation unchanged", () => {
+      const result = deriveLightColor("hsl(150, 73%, 63%)");
+      const l = extractLightness(result);
+      const s = extractSaturation(result);
+
+      expect(l).toBe(25); // 63 - 38 = 25
+      expect(s).toBe(73); // unchanged because s >= 70
+    });
+  });
+
+  describe("Tier 3: Low lightness (<= 50)", () => {
+    it("low lightness: hsl(150, 53%, 49%) -> resulting lightness = 32", () => {
+      const result = deriveLightColor("hsl(150, 53%, 49%)");
+      const l = extractLightness(result);
+
+      expect(l).toBe(32); // 49 - 15 = 34, clamped to 32
+    });
+
+    it("very low lightness: hsl(150, 53%, 20%) -> lightness = 22 (clamped to min)", () => {
+      const result = deriveLightColor("hsl(150, 53%, 20%)");
+      const l = extractLightness(result);
+
+      expect(l).toBe(22); // 20 - 15 = 5, clamped to 22
+    });
+
+    it("borderline low lightness: hsl(0, 0%, 50%) -> resulting lightness = 32", () => {
+      const result = deriveLightColor("hsl(0, 0%, 50%)");
+      const l = extractLightness(result);
+
+      expect(l).toBe(32); // 50 - 15 = 35, clamped to 32
+    });
+  });
+});
+
+describe("App Theme palette coverage", () => {
+  const appThemePalettes = PALETTES.filter((p) => p.group === "App Themes");
+
+  it("derives all App Theme colors to readable lightness (22-32)", () => {
+    for (const palette of appThemePalettes) {
+      for (const color of Object.values(palette.colors)) {
+        const derived = deriveLightColor(color);
+        const l = extractLightness(derived);
+
+        expect(l).toBeGreaterThanOrEqual(22);
+        expect(l).toBeLessThanOrEqual(32);
+      }
+    }
+  });
+
+  it("derives string tokens to lightness 22-32", () => {
+    for (const palette of appThemePalettes) {
+      const derived = deriveLightColor(palette.colors.string);
+      const l = extractLightness(derived);
+
+      expect(l).toBeGreaterThanOrEqual(22);
+      expect(l).toBeLessThanOrEqual(32);
+    }
+  });
+
+  it("derives atom tokens to lightness 22-32", () => {
+    for (const palette of appThemePalettes) {
+      const derived = deriveLightColor(palette.colors.atom);
+      const l = extractLightness(derived);
+
+      expect(l).toBeGreaterThanOrEqual(22);
+      expect(l).toBeLessThanOrEqual(32);
+    }
+  });
+
+  it("preserves saturation 0 for grey string tokens", () => {
+    for (const palette of appThemePalettes) {
+      const derived = deriveLightColor(palette.colors.string);
+      const s = extractSaturation(derived);
+
+      // All string tokens in App Themes are hsl(0, 0%, 82%)
+      expect(s).toBe(0);
+    }
+  });
+
+  it("boosts saturation for colored atom tokens (original saturation > 0)", () => {
+    for (const palette of appThemePalettes) {
+      const original = palette.colors.atom;
+      const originalS = extractSaturation(original);
+      const derived = deriveLightColor(original);
+      const derivedS = extractSaturation(derived);
+
+      if (originalS > 0) {
+        // All atom tokens have lightness > 70, so they get saturation boost
+        expect(derivedS).toBeGreaterThan(originalS);
+      }
+    }
+  });
+});
+
+describe("applyPalette", () => {
+  beforeEach(() => {
+    const root = document.documentElement;
+    for (const key of [
+      "keyword",
+      "string",
+      "comment",
+      "number",
+      "variable",
+      "atom",
+      "property",
+      "operator",
+      "punctuation",
+      "config-keyword",
+      "audio-keyword",
+    ]) {
+      root.style.removeProperty(`--${key}`);
+      root.style.removeProperty(`--${key}-dark`);
+      root.style.removeProperty(`--${key}-light`);
+    }
+  });
+
+  it("sets -dark and -light tokens without overriding mode remapping", () => {
+    const palette = PALETTES[0];
+    applyPalette(palette);
+
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue("--keyword")).toBe("");
+    expect(root.style.getPropertyValue("--keyword-dark")).toBe(
+      palette.colors.keyword
+    );
+    expect(root.style.getPropertyValue("--keyword-light")).toBe(
+      deriveLightColor(palette.colors.keyword)
+    );
+    expect(root.style.getPropertyValue("--string-dark")).toBe(
+      palette.colors.string
+    );
+    expect(root.style.getPropertyValue("--string-light")).toBe(
+      deriveLightColor(palette.colors.string)
+    );
+  });
+});

--- a/apps/frontend/src/lib/codemirror/palettes.ts
+++ b/apps/frontend/src/lib/codemirror/palettes.ts
@@ -213,7 +213,11 @@ export const PALETTES: SyntaxPalette[] = [
  * Parse an HSL string into components
  * Supports both "hsl(h, s%, l%)" and "hsl(h s% l%)" formats
  */
-function parseHSL(hslString: string): { h: number; s: number; l: number } {
+export function parseHSL(hslString: string): {
+  h: number;
+  s: number;
+  l: number;
+} {
   const match = hslString.match(
     /hsl\((\d+(?:\.\d+)?)\s*[,]\s*(\d+(?:\.\d+)?)%\s*[,]\s*(\d+(?:\.\d+)?)%\)/
   );
@@ -239,20 +243,34 @@ function parseHSL(hslString: string): { h: number; s: number; l: number } {
 }
 
 /**
- * Derive a light theme color from a dark theme HSL color
- * Light themes need darker colors for contrast on light backgrounds
+ * Derive a light theme color from a dark theme HSL color.
+ * Light backgrounds need darker, more saturated tokens to match the
+ * visual punch of syntax colors on a dark editor surface.
  */
-function deriveLightColor(hslString: string): string {
+export function deriveLightColor(hslString: string): string {
   const { h, s, l } = parseHSL(hslString);
 
-  // For light theme: reduce lightness significantly for contrast
-  // Adjust saturation based on original saturation to maintain color character
-  const newL = Math.max(25, l - 25); // Reduce lightness by ~25%, min 25%
+  let newL: number;
   let newS = s;
 
-  // Increase saturation slightly for low-lightness colors to prevent washing out
-  if (newL < 40 && s < 60) {
-    newS = Math.min(100, s + 10);
+  if (l > 70) {
+    // "Light-on-dark" tokens (string, atom, pale numbers).
+    newL = Math.max(22, Math.min(32, l - 55));
+    if (s > 0) {
+      newS = Math.min(100, s + 25);
+    }
+  } else if (l > 50) {
+    // Medium tones — darken aggressively for legibility on off-white.
+    newL = Math.max(22, l - 38);
+    if (s < 70) {
+      newS = Math.min(100, s + 15);
+    }
+  } else {
+    // Already dark — nudge into the same readable band as other tokens.
+    newL = Math.max(22, Math.min(32, l - 15));
+    if (s > 0 && s < 70) {
+      newS = Math.min(100, s + 10);
+    }
   }
 
   return `hsl(${h}, ${newS}%, ${newL}%)`;
@@ -271,9 +289,10 @@ export function applyPalette(palette: SyntaxPalette): void {
 
   Object.entries(palette.colors).forEach(([key, value]) => {
     const cssKey = keyMap[key] || key;
-    // Set dark theme color (used by default)
-    root.style.setProperty(`--${cssKey}`, value);
-    // Set light theme variant (derived from dark)
+    // Set mode-specific tokens; index.css maps --keyword etc. to the
+    // appropriate variant so inline styles never override .light remapping.
+    root.style.removeProperty(`--${cssKey}`);
+    root.style.setProperty(`--${cssKey}-dark`, value);
     root.style.setProperty(`--${cssKey}-light`, deriveLightColor(value));
   });
 }

--- a/apps/frontend/src/lib/codemirror/renpy-theme.ts
+++ b/apps/frontend/src/lib/codemirror/renpy-theme.ts
@@ -59,7 +59,7 @@ export const renPyBaseTheme = EditorView.theme({
   // Line numbers
   ".cm-gutters": {
     backgroundColor: "transparent",
-    color: "hsl(var(--muted-foreground) / 0.4)",
+    color: "hsl(var(--muted-foreground) / 0.55)",
     border: "none",
   },
   ".cm-lineNumbers .cm-gutterElement": {
@@ -89,12 +89,13 @@ export const renPyBaseTheme = EditorView.theme({
     backgroundColor:
       "rgba(var(--theme-color-rgb, 61, 74, 194), 0.38) !important",
   },
-  // Cursor
+  // Cursor — use var(--theme-color) directly: ThemeContext sets it to a hex
+  // value at runtime, so wrapping in hsl() would produce an invalid color.
   ".cm-cursor": {
-    borderLeftColor: "hsl(var(--theme-color))",
+    borderLeftColor: "var(--theme-color)",
   },
   "&.cm-focused .cm-cursor": {
-    borderLeftColor: "hsl(var(--theme-color))",
+    borderLeftColor: "var(--theme-color)",
   },
   // Matching brackets
   ".cm-matchingBracket, .cm-nonmatchingBracket": {
@@ -203,8 +204,8 @@ export const renPyBaseTheme = EditorView.theme({
     fontWeight: "600",
     fontFamily: "'Fira Code', monospace",
     letterSpacing: "0.06em",
-    color: "hsl(var(--muted-foreground) / 0.7)",
-    backgroundColor: "hsl(var(--muted) / 0.35)",
+    color: "hsl(var(--muted-foreground))",
+    backgroundColor: "rgba(var(--theme-color-rgb, 61, 74, 194), 0.08)",
     border: "1px solid rgba(var(--theme-color-rgb, 61, 74, 194), 0.5)",
     borderRadius: "9999px",
     padding: "1px 8px",

--- a/apps/frontend/src/pages/ide/index.tsx
+++ b/apps/frontend/src/pages/ide/index.tsx
@@ -22,7 +22,7 @@ const ScriptMode = lazy(() =>
 );
 
 export function HomePageIDE() {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, isDarkMode, toggleDarkMode } = useTheme();
   const { logout } = useAuth();
   const navigate = useNavigate();
   const [mode, setMode] = useLocalStorage<"write" | "script">(
@@ -206,6 +206,8 @@ export function HomePageIDE() {
         theme={theme}
         setTheme={setTheme}
         themePalettes={themePalettes}
+        isDarkMode={isDarkMode}
+        onToggleDarkMode={toggleDarkMode}
         onLogout={handleLogout}
         projectId={currentProject?.id}
         projects={projects}

--- a/apps/frontend/src/pages/ide/index.tsx
+++ b/apps/frontend/src/pages/ide/index.tsx
@@ -241,7 +241,7 @@ export function HomePageIDE() {
             key={scriptModeKey}
             fallback={
               <div
-                className="flex flex-col items-center justify-center h-full gap-3 text-slate-400"
+                className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground"
                 role="alert"
                 aria-live="assertive"
                 aria-label="Editor failed to load"
@@ -262,7 +262,7 @@ export function HomePageIDE() {
           >
             <Suspense
               fallback={
-                <div className="flex items-center justify-center h-full text-slate-400">
+                <div className="flex items-center justify-center h-full text-muted-foreground">
                   Loading editor…
                 </div>
               }


### PR DESCRIPTION
Closes #177

## Summary

Adds a dark/light mode toggle to the left sidebar (between the collapse button and the color palette switcher), with persistent preference and full light-mode styling support.

## What changed

- **`ThemeContext` / `useTheme`**: extended with `isDarkMode`, `setDarkMode`, and `toggleDarkMode`. Preference persists to `localStorage` (`branchforge:dark-mode`), stored separately from the color palette. Defaults to dark for existing users so current behavior is unchanged.
- **Class application**: `.dark` / `.light` are toggled on `<html>`. `.dark` activates Tailwind `dark:` utilities **and** keeps the `:root` dark CSS variables; `.light` swaps in the light CSS variables. Exactly one is present at a time.
- **`LeftSidebar`**: new `DarkModeToggle` sub-component (Moon = dark active, Sun = light active; label + tooltip reflect state/action). Wired through the `pages/ide/index.tsx` consumer.
- **Toast colors**: replaced hard-coded `dark:` classes with semantic CSS variables (`--toast-*-bg` / `--toast-*-border`) defined for both dark and light, ensuring good contrast in both modes.
- **Body texture**: light mode now uses dark dots so the radial-gradient texture stays visible on white.

## How it was verified

- `pnpm --filter @branchforge/frontend typecheck` — clean
- `pnpm --filter @branchforge/frontend lint` — 0 errors (2 pre-existing `react-refresh` warnings on untouched exports)
- `pnpm --filter @branchforge/frontend test:unit` — **836 tests pass** (incl. 7 new dark-mode tests in `ThemeContext.test.tsx`)
- `pnpm --filter @branchforge/frontend build` — succeeds; verified the toast CSS variables and compiled arbitrary-value utility classes are present in the bundle.

## Reviewer note (worth a visual check)

Activating `.dark` makes the previously-dead `dark:` Tailwind utilities across ~12 files (import dialogs, conflict review, character wizard, toasts, inline errors) actually apply in dark mode. These all follow the standard `base(light) + dark:(dark)` pattern and were effectively broken before (rendering light-styled alert boxes on dark backgrounds), so this is a net improvement — but a quick visual pass of the import/conflict dialogs in dark mode is the most valuable human check here.

## Out of scope (per issue)

- System preference detection (`prefers-color-scheme`)
- Additional themes beyond dark/light
- Theme transition animations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dark/light mode toggle to the IDE sidebar, with the preference persisted across sessions and independent of the selected theme palette.
* **Bug Fixes**
  * Improved toast styling and ensured toasts render inside the topmost open dialog when present.
  * Refined dark/light visual treatments (selection rings, badges, tinted panels, placeholder/interpolation colors, logo gradient).
* **Tests**
  * Expanded coverage for dark/light mode behavior, dialog-scoped toasts, and CodeMirror palette color derivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->