### PR TITLE
feat: mobile responsive component fixes (#263)

### DIFF
--- a/apps/frontend/src/components/CharacterDialog.tsx
+++ b/apps/frontend/src/components/CharacterDialog.tsx
@@ -50,7 +50,7 @@ export function CharacterDialog({
     >
       <DialogContent className="max-w-3xl w-full max-h-[90vh] p-0 gap-0 flex flex-col">
         {/* Header */}
-        <div className="p-6 border-b border-border/30 flex items-start justify-between">
+        <div className="p-6 max-mobile:p-4 border-b border-border/30 flex items-start justify-between">
           <div>
             <h2 className="text-lg font-medium">Character Management</h2>
             <p className="text-sm text-muted-foreground mt-1">
@@ -69,7 +69,7 @@ export function CharacterDialog({
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
+        <div className="flex-1 overflow-y-auto p-6 max-mobile:p-4">
           <CharacterSettingsContent
             projectId={projectId}
             duoEndingEnabled={currentProject?.duoEndingEnabled ?? false}
@@ -78,7 +78,7 @@ export function CharacterDialog({
         </div>
 
         {/* Footer */}
-        <div className="p-6 border-t border-border/30 flex justify-end">
+        <div className="p-6 max-mobile:p-4 border-t border-border/30 flex justify-end">
           <Button
             type="button"
             variant="outline"

--- a/apps/frontend/src/components/CharacterEditDialog.tsx
+++ b/apps/frontend/src/components/CharacterEditDialog.tsx
@@ -380,7 +380,7 @@ export function CharacterEditDialog({
 
         <div className="space-y-4 mt-4">
           {/* Name + Display Name */}
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
             <div className="space-y-1">
               <Label htmlFor="edit-char-name" className="text-xs">
                 Name *
@@ -421,7 +421,7 @@ export function CharacterEditDialog({
           </div>
 
           {/* Ren'Py Tag + Color */}
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
             <div className="space-y-1">
               <Label htmlFor="edit-char-tag" className="text-xs">
                 Ren'Py Tag *
@@ -523,7 +523,7 @@ export function CharacterEditDialog({
           </div>
 
           {/* Route + Conditional Prefix */}
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
             <div className="space-y-1">
               <Label htmlFor="edit-char-route" className="text-xs">
                 Route Affiliation
@@ -576,7 +576,7 @@ export function CharacterEditDialog({
           </div>
 
           {/* Love Interest + Narrator */}
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
             <div className="flex items-center gap-2 pt-5">
               <input
                 type="checkbox"

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -119,7 +119,7 @@ export function ProjectSettingsDialog({
     >
       <DialogContent className="max-w-3xl w-full h-[80vh] min-h-[500px] p-0 gap-0 flex flex-col overflow-hidden">
         {/* Header */}
-        <div className="p-6 border-b border-border/30 flex items-start justify-between shrink-0">
+        <div className="p-6 max-mobile:p-4 border-b border-border/30 flex items-start justify-between shrink-0">
           <div>
             <h2 className="text-lg font-medium">Project Settings</h2>
             <p className="text-sm text-muted-foreground mt-1">
@@ -143,8 +143,11 @@ export function ProjectSettingsDialog({
           onValueChange={(next) => setActiveTab(next as SettingsTab)}
           className="flex flex-col flex-1 min-h-0"
         >
-          <div className="px-6 pt-2 shrink-0">
-            <TabsList ariaLabel="Project settings sections">
+          <div className="px-6 pt-2 shrink-0 max-sm:overflow-x-auto">
+            <TabsList
+              ariaLabel="Project settings sections"
+              className="max-sm:mx-0 max-sm:px-3"
+            >
               {TAB_ORDER.map((tab) => {
                 const Icon = TAB_ICONS[tab];
                 return (
@@ -159,7 +162,7 @@ export function ProjectSettingsDialog({
             </TabsList>
           </div>
 
-          <div className="flex-1 overflow-y-auto p-6">
+          <div className="flex-1 overflow-y-auto p-6 max-mobile:p-4">
             <TabsPanel value="characters" className="space-y-4">
               <CharactersTabContent projectId={projectId} />
             </TabsPanel>
@@ -176,7 +179,7 @@ export function ProjectSettingsDialog({
         </Tabs>
 
         {/* Footer */}
-        <div className="p-6 border-t border-border/30 flex justify-end shrink-0">
+        <div className="p-6 max-mobile:p-4 border-t border-border/30 flex justify-end shrink-0">
           <Button
             type="button"
             variant="outline"

--- a/apps/frontend/src/components/RouteEditDialog.tsx
+++ b/apps/frontend/src/components/RouteEditDialog.tsx
@@ -145,7 +145,7 @@ function RouteFormContent({
       </DialogHeader>
 
       <div className="space-y-4 mt-4">
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
           <div className="space-y-1">
             <Label htmlFor="route-key" className="text-xs">
               Route Key *
@@ -188,7 +188,7 @@ function RouteFormContent({
           </div>
         </div>
 
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
           <div className="space-y-1">
             <Label htmlFor="jump-prefix" className="text-xs">
               Jump Prefix *

--- a/apps/frontend/src/components/StatEditDialog.tsx
+++ b/apps/frontend/src/components/StatEditDialog.tsx
@@ -158,7 +158,7 @@ function StatFormContent({
 
   return (
     <div className="space-y-4 mt-4">
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
         <div className="space-y-1">
           <Label htmlFor="stat-key" className="text-xs">
             Key *
@@ -199,7 +199,7 @@ function StatFormContent({
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
         <div className="space-y-1">
           <Label htmlFor="stat-min" className="text-xs">
             Min Value

--- a/apps/frontend/src/components/VariableEditDialog.tsx
+++ b/apps/frontend/src/components/VariableEditDialog.tsx
@@ -131,7 +131,7 @@ function VariableFormContent({
 
   return (
     <div className="space-y-4 mt-4">
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
         <div className="space-y-1">
           <Label htmlFor="variable-key" className="text-xs">
             Variable Key *

--- a/apps/frontend/src/components/VisualSystemDialog.tsx
+++ b/apps/frontend/src/components/VisualSystemDialog.tsx
@@ -229,7 +229,7 @@ export function VisualSystemFormContent({
         )}
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
         <div className="space-y-1">
           <Label htmlFor="vs-label-padding" className="text-xs">
             Label Padding *
@@ -292,7 +292,7 @@ export function VisualSystemFormContent({
         )}
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
         <div className="space-y-1">
           <Label htmlFor="vs-default-group" className="text-xs">
             Default Group Type

--- a/apps/frontend/src/components/WorldElementEditDialog.tsx
+++ b/apps/frontend/src/components/WorldElementEditDialog.tsx
@@ -147,7 +147,7 @@ function ElementFormContent({
 
   return (
     <div className="space-y-4 mt-4">
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
         <div className="space-y-1">
           <Label htmlFor="element-name" className="text-xs">
             Name *

--- a/apps/frontend/src/components/flow/FlowDialog.tsx
+++ b/apps/frontend/src/components/flow/FlowDialog.tsx
@@ -63,7 +63,7 @@ export function FlowDialog({ open, onOpenChange, projectId }: FlowDialogProps) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="w-[95vw] max-w-[2200px] h-[96vh] p-0 gap-0 overflow-hidden flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between px-5 py-3 border-b border-border/30 shrink-0">
+        <div className="flex items-center justify-between px-5 py-3 max-mobile:px-4 max-mobile:py-2 border-b border-border/30 shrink-0">
           <DialogTitle>Flow Graph</DialogTitle>
           <button
             type="button"

--- a/apps/frontend/src/components/ide-shared/SettingsModal.tsx
+++ b/apps/frontend/src/components/ide-shared/SettingsModal.tsx
@@ -208,10 +208,10 @@ export function SettingsModal({
           </Button>
         </DialogHeader>
 
-        <div className="flex h-[700px] max-h-[calc(95vh-120px)]">
+        <div className="flex max-md:flex-col h-[700px] max-h-[calc(95vh-120px)] max-md:h-auto">
           {/* Vertical Tabs */}
-          <div className="w-48 border-r border-border/30 p-2 flex flex-col">
-            <div className="space-y-1">
+          <div className="w-48 border-r border-border/30 p-2 flex flex-col max-md:w-full max-md:border-r-0 max-md:border-b max-md:flex-row max-md:overflow-x-auto max-md:sticky max-md:top-0 max-md:bg-card max-md:z-10">
+            <div className="space-y-1 max-md:flex max-md:space-y-0 max-md:space-x-1 max-md:gap-1">
               {visibleTabs.map((tab) => (
                 <button
                   type="button"
@@ -230,7 +230,7 @@ export function SettingsModal({
             </div>
 
             {/* Version */}
-            <div className="mt-auto pt-4 px-3">
+            <div className="mt-auto pt-4 px-3 max-md:hidden">
               <p className="text-xs text-muted-foreground">
                 {APP_NAME} v{APP_VERSION}
               </p>

--- a/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
+++ b/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
@@ -323,7 +323,7 @@ export function ConflictReviewDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-4xl w-full max-h-[90vh] p-0 gap-0 flex flex-col">
         {/* Header */}
-        <div className="p-6 border-b border-border/30 flex items-start justify-between">
+        <div className="p-6 max-mobile:p-4 border-b border-border/30 flex items-start justify-between">
           <div className="flex-1">
             <div className="flex items-center gap-3">
               <h2 className="text-lg font-medium">Review Sync Conflicts</h2>
@@ -355,7 +355,7 @@ export function ConflictReviewDialog({
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
+        <div className="flex-1 overflow-y-auto p-6 max-mobile:p-4">
           {state.isLoading && state.conflicts.length === 0 ? (
             <div className="flex items-center justify-center h-full">
               <div className="text-center">
@@ -447,7 +447,7 @@ export function ConflictReviewDialog({
               )}
 
               {/* Side-by-side Comparison */}
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-4">
                 {/* BranchForge Version */}
                 <div className="space-y-2">
                   <div className="flex items-center justify-between">
@@ -523,7 +523,7 @@ export function ConflictReviewDialog({
         </div>
 
         {/* Footer */}
-        <div className="p-6 border-t border-border/30 flex justify-between">
+        <div className="p-6 max-mobile:p-4 border-t border-border/30 flex justify-between">
           <Button
             type="button"
             variant="outline"

--- a/apps/frontend/src/components/script-mode/GitLabSyncDialog.tsx
+++ b/apps/frontend/src/components/script-mode/GitLabSyncDialog.tsx
@@ -307,7 +307,7 @@ export function GitLabSyncDialog({
     <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <DialogContent className="max-w-md w-full p-0 gap-0">
         {/* Header */}
-        <div className="p-6 border-b border-border/30 flex items-start justify-between">
+        <div className="p-6 max-mobile:p-4 border-b border-border/30 flex items-start justify-between">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-muted rounded-md">
               <SyncIcon className="size-5" />
@@ -337,7 +337,7 @@ export function GitLabSyncDialog({
         </div>
 
         {/* Content */}
-        <div className="p-6 space-y-4">
+        <div className="p-6 max-mobile:p-4 space-y-4">
           {/* Progress / Status */}
           {state.isProcessing || state.operation ? (
             <div className="space-y-3">
@@ -495,7 +495,7 @@ export function GitLabSyncDialog({
         </div>
 
         {/* Footer */}
-        <div className="p-6 border-t border-border/30 flex justify-end gap-2">
+        <div className="p-6 max-mobile:p-4 border-t border-border/30 flex justify-end gap-2">
           {!state.isProcessing && !state.operation && (
             <>
               <Button type="button" variant="outline" onClick={handleClose}>

--- a/apps/frontend/src/components/script-mode/StatManagementDialog.tsx
+++ b/apps/frontend/src/components/script-mode/StatManagementDialog.tsx
@@ -75,8 +75,8 @@ export function StatManagementDialog({
       maxWidth="5xl"
       onOpenTrigger={refreshProgression}
     >
-      <div className="flex h-full overflow-hidden">
-        <div className="w-[340px] shrink-0 border-r border-border/30 overflow-y-auto p-6">
+      <div className="flex h-full overflow-hidden max-md:flex-col">
+        <div className="w-[340px] shrink-0 border-r border-border/30 overflow-y-auto p-6 max-md:w-full max-md:border-r-0 max-md:border-b">
           <h3 className="text-sm font-medium mb-4">Stats</h3>
           {isLoadingStats ? (
             <div className="flex items-center justify-center py-8">

--- a/apps/frontend/src/components/write-mode/LabelEditDialog.tsx
+++ b/apps/frontend/src/components/write-mode/LabelEditDialog.tsx
@@ -337,7 +337,7 @@ export function LabelEditDialog({
           )}
 
           {/* Route, Status, Visibility Grid */}
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-3 max-sm:grid-cols-1 gap-3">
             {/* Route Field */}
             <div className="space-y-1.5">
               <label

--- a/apps/frontend/src/components/write-mode/WritingGoalPill.tsx
+++ b/apps/frontend/src/components/write-mode/WritingGoalPill.tsx
@@ -74,7 +74,7 @@ export const WritingGoalPill = memo(function WritingGoalPill({
       </div>
 
       {/* Text indicator */}
-      <span className="text-xs font-medium shrink-0 text-muted-foreground whitespace-nowrap">
+      <span className="text-xs font-medium shrink-0 text-muted-foreground max-sm:whitespace-normal whitespace-nowrap">
         {remaining} words to go
       </span>
 
@@ -90,7 +90,7 @@ export const WritingGoalPill = memo(function WritingGoalPill({
 
       {/* Click hint */}
       {onClick && (
-        <span className="text-xs text-muted-foreground/40 shrink-0">
+        <span className="text-xs text-muted-foreground/40 shrink-0 max-sm:hidden">
           Click for stats
         </span>
       )}

--- a/apps/frontend/src/components/write-mode/WritingStatsDialog.tsx
+++ b/apps/frontend/src/components/write-mode/WritingStatsDialog.tsx
@@ -88,7 +88,7 @@ export function WritingStatsDialog({
     >
       <div className="space-y-6">
         {/* Summary Stats */}
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-3 max-sm:grid-cols-1 gap-4">
           <div className="bg-muted/50 rounded-lg p-3 text-center">
             <p className="text-2xl font-bold text-[var(--theme-color)]">
               {totalWords.toLocaleString()}

--- a/apps/frontend/src/pages/ide/WriteMode.tsx
+++ b/apps/frontend/src/pages/ide/WriteMode.tsx
@@ -45,7 +45,8 @@ const sidebarVariants = cva(
     variants: {
       variant: {
         collapsed: "w-0 opacity-0 -translate-x-full pointer-events-none",
-        expanded: "w-48 opacity-100 translate-x-0",
+        expanded:
+          "w-48 opacity-100 translate-x-0 max-md:absolute max-md:z-50 max-md:left-0 max-md:top-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0",
       },
     },
     defaultVariants: {
@@ -325,7 +326,7 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
         </div>
       )}
 
-      <div className="flex-1 flex gap-4 px-4 pb-4 overflow-hidden min-h-0 min-w-0">
+      <div className="flex-1 flex gap-4 px-4 pb-4 overflow-hidden min-h-0 min-w-0 relative">
         <div
           aria-hidden={isFocusMode}
           className={sidebarVariants({

--- a/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
+++ b/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
@@ -32,7 +32,8 @@ const sidebarVariants = cva(
     variants: {
       variant: {
         collapsed: "w-0 opacity-0 -translate-x-full pointer-events-none",
-        expanded: "w-56 opacity-100 translate-x-0",
+        expanded:
+          "w-56 opacity-100 translate-x-0 max-md:absolute max-md:z-50 max-md:left-0 max-md:top-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0",
       },
     },
     defaultVariants: {
@@ -137,7 +138,7 @@ export function ScriptModeEditorLayout({
         </div>
       )}
 
-      <div className="flex-1 flex gap-4 px-4 pb-4 overflow-hidden min-h-0 min-w-0">
+      <div className="flex-1 flex gap-4 px-4 pb-4 overflow-hidden min-h-0 min-w-0 relative">
         <div
           aria-hidden={isFocusMode}
           className={sidebarVariants({


### PR DESCRIPTION
Closes #263

## Summary
Applies mobile-responsive patterns (built in #262) to all feature-level dialogs, page layouts, and named components so they render correctly at 375px width.

## What changed (18 files, +47/-42 lines)

**Padding fixes** — Five dialogs with `DialogContent p-0` now have `max-mobile:p-4` on their inner header/content/footer divs: CharacterDialog, GitLabSyncDialog, ConflictReviewDialog, ProjectSettingsDialog, FlowDialog

**Grid layout fixes** — Nine components with `grid-cols-2`/`grid-cols-3` now collapse to single column on mobile via `max-sm:grid-cols-1`: CharacterEditDialog, WorldElementEditDialog, VariableEditDialog, RouteEditDialog, StatEditDialog, VisualSystemDialog, LabelEditDialog, WritingStatsDialog, ConflictReviewDialog

**Complex reflows:**
- **StatManagementDialog** — Left/right panels stack vertically on mobile (`max-md:flex-col`)
- **SettingsModal** — Vertical tab sidebar transforms to horizontal tabs on mobile, version text hidden
- **ProjectSettingsDialog** — Tab bar becomes horizontally scrollable on mobile
- **Page layouts** (WriteMode, ScriptModeEditorLayout) — Sidebars overlay as absolute-positioned panels on mobile to prevent flex overflow
- **WritingGoalPill** — Text wrapping on narrow containers, hide click-hint on mobile

## Verification
- `pnpm typecheck` — passes
- `pnpm lint` — passes
- `pnpm test` — all tests pass (861 frontend, 428 integration, 812 backend unit, 56 shared)