### PR TITLE
feat: implement world elements management for world bible (#26)

### DIFF
--- a/.changeset/silent-seals-throw.md
+++ b/.changeset/silent-seals-throw.md
@@ -1,7 +1,7 @@
 ---
-"@branchforge/shared": patch
-"@branchforge/frontend": patch
-"@branchforge/backend": patch
+"@branchforge/shared": minor
+"@branchforge/frontend": minor
+"@branchforge/backend": minor
 ---
 
 Added world bible feature for tracking info

--- a/.changeset/silent-seals-throw.md
+++ b/.changeset/silent-seals-throw.md
@@ -1,0 +1,7 @@
+---
+"@branchforge/shared": patch
+"@branchforge/frontend": patch
+"@branchforge/backend": patch
+---
+
+Added world bible feature for tracking info

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -25,6 +25,7 @@ import { zipImportRoutes } from "./routes/zip-import.routes.js";
 import { flowRoutes } from "./routes/flow.routes.js";
 import { exportsRoutes } from "./routes/exports.routes.js";
 import { visualSystemsRoutes } from "./routes/visual-systems.routes.js";
+import { worldElementsRoutes } from "./routes/world-elements.routes.js";
 import { createDrizzleSessionStore } from "./services/session-store.service.js";
 import { setupShutdownHandlers } from "./lib/shutdown.js";
 import { globalErrorHandler } from "./middleware/error-handler.middleware.js";
@@ -163,6 +164,7 @@ await server.register(zipImportRoutes, { prefix: basePath });
 await server.register(flowRoutes, { prefix: basePath });
 await server.register(exportsRoutes, { prefix: basePath });
 await server.register(visualSystemsRoutes, { prefix: basePath });
+await server.register(worldElementsRoutes, { prefix: basePath });
 
 // Register a global preValidation hook that enforces double-submit
 // CSRF protection on every state-changing request. The hook itself

--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -914,6 +914,42 @@ export const characterIdParamsSchema = z.object({
 });
 
 // ============================================================================
+// World Element Validation Schemas
+// ============================================================================
+
+/**
+ * Create world element request validation
+ */
+export const createWorldElementSchema = z
+  .object({
+    name: requiredString(200, "Name is too long"),
+    type: elementTypeSchema,
+    description: optionalString(2000, "Description is too long"),
+    tags: z.array(z.string().max(100)).default([]),
+  })
+  .strict();
+
+/**
+ * Update world element request validation
+ */
+export const updateWorldElementSchema = z
+  .object({
+    name: requiredString(200, "Name is too long").optional(),
+    type: elementTypeSchema.optional(),
+    description: optionalString(2000, "Description is too long"),
+    tags: z.array(z.string().max(100)).optional(),
+  })
+  .strict()
+  .partial();
+
+/**
+ * World element ID params validation
+ */
+export const worldElementIdParamsSchema = z.object({
+  elementId: uuidSchema,
+});
+
+// ============================================================================
 // GitLab Schemas
 // ============================================================================
 
@@ -1259,6 +1295,8 @@ export type CreateRouteConfigInput = z.infer<typeof createRouteConfigSchema>;
 export type UpdateRouteConfigInput = z.infer<typeof updateRouteConfigSchema>;
 export type CreateVariableInput = z.infer<typeof createVariableSchema>;
 export type UpdateVariableInput = z.infer<typeof updateVariableSchema>;
+export type CreateWorldElementInput = z.infer<typeof createWorldElementSchema>;
+export type UpdateWorldElementInput = z.infer<typeof updateWorldElementSchema>;
 // ============================================================================
 // User Settings Schemas
 // ============================================================================

--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -924,8 +924,16 @@ export const createWorldElementSchema = z
   .object({
     name: requiredString(200, "Name is too long"),
     type: elementTypeSchema,
-    description: optionalString(2000, "Description is too long"),
-    tags: z.array(z.string().max(100)).default([]),
+    description: z
+      .string()
+      .max(2000, "Description is too long")
+      .trim()
+      .nullable()
+      .optional(),
+    tags: z
+      .array(z.string().max(100))
+      .max(20, "Maximum 20 tags per element")
+      .default([]),
   })
   .strict();
 
@@ -936,8 +944,16 @@ export const updateWorldElementSchema = z
   .object({
     name: requiredString(200, "Name is too long").optional(),
     type: elementTypeSchema.optional(),
-    description: optionalString(2000, "Description is too long"),
-    tags: z.array(z.string().max(100)).optional(),
+    description: z
+      .string()
+      .max(2000, "Description is too long")
+      .trim()
+      .nullable()
+      .optional(),
+    tags: z
+      .array(z.string().max(100))
+      .max(20, "Maximum 20 tags per element")
+      .optional(),
   })
   .strict()
   .partial();

--- a/apps/backend/src/routes/world-elements.routes.ts
+++ b/apps/backend/src/routes/world-elements.routes.ts
@@ -22,6 +22,7 @@ import {
   validateParams,
 } from "../middleware/validation.middleware.js";
 import { NotFoundError } from "../middleware/error-handler.middleware.js";
+import { checkRateLimit } from "../services/rate-limiter.service.js";
 import {
   createWorldElementSchema,
   updateWorldElementSchema,
@@ -113,6 +114,8 @@ async function createWorldElementHandler(
   const user = request.user!;
   const body = request.body;
 
+  checkRateLimit(`worldElementCreate:${request.ip}`);
+
   const element = await createWorldElement(projectId, user.id, body);
 
   reply.status(201).send({ element } as CreateWorldElementResponse);
@@ -134,6 +137,8 @@ async function updateWorldElementHandler(
   const user = request.user!;
   const body = request.body;
 
+  checkRateLimit(`worldElementUpdate:${request.ip}`);
+
   const element = await updateWorldElement(elementId, user.id, body);
 
   reply.status(200).send({ element } as UpdateWorldElementResponse);
@@ -150,6 +155,8 @@ async function deleteWorldElementHandler(
 ): Promise<void> {
   const { elementId } = request.params;
   const user = request.user!;
+
+  checkRateLimit(`worldElementDelete:${request.ip}`);
 
   await deleteWorldElement(elementId, user.id);
 

--- a/apps/backend/src/routes/world-elements.routes.ts
+++ b/apps/backend/src/routes/world-elements.routes.ts
@@ -1,0 +1,229 @@
+/**
+ * World Elements Routes
+ *
+ * Routes for world element management including listing,
+ * creating, updating, and deleting world elements.
+ */
+
+import type { FastifyInstance } from "fastify";
+import type { FastifyRequest, FastifyReply } from "fastify";
+import { z } from "zod";
+import {
+  listWorldElements,
+  getWorldElement,
+  createWorldElement,
+  updateWorldElement,
+  deleteWorldElement,
+  type PublicWorldElement,
+} from "../services/world-elements.service.js";
+import { authenticate } from "../middleware/auth.middleware.js";
+import {
+  validateBody,
+  validateParams,
+} from "../middleware/validation.middleware.js";
+import { NotFoundError } from "../middleware/error-handler.middleware.js";
+import {
+  createWorldElementSchema,
+  updateWorldElementSchema,
+  worldElementIdParamsSchema,
+  projectIdParamsSchema,
+  type CreateWorldElementInput,
+  type UpdateWorldElementInput,
+} from "../lib/validation.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ListWorldElementsResponse {
+  elements: PublicWorldElement[];
+}
+
+type GetWorldElementParams = z.infer<typeof worldElementIdParamsSchema>;
+
+interface GetWorldElementResponse {
+  element: PublicWorldElement;
+}
+
+type ListByProjectParams = z.infer<typeof projectIdParamsSchema>;
+
+interface CreateWorldElementResponse {
+  element: PublicWorldElement;
+}
+
+interface UpdateWorldElementResponse {
+  element: PublicWorldElement;
+}
+
+// ============================================================================
+// Route Handlers
+// ============================================================================
+
+/**
+ * List all world elements for a project
+ *
+ * GET /projects/:projectId/world-elements
+ */
+async function listWorldElementsHandler(
+  request: FastifyRequest<{ Params: ListByProjectParams }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { projectId } = request.params;
+  const user = request.user!;
+
+  const elements = await listWorldElements(projectId, user.id);
+
+  reply.status(200).send({ elements } as ListWorldElementsResponse);
+}
+
+/**
+ * Get a single world element by ID
+ *
+ * GET /world-elements/:elementId
+ */
+async function getWorldElementHandler(
+  request: FastifyRequest<{ Params: GetWorldElementParams }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { elementId } = request.params;
+  const user = request.user!;
+
+  const element = await getWorldElement(elementId, user.id);
+
+  if (!element) {
+    throw new NotFoundError("World element not found");
+  }
+
+  reply.status(200).send({ element } as GetWorldElementResponse);
+}
+
+/**
+ * Create a new world element for a project
+ *
+ * POST /projects/:projectId/world-elements
+ */
+async function createWorldElementHandler(
+  request: FastifyRequest<{
+    Params: ListByProjectParams;
+    Body: CreateWorldElementInput;
+  }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { projectId } = request.params;
+  const user = request.user!;
+  const body = request.body;
+
+  const element = await createWorldElement(projectId, user.id, body);
+
+  reply.status(201).send({ element } as CreateWorldElementResponse);
+}
+
+/**
+ * Update an existing world element
+ *
+ * PATCH /world-elements/:elementId
+ */
+async function updateWorldElementHandler(
+  request: FastifyRequest<{
+    Params: GetWorldElementParams;
+    Body: UpdateWorldElementInput;
+  }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { elementId } = request.params;
+  const user = request.user!;
+  const body = request.body;
+
+  const element = await updateWorldElement(elementId, user.id, body);
+
+  reply.status(200).send({ element } as UpdateWorldElementResponse);
+}
+
+/**
+ * Delete a world element
+ *
+ * DELETE /world-elements/:elementId
+ */
+async function deleteWorldElementHandler(
+  request: FastifyRequest<{ Params: GetWorldElementParams }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { elementId } = request.params;
+  const user = request.user!;
+
+  await deleteWorldElement(elementId, user.id);
+
+  reply.status(204).send();
+}
+
+// ============================================================================
+// Routes Registration
+// ============================================================================
+
+export async function worldElementsRoutes(
+  fastify: FastifyInstance
+): Promise<void> {
+  // All routes require authentication
+
+  // List world elements for a project
+  fastify.get<{ Params: ListByProjectParams }>(
+    "/projects/:projectId/world-elements",
+    {
+      onRequest: authenticate,
+      preValidation: validateParams(projectIdParamsSchema),
+    },
+    listWorldElementsHandler
+  );
+
+  // Create world element for a project
+  fastify.post<{
+    Params: ListByProjectParams;
+    Body: CreateWorldElementInput;
+  }>(
+    "/projects/:projectId/world-elements",
+    {
+      onRequest: authenticate,
+      preValidation: [
+        validateParams(projectIdParamsSchema),
+        validateBody(createWorldElementSchema),
+      ],
+    },
+    createWorldElementHandler
+  );
+
+  // Get a single world element
+  fastify.get<{ Params: GetWorldElementParams }>(
+    "/world-elements/:elementId",
+    {
+      onRequest: authenticate,
+      preValidation: validateParams(worldElementIdParamsSchema),
+    },
+    getWorldElementHandler
+  );
+
+  // Update a world element
+  fastify.patch<{
+    Params: GetWorldElementParams;
+    Body: UpdateWorldElementInput;
+  }>(
+    "/world-elements/:elementId",
+    {
+      onRequest: authenticate,
+      preValidation: [
+        validateParams(worldElementIdParamsSchema),
+        validateBody(updateWorldElementSchema),
+      ],
+    },
+    updateWorldElementHandler
+  );
+
+  // Delete a world element
+  fastify.delete<{ Params: GetWorldElementParams }>(
+    "/world-elements/:elementId",
+    {
+      onRequest: authenticate,
+      preValidation: validateParams(worldElementIdParamsSchema),
+    },
+    deleteWorldElementHandler
+  );
+}

--- a/apps/backend/src/services/world-elements.service.ts
+++ b/apps/backend/src/services/world-elements.service.ts
@@ -1,0 +1,213 @@
+/**
+ * World Elements Service
+ *
+ * Handles world element CRUD operations for projects.
+ * World elements are world bible entries: locations, items, concepts, events.
+ * Authorization is enforced via requireProjectOwnership from authz.service.
+ */
+
+import { getDb } from "../db/index.js";
+import { worldElements, projects } from "../db/schema/index.js";
+import { eq, and, asc } from "drizzle-orm";
+import type { WorldElement, NewWorldElement } from "../db/schema/index.js";
+import {
+  NotFoundError,
+  ValidationError,
+} from "../middleware/error-handler.middleware.js";
+import { requireProjectOwnership } from "./authz.service.js";
+import type {
+  CreateWorldElementInput,
+  UpdateWorldElementInput,
+} from "../lib/validation.js";
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export interface PublicWorldElement {
+  id: string;
+  projectId: string;
+  name: string;
+  type: "LOCATION" | "ITEM" | "CONCEPT" | "EVENT";
+  description: string | null;
+  tags: string[];
+  createdAt: Date;
+}
+
+// ============================================================================
+// Service Functions
+// ============================================================================
+
+/**
+ * List all world elements for a project
+ */
+export async function listWorldElements(
+  projectId: string,
+  userId: string
+): Promise<PublicWorldElement[]> {
+  await requireProjectOwnership(projectId, userId);
+
+  const db = getDb();
+
+  const result = await db
+    .select()
+    .from(worldElements)
+    .where(eq(worldElements.projectId, projectId))
+    .orderBy(asc(worldElements.type), asc(worldElements.name));
+
+  return result.map(mapToPublicWorldElement);
+}
+
+/**
+ * Get a single world element by ID
+ */
+export async function getWorldElement(
+  elementId: string,
+  userId: string
+): Promise<PublicWorldElement | null> {
+  const db = getDb();
+
+  const result = await db
+    .select({
+      element: worldElements,
+    })
+    .from(worldElements)
+    .innerJoin(projects, eq(worldElements.projectId, projects.id))
+    .where(and(eq(worldElements.id, elementId), eq(projects.userId, userId)))
+    .limit(1);
+
+  if (result.length === 0) {
+    return null;
+  }
+
+  return mapToPublicWorldElement(result[0].element);
+}
+
+/**
+ * Create a new world element
+ */
+export async function createWorldElement(
+  projectId: string,
+  userId: string,
+  body: CreateWorldElementInput
+): Promise<PublicWorldElement> {
+  await requireProjectOwnership(projectId, userId);
+
+  const db = getDb();
+
+  const newElement: NewWorldElement = {
+    projectId,
+    name: body.name,
+    type: body.type,
+    description: body.description ?? null,
+    tags: body.tags ?? [],
+  };
+
+  const result = await db.insert(worldElements).values(newElement).returning();
+
+  if (!result || result.length === 0 || !result[0]) {
+    throw new Error(
+      "Failed to create world element: database insert returned no rows"
+    );
+  }
+
+  return mapToPublicWorldElement(result[0]);
+}
+
+/**
+ * Update an existing world element
+ */
+export async function updateWorldElement(
+  elementId: string,
+  userId: string,
+  body: UpdateWorldElementInput
+): Promise<PublicWorldElement> {
+  const db = getDb();
+
+  // Verify user has access to the element
+  const accessCheck = await db
+    .select({
+      element: worldElements,
+    })
+    .from(worldElements)
+    .innerJoin(projects, eq(worldElements.projectId, projects.id))
+    .where(and(eq(worldElements.id, elementId), eq(projects.userId, userId)))
+    .limit(1);
+
+  if (accessCheck.length === 0) {
+    throw new NotFoundError("World element");
+  }
+
+  // Build update payload with only allowed fields
+  const updateData: Record<string, unknown> = {};
+
+  if (body.name !== undefined) updateData.name = body.name;
+  if (body.type !== undefined) updateData.type = body.type;
+  if (body.description !== undefined) updateData.description = body.description;
+  if (body.tags !== undefined) updateData.tags = body.tags;
+
+  // Guard against empty update payload
+  if (Object.keys(updateData).length === 0) {
+    throw new ValidationError("No valid fields provided for update");
+  }
+
+  // Update the element
+  const result = await db
+    .update(worldElements)
+    .set(updateData)
+    .where(eq(worldElements.id, elementId))
+    .returning();
+
+  if (!result || result.length === 0 || !result[0]) {
+    throw new Error(
+      "Failed to update world element: database update returned no rows"
+    );
+  }
+
+  return mapToPublicWorldElement(result[0]);
+}
+
+/**
+ * Delete a world element
+ */
+export async function deleteWorldElement(
+  elementId: string,
+  userId: string
+): Promise<boolean> {
+  const db = getDb();
+
+  // Verify user has access to the element
+  const accessCheck = await db
+    .select({ id: worldElements.id })
+    .from(worldElements)
+    .innerJoin(projects, eq(worldElements.projectId, projects.id))
+    .where(and(eq(worldElements.id, elementId), eq(projects.userId, userId)))
+    .limit(1);
+
+  if (accessCheck.length === 0) {
+    throw new NotFoundError("World element");
+  }
+
+  const result = await db
+    .delete(worldElements)
+    .where(eq(worldElements.id, elementId))
+    .returning();
+
+  return result.length > 0;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function mapToPublicWorldElement(element: WorldElement): PublicWorldElement {
+  return {
+    id: element.id,
+    projectId: element.projectId,
+    name: element.name,
+    type: element.type,
+    description: element.description,
+    tags: element.tags ?? [],
+    createdAt: element.createdAt,
+  };
+}

--- a/apps/backend/src/services/world-elements.service.ts
+++ b/apps/backend/src/services/world-elements.service.ts
@@ -19,6 +19,7 @@ import type {
   CreateWorldElementInput,
   UpdateWorldElementInput,
 } from "../lib/validation.js";
+import type { WorldElementType } from "@branchforge/shared";
 
 // ============================================================================
 // Public Types
@@ -28,7 +29,7 @@ export interface PublicWorldElement {
   id: string;
   projectId: string;
   name: string;
-  type: "LOCATION" | "ITEM" | "CONCEPT" | "EVENT";
+  type: WorldElementType;
   description: string | null;
   tags: string[];
   createdAt: Date;
@@ -106,9 +107,7 @@ export async function createWorldElement(
   const result = await db.insert(worldElements).values(newElement).returning();
 
   if (!result || result.length === 0 || !result[0]) {
-    throw new Error(
-      "Failed to create world element: database insert returned no rows"
-    );
+    throw new ValidationError("Failed to create world element");
   }
 
   return mapToPublicWorldElement(result[0]);
@@ -159,9 +158,7 @@ export async function updateWorldElement(
     .returning();
 
   if (!result || result.length === 0 || !result[0]) {
-    throw new Error(
-      "Failed to update world element: database update returned no rows"
-    );
+    throw new NotFoundError("World element");
   }
 
   return mapToPublicWorldElement(result[0]);

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -23,6 +23,7 @@ import {
   Users,
   Route as RouteIcon,
   Wand2,
+  BookText,
   X,
 } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
@@ -31,6 +32,7 @@ import { Tabs, TabsList, TabsTrigger, TabsPanel } from "@/components/ui/tabs";
 import { CharacterSettingsContent } from "@/components/CharacterSettingsContent";
 import { RouteSettingsContent } from "@/components/RouteSettingsContent";
 import { VisualSystemFormContent } from "@/components/VisualSystemDialog";
+import { WorldElementsSettingsContent } from "@/components/WorldElementsSettingsContent";
 import { useVisualSystem } from "@/hooks/useVisualSystem";
 import {
   parseGroupPrefixes,
@@ -49,7 +51,7 @@ export interface ProjectSettingsDialogProps {
   defaultTab?: SettingsTab;
 }
 
-export type SettingsTab = "characters" | "routes" | "visual";
+export type SettingsTab = "characters" | "routes" | "visual" | "world";
 
 // ============================================================================
 // Helpers
@@ -59,6 +61,7 @@ const TAB_LABELS: Record<SettingsTab, string> = {
   characters: "Characters",
   routes: "Routes",
   visual: "Visual System",
+  world: "World Bible",
 };
 
 const TAB_ICONS: Record<
@@ -68,9 +71,10 @@ const TAB_ICONS: Record<
   characters: Users,
   routes: RouteIcon,
   visual: Wand2,
+  world: BookText,
 };
 
-const TAB_ORDER: SettingsTab[] = ["characters", "routes", "visual"];
+const TAB_ORDER: SettingsTab[] = ["characters", "routes", "visual", "world"];
 
 // ============================================================================
 // Component
@@ -118,7 +122,8 @@ export function ProjectSettingsDialog({
           <div>
             <h2 className="text-lg font-medium">Project Settings</h2>
             <p className="text-sm text-muted-foreground mt-1">
-              Configure characters, routes, and visual filename generation.
+              Configure characters, routes, visual system, and world bible
+              elements.
             </p>
           </div>
           <button
@@ -162,6 +167,9 @@ export function ProjectSettingsDialog({
             </TabsPanel>
             <TabsPanel value="visual" className="space-y-4">
               <VisualSystemTabContent projectId={projectId} />
+            </TabsPanel>
+            <TabsPanel value="world" className="space-y-4">
+              <WorldElementsSettingsContent projectId={projectId} />
             </TabsPanel>
           </div>
         </Tabs>

--- a/apps/frontend/src/components/WorldElementEditDialog.tsx
+++ b/apps/frontend/src/components/WorldElementEditDialog.tsx
@@ -4,7 +4,7 @@
  * Modal for creating or editing a single world element.
  */
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Loader2, Plus, X } from "lucide-react";
 import {
   Dialog,
@@ -106,15 +106,6 @@ function ElementFormContent({
   });
   const [errors, setErrors] = useState<ElementFormErrors>({});
   const [newTag, setNewTag] = useState("");
-
-  const isEditMode = !!elementId;
-
-  // Close dialog if editing an element that no longer exists
-  useEffect(() => {
-    if (isEditMode && !elements.find((e) => e.id === elementId)) {
-      onClose();
-    }
-  }, [isEditMode, elementId, elements, onClose]);
 
   const handleChange = (
     field: keyof ElementFormState,
@@ -304,14 +295,14 @@ export function WorldElementEditDialog({
       await updateElement(id, {
         name: form.name.trim(),
         type: form.type as WorldElementType,
-        description: form.description.trim() || undefined,
+        description: form.description.trim() || null,
         tags: form.tags,
       });
     } else {
       await createElement({
         name: form.name.trim(),
         type: form.type as WorldElementType,
-        description: form.description.trim() || undefined,
+        description: form.description.trim() || null,
         tags: form.tags,
       });
     }

--- a/apps/frontend/src/components/WorldElementEditDialog.tsx
+++ b/apps/frontend/src/components/WorldElementEditDialog.tsx
@@ -1,0 +1,351 @@
+/**
+ * World Element Edit Dialog
+ *
+ * Modal for creating or editing a single world element.
+ */
+
+import { useState, useEffect } from "react";
+import { Loader2, Plus, X } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, type SelectOption } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useWorldElements } from "@/hooks/useWorldElements";
+import type { WorldElement, WorldElementType } from "@branchforge/shared";
+
+interface WorldElementEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  elementId?: string;
+}
+
+interface ElementFormState {
+  name: string;
+  type: WorldElementType | "";
+  description: string;
+  tags: string[];
+}
+
+interface ElementFormErrors {
+  name?: string;
+  type?: string;
+  description?: string;
+}
+
+const TYPE_OPTIONS: SelectOption<WorldElementType>[] = [
+  { value: "LOCATION", label: "Location" },
+  { value: "ITEM", label: "Item" },
+  { value: "CONCEPT", label: "Concept" },
+  { value: "EVENT", label: "Event" },
+];
+
+const INITIAL_FORM: ElementFormState = {
+  name: "",
+  type: "",
+  description: "",
+  tags: [],
+};
+
+function validateElement(form: ElementFormState): ElementFormErrors {
+  const errors: ElementFormErrors = {};
+
+  if (!form.name.trim()) {
+    errors.name = "Name is required";
+  } else if (form.name.length > 200) {
+    errors.name = "Name is too long (max 200 characters)";
+  }
+
+  if (!form.type) {
+    errors.type = "Type is required";
+  }
+
+  if (form.description && form.description.length > 2000) {
+    errors.description = "Description is too long (max 2000 characters)";
+  }
+
+  return errors;
+}
+
+interface ElementFormContentProps {
+  elementId: string | undefined;
+  elements: WorldElement[];
+  isSaving: boolean;
+  onSave: (
+    elementId: string | undefined,
+    form: ElementFormState
+  ) => Promise<void>;
+  onClose: () => void;
+}
+
+function ElementFormContent({
+  elementId,
+  elements,
+  isSaving,
+  onSave,
+  onClose,
+}: ElementFormContentProps) {
+  const [form, setForm] = useState<ElementFormState>(() => {
+    if (!elementId) return INITIAL_FORM;
+    const element = elements.find((e) => e.id === elementId);
+    if (!element) return INITIAL_FORM;
+    return {
+      name: element.name,
+      type: element.type,
+      description: element.description ?? "",
+      tags: element.tags ?? [],
+    };
+  });
+  const [errors, setErrors] = useState<ElementFormErrors>({});
+  const [newTag, setNewTag] = useState("");
+
+  const isEditMode = !!elementId;
+
+  // Close dialog if editing an element that no longer exists
+  useEffect(() => {
+    if (isEditMode && !elements.find((e) => e.id === elementId)) {
+      onClose();
+    }
+  }, [isEditMode, elementId, elements, onClose]);
+
+  const handleChange = (
+    field: keyof ElementFormState,
+    value: string | string[]
+  ) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setErrors({});
+  };
+
+  const handleAddTag = () => {
+    const trimmed = newTag.trim();
+    if (trimmed && !form.tags.includes(trimmed) && form.tags.length < 20) {
+      handleChange("tags", [...form.tags, trimmed]);
+      setNewTag("");
+    }
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    handleChange(
+      "tags",
+      form.tags.filter((t) => t !== tag)
+    );
+  };
+
+  const handleSave = async () => {
+    const validationErrors = validateElement(form);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    try {
+      await onSave(elementId, form);
+      onClose();
+    } catch {
+      // Error handled by hook toast
+    }
+  };
+
+  return (
+    <div className="space-y-4 mt-4">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <Label htmlFor="element-name" className="text-xs">
+            Name *
+          </Label>
+          <Input
+            id="element-name"
+            type="text"
+            placeholder="Castle Blackthorn"
+            value={form.name}
+            onChange={(event) => handleChange("name", event.target.value)}
+            disabled={isSaving}
+          />
+          {errors.name && (
+            <p className="text-xs text-destructive">{errors.name}</p>
+          )}
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="element-type" className="text-xs">
+            Type *
+          </Label>
+          <Select<WorldElementType>
+            id="element-type"
+            options={TYPE_OPTIONS}
+            value={form.type || undefined}
+            onChange={(value) => handleChange("type", value)}
+            placeholder="Select type"
+            disabled={isSaving}
+          />
+          {errors.type && (
+            <p className="text-xs text-destructive">{errors.type}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor="element-description" className="text-xs">
+          Description
+        </Label>
+        <Textarea
+          id="element-description"
+          placeholder="Describe this world element..."
+          value={form.description}
+          onChange={(event) => handleChange("description", event.target.value)}
+          disabled={isSaving}
+          rows={3}
+          className="resize-none"
+        />
+        {errors.description && (
+          <p className="text-xs text-destructive">{errors.description}</p>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <Label className="text-xs">Tags</Label>
+        <div className="flex gap-2">
+          <Input
+            type="text"
+            placeholder="Add a tag..."
+            value={newTag}
+            onChange={(event) => setNewTag(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                handleAddTag();
+              }
+            }}
+            disabled={isSaving}
+            className="flex-1"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleAddTag}
+            disabled={isSaving || !newTag.trim() || form.tags.length >= 20}
+          >
+            <Plus className="size-4" />
+          </Button>
+        </div>
+        {form.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-2">
+            {form.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-secondary text-secondary-foreground"
+              >
+                {tag}
+                <button
+                  type="button"
+                  onClick={() => handleRemoveTag(tag)}
+                  disabled={isSaving}
+                  className="hover:text-destructive transition-colors"
+                  aria-label={`Remove tag ${tag}`}
+                >
+                  <X className="size-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        <p className="text-xs text-muted-foreground">
+          {form.tags.length}/20 tags. Press Enter to add.
+        </p>
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onClose}
+          disabled={isSaving}
+        >
+          Cancel
+        </Button>
+        <Button type="button" onClick={handleSave} disabled={isSaving}>
+          {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function WorldElementEditDialog({
+  open,
+  onOpenChange,
+  projectId,
+  elementId,
+}: WorldElementEditDialogProps) {
+  const {
+    elements,
+    isLoadingElements,
+    createElement,
+    updateElement,
+    isCreatingElement,
+    isUpdatingElement,
+  } = useWorldElements(projectId);
+
+  const isSaving = isCreatingElement || isUpdatingElement;
+  const isEditMode = !!elementId;
+
+  const handleSave = async (id: string | undefined, form: ElementFormState) => {
+    if (id) {
+      await updateElement(id, {
+        name: form.name.trim(),
+        type: form.type as WorldElementType,
+        description: form.description.trim() || undefined,
+        tags: form.tags,
+      });
+    } else {
+      await createElement({
+        name: form.name.trim(),
+        type: form.type as WorldElementType,
+        description: form.description.trim() || undefined,
+        tags: form.tags,
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl w-full">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditMode ? "Edit World Element" : "Add World Element"}
+          </DialogTitle>
+          <DialogDescription>
+            {isEditMode
+              ? "Update world element details."
+              : "Create a new entry for your world bible."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {isEditMode && isLoadingElements ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="size-6 animate-spin" />
+          </div>
+        ) : (
+          <ElementFormContent
+            key={`${elementId ?? "new"}-${open}`}
+            elementId={elementId}
+            elements={elements}
+            isSaving={isSaving}
+            onSave={handleSave}
+            onClose={() => onOpenChange(false)}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/WorldElementsDialog.tsx
+++ b/apps/frontend/src/components/WorldElementsDialog.tsx
@@ -1,0 +1,26 @@
+import { DialogShell } from "@/components/ui/DialogShell";
+import { WorldElementsSettingsContent } from "@/components/WorldElementsSettingsContent";
+
+interface WorldElementsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+}
+
+export function WorldElementsDialog({
+  open,
+  onOpenChange,
+  projectId,
+}: WorldElementsDialogProps) {
+  return (
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title="World Bible"
+      description="Manage world elements: locations, items, concepts, and events."
+      maxWidth="3xl"
+    >
+      <WorldElementsSettingsContent projectId={projectId} />
+    </DialogShell>
+  );
+}

--- a/apps/frontend/src/components/WorldElementsList.tsx
+++ b/apps/frontend/src/components/WorldElementsList.tsx
@@ -1,0 +1,162 @@
+/**
+ * World Elements List
+ *
+ * Read-only list of world elements grouped by type with edit and delete actions.
+ */
+
+import { useMemo, useState } from "react";
+import { Pencil, Trash2 } from "lucide-react";
+import type { WorldElement, WorldElementType } from "@branchforge/shared";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+
+const TYPE_LABELS: Record<WorldElementType, string> = {
+  LOCATION: "Locations",
+  ITEM: "Items",
+  CONCEPT: "Concepts",
+  EVENT: "Events",
+};
+
+interface WorldElementsListProps {
+  elements: WorldElement[];
+  isSaving: boolean;
+  onEdit: (elementId: string) => void;
+  onDelete: (elementId: string) => void | Promise<void>;
+}
+
+export function WorldElementsList({
+  elements,
+  isSaving,
+  onEdit,
+  onDelete,
+}: WorldElementsListProps) {
+  const [deleteTarget, setDeleteTarget] = useState<WorldElement | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const groupedElements = useMemo(() => {
+    const groups: Record<string, WorldElement[]> = {};
+    for (const element of elements) {
+      const typeLabel = TYPE_LABELS[element.type] ?? element.type;
+      if (!groups[typeLabel]) {
+        groups[typeLabel] = [];
+      }
+      groups[typeLabel].push(element);
+    }
+    return groups;
+  }, [elements]);
+
+  if (elements.length === 0) {
+    return null;
+  }
+
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) return;
+
+    setIsDeleting(true);
+    try {
+      await onDelete(deleteTarget.id);
+      setDeleteTarget(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const typeOrder: WorldElementType[] = [
+    "LOCATION",
+    "ITEM",
+    "CONCEPT",
+    "EVENT",
+  ];
+
+  return (
+    <>
+      <div className="space-y-6">
+        {typeOrder
+          .map(
+            (type) =>
+              [TYPE_LABELS[type], groupedElements[TYPE_LABELS[type]]] as const
+          )
+          .filter(([, items]) => items && items.length > 0)
+          .map(([category, items]) => (
+            <div key={category} className="space-y-3">
+              <h3 className="text-sm font-medium text-muted-foreground">
+                {category}
+              </h3>
+              <div className="space-y-2">
+                {items.map((element) => (
+                  <div
+                    key={element.id}
+                    className="border border-border/30 rounded-md p-4 flex items-start justify-between"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-sm">
+                          {element.name}
+                        </span>
+                      </div>
+                      {element.description && (
+                        <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+                          {element.description}
+                        </p>
+                      )}
+                      {element.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-1 mt-2">
+                          {element.tags.map((tag) => (
+                            <span
+                              key={tag}
+                              className="text-xs px-2 py-0.5 rounded-full bg-secondary text-secondary-foreground"
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0 ml-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onEdit(element.id)}
+                        disabled={isSaving}
+                        aria-label={`Edit ${element.name}`}
+                      >
+                        <Pencil className="size-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setDeleteTarget(element)}
+                        disabled={isSaving}
+                        className="text-destructive hover:text-destructive"
+                        aria-label={`Delete ${element.name}`}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+      </div>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open && !isDeleting) {
+            setDeleteTarget(null);
+          }
+        }}
+        onConfirm={handleConfirmDelete}
+        title="Delete World Element"
+        description={`Are you sure you want to delete ${deleteTarget?.name || "this element"}? This action cannot be undone.`}
+        cancelLabel="Cancel"
+        confirmLabel="Delete Element"
+        isLoading={isDeleting}
+        loadingLabel="Deleting..."
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/components/WorldElementsList.tsx
+++ b/apps/frontend/src/components/WorldElementsList.tsx
@@ -17,6 +17,8 @@ const TYPE_LABELS: Record<WorldElementType, string> = {
   EVENT: "Events",
 };
 
+const TYPE_ORDER: WorldElementType[] = ["LOCATION", "ITEM", "CONCEPT", "EVENT"];
+
 interface WorldElementsListProps {
   elements: WorldElement[];
   isSaving: boolean;
@@ -61,23 +63,31 @@ export function WorldElementsList({
     }
   };
 
-  const typeOrder: WorldElementType[] = [
-    "LOCATION",
-    "ITEM",
-    "CONCEPT",
-    "EVENT",
-  ];
-
   return (
     <>
       <div className="space-y-6">
-        {typeOrder
-          .map(
-            (type) =>
-              [TYPE_LABELS[type], groupedElements[TYPE_LABELS[type]]] as const
-          )
-          .filter(([, items]) => items && items.length > 0)
-          .map(([category, items]) => (
+        {(() => {
+          const renderedCategories = new Set<string>();
+          const groups: Array<[string, WorldElement[]]> = [];
+
+          // Known types first, in defined order
+          for (const type of TYPE_ORDER) {
+            const category = TYPE_LABELS[type];
+            const items = groupedElements[category];
+            if (items && items.length > 0) {
+              groups.push([category, items]);
+              renderedCategories.add(category);
+            }
+          }
+
+          // Unknown types after known ones
+          for (const [category, items] of Object.entries(groupedElements)) {
+            if (!renderedCategories.has(category) && items) {
+              groups.push([category, items]);
+            }
+          }
+
+          return groups.map(([category, items]) => (
             <div key={category} className="space-y-3">
               <h3 className="text-sm font-medium text-muted-foreground">
                 {category}
@@ -139,7 +149,8 @@ export function WorldElementsList({
                 ))}
               </div>
             </div>
-          ))}
+          ));
+        })()}
       </div>
 
       <ConfirmDialog

--- a/apps/frontend/src/components/WorldElementsSettingsContent.tsx
+++ b/apps/frontend/src/components/WorldElementsSettingsContent.tsx
@@ -43,6 +43,9 @@ export function WorldElementsSettingsContent({
   const handleDelete = async (elementId: string) => {
     try {
       await deleteElement(elementId);
+      if (editingElementId === elementId) {
+        setEditingElementId(null);
+      }
     } catch {
       // Error handled by hook toast
     }

--- a/apps/frontend/src/components/WorldElementsSettingsContent.tsx
+++ b/apps/frontend/src/components/WorldElementsSettingsContent.tsx
@@ -1,0 +1,115 @@
+/**
+ * World Elements Settings Content
+ *
+ * Body of the "World Bible" tab. Renders the list of world
+ * elements with add / edit / delete, plus the inner
+ * `WorldElementEditDialog` for the create-or-edit flow. No dialog
+ * chrome here — the parent (`ProjectSettingsDialog` or the
+ * standalone `WorldElementsDialog`) provides that.
+ */
+
+import { useState } from "react";
+import { Loader2, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { InlineMessage } from "@/components/ui/inline-error";
+import { WorldElementsList } from "@/components/WorldElementsList";
+import { WorldElementEditDialog } from "@/components/WorldElementEditDialog";
+import { useWorldElements } from "@/hooks/useWorldElements";
+
+interface WorldElementsSettingsContentProps {
+  projectId: string;
+}
+
+const MODE_NEW = "__new__" as const;
+type EditMode = null | typeof MODE_NEW | string;
+
+export function WorldElementsSettingsContent({
+  projectId,
+}: WorldElementsSettingsContentProps) {
+  const {
+    elements,
+    isLoadingElements,
+    elementsError,
+    isCreatingElement,
+    isUpdatingElement,
+    isDeletingElement,
+    deleteElement,
+  } = useWorldElements(projectId);
+
+  const [editingElementId, setEditingElementId] = useState<EditMode>(null);
+
+  const isSaving = isCreatingElement || isUpdatingElement || isDeletingElement;
+
+  const handleDelete = async (elementId: string) => {
+    try {
+      await deleteElement(elementId);
+    } catch {
+      // Error handled by hook toast
+    }
+  };
+
+  return (
+    <>
+      {isLoadingElements ? (
+        <div className="flex items-center justify-center py-8">
+          <output>
+            <Loader2 className="size-6 animate-spin text-muted-foreground" />
+          </output>
+        </div>
+      ) : elementsError ? (
+        <InlineMessage variant="error">
+          Failed to load world elements
+        </InlineMessage>
+      ) : elements.length === 0 ? (
+        <div className="space-y-4">
+          <div className="p-8 border border-dashed border-border/30 rounded-md text-center">
+            <p className="text-sm text-muted-foreground">
+              No world elements yet. Add your first location, item, concept, or
+              event to build your world bible.
+            </p>
+          </div>
+          <Button
+            type="button"
+            onClick={() => setEditingElementId(MODE_NEW)}
+            disabled={isSaving}
+            className="w-full"
+          >
+            <Plus className="size-4 mr-2" />
+            Add Element
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <Button
+            type="button"
+            onClick={() => setEditingElementId(MODE_NEW)}
+            disabled={isSaving}
+            className="w-full"
+          >
+            <Plus className="size-4 mr-2" />
+            Add Another Element
+          </Button>
+          <WorldElementsList
+            elements={elements}
+            isSaving={isSaving}
+            onEdit={setEditingElementId}
+            onDelete={handleDelete}
+          />
+        </div>
+      )}
+
+      <WorldElementEditDialog
+        open={editingElementId !== null}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setEditingElementId(null);
+        }}
+        projectId={projectId}
+        elementId={
+          editingElementId === MODE_NEW
+            ? undefined
+            : (editingElementId as string | undefined)
+        }
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/components/script-mode/ScriptReferencePanel.tsx
+++ b/apps/frontend/src/components/script-mode/ScriptReferencePanel.tsx
@@ -7,12 +7,15 @@ import {
   Plus,
   Pencil,
   Loader2,
+  BookText,
 } from "lucide-react";
 import { CollapsibleSection } from "@/components/ide-shared/CollapsibleSection";
 import { VariablesDialog } from "./VariablesDialog";
 import { StatManagementDialog } from "./StatManagementDialog";
+import { WorldElementsDialog } from "@/components/WorldElementsDialog";
 import { useVariables } from "@/hooks/useVariables";
 import { useStats } from "@/hooks/useStats";
+import { useWorldElements } from "@/hooks/useWorldElements";
 import { cva } from "class-variance-authority";
 import type { Character } from "@branchforge/shared";
 
@@ -130,6 +133,7 @@ export function ScriptReferencePanel({
 }: ScriptReferencePanelProps) {
   const [variablesDialogOpen, setVariablesDialogOpen] = useState(false);
   const [statsDialogOpen, setStatsDialogOpen] = useState(false);
+  const [worldElementsDialogOpen, setWorldElementsDialogOpen] = useState(false);
   const [failedAvatars, setFailedAvatars] = useState<Record<string, boolean>>(
     {}
   );
@@ -139,6 +143,9 @@ export function ScriptReferencePanel({
     projectId && projectId.trim() ? projectId : ""
   );
   const { stats, isLoadingStats } = useStats(
+    projectId && projectId.trim() ? projectId : ""
+  );
+  const { elements, isLoadingElements } = useWorldElements(
     projectId && projectId.trim() ? projectId : ""
   );
 
@@ -363,6 +370,76 @@ export function ScriptReferencePanel({
                 </div>
               )}
             </CollapsibleSection>
+
+            {/* World Elements — read-only list, edit via dialog */}
+            <CollapsibleSection
+              title="World Bible"
+              defaultOpen={false}
+              headerAction={
+                <button
+                  type="button"
+                  onClick={() => setWorldElementsDialogOpen(true)}
+                  className="p-1 rounded hover:bg-muted/80 transition-colors"
+                  aria-label="Manage world elements"
+                  title="Manage world elements"
+                >
+                  <BookText className="size-3 text-muted-foreground" />
+                </button>
+              }
+            >
+              {isLoadingElements ? (
+                <div className="flex items-center justify-center py-4">
+                  <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                </div>
+              ) : elements.length === 0 ? (
+                <div className="text-center py-3">
+                  <p className="text-xs text-muted-foreground mb-2">
+                    No world elements defined
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setWorldElementsDialogOpen(true)}
+                    className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                  >
+                    <Plus className="size-3" />
+                    Add element
+                  </button>
+                </div>
+              ) : (
+                <div className="space-y-1">
+                  {elements
+                    .toSorted((a, b) =>
+                      a.type !== b.type
+                        ? a.type.localeCompare(b.type)
+                        : a.name.localeCompare(b.name)
+                    )
+                    .map((element) => (
+                      <div
+                        key={element.id}
+                        className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-muted/50 transition-colors"
+                      >
+                        <div className="min-w-0 flex-1">
+                          <span className="text-xs truncate block">
+                            {element.name}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {element.type.charAt(0) +
+                              element.type.slice(1).toLowerCase()}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  <button
+                    type="button"
+                    onClick={() => setWorldElementsDialogOpen(true)}
+                    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors w-full justify-center pt-1"
+                  >
+                    <Plus className="size-3" />
+                    Manage elements
+                  </button>
+                </div>
+              )}
+            </CollapsibleSection>
           </div>
         </div>
       </div>
@@ -376,6 +453,11 @@ export function ScriptReferencePanel({
       <StatManagementDialog
         open={statsDialogOpen}
         onOpenChange={setStatsDialogOpen}
+        projectId={projectId}
+      />
+      <WorldElementsDialog
+        open={worldElementsDialogOpen}
+        onOpenChange={setWorldElementsDialogOpen}
         projectId={projectId}
       />
 

--- a/apps/frontend/src/hooks/useWorldElements.ts
+++ b/apps/frontend/src/hooks/useWorldElements.ts
@@ -1,0 +1,159 @@
+/**
+ * useWorldElements Hook
+ *
+ * Provides world element state and operations using TanStack Query.
+ * World elements are world bible entries: locations, items, concepts, events.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { worldElementsApi } from "@/lib/api/world-elements";
+import { worldElementKeys } from "@/lib/query-keys";
+import { useToast } from "@/contexts/ToastContext";
+import type { WorldElement } from "@branchforge/shared";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface CreateWorldElementInput {
+  name: string;
+  type: "LOCATION" | "ITEM" | "CONCEPT" | "EVENT";
+  description?: string;
+  tags?: string[];
+}
+
+interface UpdateWorldElementInput {
+  name?: string;
+  type?: "LOCATION" | "ITEM" | "CONCEPT" | "EVENT";
+  description?: string;
+  tags?: string[];
+}
+
+export interface UseWorldElementsReturn {
+  // State
+  elements: WorldElement[];
+  isLoadingElements: boolean;
+  elementsError: Error | null;
+
+  // Mutation loading states
+  isCreatingElement: boolean;
+  isUpdatingElement: boolean;
+  isDeletingElement: boolean;
+
+  // Methods
+  refreshElements: () => void;
+  createElement: (input: CreateWorldElementInput) => Promise<WorldElement>;
+  updateElement: (
+    elementId: string,
+    input: UpdateWorldElementInput
+  ) => Promise<WorldElement>;
+  deleteElement: (elementId: string) => Promise<void>;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export function useWorldElements(projectId: string): UseWorldElementsReturn {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  // Query for world elements (only when projectId is provided)
+  const {
+    data: elements = [],
+    isLoading: isLoadingElements,
+    error: elementsError,
+    refetch: refreshElements,
+  } = useQuery({
+    queryKey: worldElementKeys.lists(projectId),
+    queryFn: async () => {
+      return worldElementsApi.listWorldElements(projectId);
+    },
+    enabled: !!projectId,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  // Create element mutation
+  const createElementMutation = useMutation({
+    mutationFn: async (input: CreateWorldElementInput) => {
+      return worldElementsApi.createWorldElement(projectId, input);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: worldElementKeys.lists(projectId),
+      });
+      toast.success("World element created successfully", "Success");
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to create world element: ${error.message}`, "Error");
+    },
+  });
+
+  // Update element mutation
+  const updateElementMutation = useMutation({
+    mutationFn: async ({
+      elementId,
+      input,
+    }: {
+      elementId: string;
+      input: UpdateWorldElementInput;
+    }) => {
+      return worldElementsApi.updateWorldElement(elementId, input);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: worldElementKeys.lists(projectId),
+      });
+      toast.success("World element updated successfully", "Success");
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to update world element: ${error.message}`, "Error");
+    },
+  });
+
+  // Delete element mutation
+  const deleteElementMutation = useMutation({
+    mutationFn: async (elementId: string) => {
+      await worldElementsApi.deleteWorldElement(elementId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: worldElementKeys.lists(projectId),
+      });
+      toast.success("World element deleted successfully", "Success");
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to delete world element: ${error.message}`, "Error");
+    },
+  });
+
+  const createElement = async (
+    input: CreateWorldElementInput
+  ): Promise<WorldElement> => {
+    return createElementMutation.mutateAsync(input);
+  };
+
+  const updateElement = async (
+    elementId: string,
+    input: UpdateWorldElementInput
+  ): Promise<WorldElement> => {
+    return updateElementMutation.mutateAsync({ elementId, input });
+  };
+
+  const deleteElement = async (elementId: string): Promise<void> => {
+    return deleteElementMutation.mutateAsync(elementId);
+  };
+
+  return {
+    elements,
+    isLoadingElements,
+    elementsError: elementsError as Error | null,
+    isCreatingElement: createElementMutation.isPending,
+    isUpdatingElement: updateElementMutation.isPending,
+    isDeletingElement: deleteElementMutation.isPending,
+    refreshElements,
+    createElement,
+    updateElement,
+    deleteElement,
+  };
+}

--- a/apps/frontend/src/hooks/useWorldElements.ts
+++ b/apps/frontend/src/hooks/useWorldElements.ts
@@ -7,6 +7,10 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { worldElementsApi } from "@/lib/api/world-elements";
+import type {
+  CreateWorldElementBody,
+  UpdateWorldElementBody,
+} from "@/lib/api/world-elements";
 import { worldElementKeys } from "@/lib/query-keys";
 import { useToast } from "@/contexts/ToastContext";
 import type { WorldElement } from "@branchforge/shared";
@@ -14,20 +18,6 @@ import type { WorldElement } from "@branchforge/shared";
 // ============================================================================
 // Types
 // ============================================================================
-
-interface CreateWorldElementInput {
-  name: string;
-  type: "LOCATION" | "ITEM" | "CONCEPT" | "EVENT";
-  description?: string;
-  tags?: string[];
-}
-
-interface UpdateWorldElementInput {
-  name?: string;
-  type?: "LOCATION" | "ITEM" | "CONCEPT" | "EVENT";
-  description?: string;
-  tags?: string[];
-}
 
 export interface UseWorldElementsReturn {
   // State
@@ -42,10 +32,10 @@ export interface UseWorldElementsReturn {
 
   // Methods
   refreshElements: () => void;
-  createElement: (input: CreateWorldElementInput) => Promise<WorldElement>;
+  createElement: (input: CreateWorldElementBody) => Promise<WorldElement>;
   updateElement: (
     elementId: string,
-    input: UpdateWorldElementInput
+    input: UpdateWorldElementBody
   ) => Promise<WorldElement>;
   deleteElement: (elementId: string) => Promise<void>;
 }
@@ -75,7 +65,7 @@ export function useWorldElements(projectId: string): UseWorldElementsReturn {
 
   // Create element mutation
   const createElementMutation = useMutation({
-    mutationFn: async (input: CreateWorldElementInput) => {
+    mutationFn: async (input: CreateWorldElementBody) => {
       return worldElementsApi.createWorldElement(projectId, input);
     },
     onSuccess: () => {
@@ -96,7 +86,7 @@ export function useWorldElements(projectId: string): UseWorldElementsReturn {
       input,
     }: {
       elementId: string;
-      input: UpdateWorldElementInput;
+      input: UpdateWorldElementBody;
     }) => {
       return worldElementsApi.updateWorldElement(elementId, input);
     },
@@ -128,14 +118,14 @@ export function useWorldElements(projectId: string): UseWorldElementsReturn {
   });
 
   const createElement = async (
-    input: CreateWorldElementInput
+    input: CreateWorldElementBody
   ): Promise<WorldElement> => {
     return createElementMutation.mutateAsync(input);
   };
 
   const updateElement = async (
     elementId: string,
-    input: UpdateWorldElementInput
+    input: UpdateWorldElementBody
   ): Promise<WorldElement> => {
     return updateElementMutation.mutateAsync({ elementId, input });
   };

--- a/apps/frontend/src/lib/api/world-elements.ts
+++ b/apps/frontend/src/lib/api/world-elements.ts
@@ -6,7 +6,7 @@
  */
 
 import { request, requestVoid } from "./client";
-import type { WorldElement } from "@branchforge/shared";
+import type { WorldElement, WorldElementType } from "@branchforge/shared";
 
 // ============================================================================
 // Types
@@ -14,15 +14,15 @@ import type { WorldElement } from "@branchforge/shared";
 
 export interface CreateWorldElementBody {
   name: string;
-  type: "LOCATION" | "ITEM" | "CONCEPT" | "EVENT";
-  description?: string;
+  type: WorldElementType;
+  description?: string | null;
   tags?: string[];
 }
 
 export interface UpdateWorldElementBody {
   name?: string;
-  type?: "LOCATION" | "ITEM" | "CONCEPT" | "EVENT";
-  description?: string;
+  type?: WorldElementType;
+  description?: string | null;
   tags?: string[];
 }
 

--- a/apps/frontend/src/lib/api/world-elements.ts
+++ b/apps/frontend/src/lib/api/world-elements.ts
@@ -1,0 +1,110 @@
+/**
+ * World Elements API Client
+ *
+ * Client for world element management operations.
+ * World elements are world bible entries: locations, items, concepts, events.
+ */
+
+import { request, requestVoid } from "./client";
+import type { WorldElement } from "@branchforge/shared";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface CreateWorldElementBody {
+  name: string;
+  type: "LOCATION" | "ITEM" | "CONCEPT" | "EVENT";
+  description?: string;
+  tags?: string[];
+}
+
+export interface UpdateWorldElementBody {
+  name?: string;
+  type?: "LOCATION" | "ITEM" | "CONCEPT" | "EVENT";
+  description?: string;
+  tags?: string[];
+}
+
+export interface ListWorldElementsResponse {
+  elements: WorldElement[];
+}
+
+export interface GetWorldElementResponse {
+  element: WorldElement;
+}
+
+// ============================================================================
+// World Elements API
+// ============================================================================
+
+export const worldElementsApi = {
+  /**
+   * List all world elements for a project
+   */
+  async listWorldElements(projectId: string): Promise<WorldElement[]> {
+    const response = await request<ListWorldElementsResponse>(
+      `/projects/${encodeURIComponent(projectId)}/world-elements`,
+      {
+        method: "GET",
+      }
+    );
+    return response.elements;
+  },
+
+  /**
+   * Get a single world element by ID
+   */
+  async getWorldElement(elementId: string): Promise<WorldElement> {
+    const response = await request<GetWorldElementResponse>(
+      `/world-elements/${encodeURIComponent(elementId)}`,
+      {
+        method: "GET",
+      }
+    );
+    return response.element;
+  },
+
+  /**
+   * Create a new world element for a project
+   */
+  async createWorldElement(
+    projectId: string,
+    body: CreateWorldElementBody
+  ): Promise<WorldElement> {
+    const response = await request<GetWorldElementResponse>(
+      `/projects/${encodeURIComponent(projectId)}/world-elements`,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+      }
+    );
+    return response.element;
+  },
+
+  /**
+   * Update an existing world element
+   */
+  async updateWorldElement(
+    elementId: string,
+    body: UpdateWorldElementBody
+  ): Promise<WorldElement> {
+    const response = await request<GetWorldElementResponse>(
+      `/world-elements/${encodeURIComponent(elementId)}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      }
+    );
+    return response.element;
+  },
+
+  /**
+   * Delete a world element
+   */
+  async deleteWorldElement(elementId: string): Promise<void> {
+    return requestVoid(`/world-elements/${encodeURIComponent(elementId)}`, {
+      method: "DELETE",
+    });
+  },
+};

--- a/apps/frontend/src/lib/query-keys.ts
+++ b/apps/frontend/src/lib/query-keys.ts
@@ -132,6 +132,17 @@ export const visualSystemKeys = {
 } as const;
 
 // ============================================================================
+// World Element Keys
+// ============================================================================
+
+export const worldElementKeys = {
+  all: ["worldElements"] as const,
+  lists: (projectId: string) => ["worldElements", projectId, "list"] as const,
+  detail: (elementId: string) =>
+    ["worldElements", "detail", elementId] as const,
+} as const;
+
+// ============================================================================
 // Variable Keys
 // ============================================================================
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -141,6 +141,29 @@ export interface Stat {
   updatedAt: string;
 }
 
+// ============================================================================
+// World Element Configuration
+// ============================================================================
+
+/**
+ * Element type for world bible entries
+ */
+export type WorldElementType = "LOCATION" | "ITEM" | "CONCEPT" | "EVENT";
+
+/**
+ * World element representing a world bible entry.
+ * Tracks locations, items, concepts, and events in the story world.
+ */
+export interface WorldElement {
+  id: string;
+  projectId: string;
+  name: string;
+  type: WorldElementType;
+  description: string | null;
+  tags: string[];
+  createdAt: string;
+}
+
 /**
  * Summary of a label's effect on a specific stat.
  */


### PR DESCRIPTION
Closes #26

## What changed

Added full CRUD for world elements — the world bible feature for tracking locations, items, concepts, and events.

### Backend
- `world-elements.service.ts` — CRUD service with `requireProjectOwnership` authz
- `world-elements.routes.ts` — 5 endpoints (`GET/POST /projects/:projectId/world-elements`, `GET/PATCH/DELETE /world-elements/:elementId`)
- Validation schemas (`createWorldElementSchema`, `updateWorldElementSchema`, `worldElementIdParamsSchema`)
- Route registration in `index.ts`

### Shared
- `WorldElementType` and `WorldElement` types in `@branchforge/shared`

### Frontend
- `useWorldElements` hook — TanStack Query with create/update/delete mutations
- `world-elements.ts` API client
- `WorldElementsList` — list grouped by type (Locations, Items, Concepts, Events) with edit/delete
- `WorldElementEditDialog` — create/edit form with name, type select, description, tag management
- `WorldElementsDialog` / `WorldElementsSettingsContent` — used in both standalone dialog and ProjectSettingsDialog tab
- "World Bible" tab in ProjectSettingsDialog
- "World Bible" collapsible section in ScriptReferencePanel

## How verified
- Backend typecheck ✅
- Frontend typecheck ✅
- Backend lint ✅
- Frontend lint ✅
- Backend unit tests: 788/788 ✅
- Frontend tests: 861/861 ✅
- Pre-push typecheck ✅

## Oracle review
Two passes, all findings addressed:
- **must-fix:** PUT → PATCH (matches variables pattern)
- **should-fix:** empty-body guard in updateWorldElement
- **should-fix:** stale JSDoc comment fixed
- Final verdict: no remaining findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “World Bible” experience to project settings, including a new world tab and a dedicated elements management dialog.
  * Users can create, edit, delete, and browse world elements (grouped by type) with support for names, descriptions, and tags.
  * The script reference panel now displays a World Bible section with a “Manage elements” action.
* **Bug Fixes**
  * Enhanced validation and form constraints, plus improved loading/disabled states during create/update/delete to reduce inconsistent submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->