### PR TITLE
feat: mobile-responsive IDE app shell (#267)

### DIFF
--- a/.changeset/brown-drinks-speak.md
+++ b/.changeset/brown-drinks-speak.md
@@ -1,0 +1,5 @@
+---
+"@branchforge/frontend": minor
+---
+
+Made the app shell significantly more mobile-responsive

--- a/apps/frontend/src/components/ide-shared/EditorTabBar.tsx
+++ b/apps/frontend/src/components/ide-shared/EditorTabBar.tsx
@@ -35,6 +35,9 @@ interface EditorTabBarProps {
   titleMaxWidthClassName?: string;
 }
 
+const META_BADGE_CLASSES =
+  "rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide bg-muted/55 text-muted-foreground/80 shrink-0";
+
 export function EditorTabBar({
   items,
   activeItemId,
@@ -92,6 +95,19 @@ export function EditorTabBar({
     return () => document.removeEventListener("mousedown", handler);
   }, [mobileDropdownOpen]);
 
+  // Escape key: close the mobile dropdown
+  useEffect(() => {
+    if (!mobileDropdownOpen) return;
+    const handler = (event: Event) => {
+      if ((event as unknown as { key: string }).key === "Escape") {
+        setMobileDropdownOpen(false);
+        mobileToggleRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [mobileDropdownOpen]);
+
   const updateScrollIndicators = useCallback(() => {
     const container = tabsScrollContainerRef.current;
     if (!container) {
@@ -113,6 +129,8 @@ export function EditorTabBar({
       setShowLeftScrollIndicator(false);
       // react-doctor-disable-next-line react-doctor/no-adjust-state-on-prop-change
       setShowRightScrollIndicator(false);
+      // react-doctor-disable-next-line react-doctor/no-adjust-state-on-prop-change
+      setMobileDropdownOpen(false);
       return;
     }
 
@@ -251,7 +269,21 @@ export function EditorTabBar({
         <button
           ref={mobileToggleRef}
           type="button"
-          onClick={() => setMobileDropdownOpen((prev) => !prev)}
+          onClick={() => {
+            const nextOpen = !mobileDropdownOpen;
+            setMobileDropdownOpen(nextOpen);
+            if (nextOpen) {
+              requestAnimationFrame(() => {
+                const firstItemButton =
+                  dropdownMenuRef.current?.querySelector<HTMLButtonElement>(
+                    "button"
+                  );
+                firstItemButton?.focus();
+              });
+            }
+          }}
+          aria-haspopup="listbox"
+          aria-expanded={mobileDropdownOpen}
           className="h-full w-full flex items-center gap-2 px-3 text-sm"
         >
           <Menu className="size-4 text-muted-foreground shrink-0" />
@@ -260,9 +292,7 @@ export function EditorTabBar({
               (items.length === 0 ? "No tabs" : "Select tab")}
           </span>
           {activeItem?.meta ? (
-            <span className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide bg-muted/55 text-muted-foreground/80 shrink-0">
-              {activeItem.meta}
-            </span>
+            <span className={META_BADGE_CLASSES}>{activeItem.meta}</span>
           ) : null}
           <ChevronDown
             className={cn(
@@ -276,6 +306,7 @@ export function EditorTabBar({
           createPortal(
             <div
               ref={dropdownMenuRef}
+              role="listbox"
               style={dropdownStyle}
               className="z-[110] rounded-lg border border-border bg-card shadow-xl max-h-48 overflow-y-auto"
             >
@@ -284,6 +315,8 @@ export function EditorTabBar({
                 return (
                   <div
                     key={item.id}
+                    role="option"
+                    aria-selected={isActive}
                     className={cn(
                       "flex items-center gap-2 px-3 py-2.5 text-sm",
                       isActive ? "bg-muted/50" : "hover:bg-muted/30"
@@ -302,9 +335,7 @@ export function EditorTabBar({
                       </span>
                     </button>
                     {item.meta ? (
-                      <span className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide bg-muted/55 text-muted-foreground/80 shrink-0">
-                        {item.meta}
-                      </span>
+                      <span className={META_BADGE_CLASSES}>{item.meta}</span>
                     ) : null}
                     <button
                       type="button"

--- a/apps/frontend/src/components/ide-shared/EditorTabBar.tsx
+++ b/apps/frontend/src/components/ide-shared/EditorTabBar.tsx
@@ -1,13 +1,21 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type KeyboardEvent,
   type MouseEvent,
   type WheelEvent as ReactWheelEvent,
 } from "react";
-import { ChevronsLeft, ChevronsRight, X } from "lucide-react";
+import { createPortal } from "react-dom";
+import {
+  ChevronsLeft,
+  ChevronsRight,
+  ChevronDown,
+  Menu,
+  X,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface EditorTabBarItem {
@@ -37,10 +45,52 @@ export function EditorTabBar({
   titleMaxWidthClassName = "max-w-[220px]",
 }: EditorTabBarProps) {
   const tabsScrollContainerRef = useRef<HTMLDivElement>(null);
+  const mobileToggleRef = useRef<HTMLButtonElement>(null);
+  const dropdownMenuRef = useRef<HTMLDivElement>(null);
   const scrollIndicatorRafIdRef = useRef<number | null>(null);
   const [showLeftScrollIndicator, setShowLeftScrollIndicator] = useState(false);
   const [showRightScrollIndicator, setShowRightScrollIndicator] =
     useState(false);
+  const [mobileDropdownOpen, setMobileDropdownOpen] = useState(false);
+  const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
+
+  // Position the dropdown relative to the toggle button (portal + fixed)
+  useLayoutEffect(() => {
+    if (!mobileDropdownOpen || !mobileToggleRef.current) return;
+    const update = () => {
+      const rect = mobileToggleRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      setDropdownStyle({
+        position: "fixed",
+        top: rect.bottom + 4,
+        left: rect.left,
+        width: rect.width,
+      });
+    };
+    update();
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [mobileDropdownOpen]);
+
+  // Click-outside: close if click is outside both toggle button and dropdown menu
+  useEffect(() => {
+    if (!mobileDropdownOpen) return;
+    const handler = (event: Event) => {
+      const target = event.target as Node;
+      if (
+        !mobileToggleRef.current?.contains(target) &&
+        !dropdownMenuRef.current?.contains(target)
+      ) {
+        setMobileDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [mobileDropdownOpen]);
 
   const updateScrollIndicators = useCallback(() => {
     const container = tabsScrollContainerRef.current;
@@ -185,6 +235,8 @@ export function EditorTabBar({
     [updateScrollIndicators]
   );
 
+  const activeItem = items.find((item) => item.id === activeItemId);
+
   return (
     <div
       className={cn(
@@ -194,7 +246,87 @@ export function EditorTabBar({
           : "mb-2 h-12 overflow-hidden rounded-lg border border-border/80 bg-card/55 opacity-100 backdrop-blur-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
       )}
     >
-      <div className="relative h-full w-full min-w-0 overflow-hidden rounded-[inherit]">
+      {/* Mobile tab dropdown (below md) */}
+      <div className="md:hidden h-full">
+        <button
+          ref={mobileToggleRef}
+          type="button"
+          onClick={() => setMobileDropdownOpen((prev) => !prev)}
+          className="h-full w-full flex items-center gap-2 px-3 text-sm"
+        >
+          <Menu className="size-4 text-muted-foreground shrink-0" />
+          <span className="truncate font-medium">
+            {activeItem?.title ??
+              (items.length === 0 ? "No tabs" : "Select tab")}
+          </span>
+          {activeItem?.meta ? (
+            <span className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide bg-muted/55 text-muted-foreground/80 shrink-0">
+              {activeItem.meta}
+            </span>
+          ) : null}
+          <ChevronDown
+            className={cn(
+              "size-4 text-muted-foreground ml-auto shrink-0 transition-transform",
+              mobileDropdownOpen && "rotate-180"
+            )}
+          />
+        </button>
+
+        {mobileDropdownOpen &&
+          createPortal(
+            <div
+              ref={dropdownMenuRef}
+              style={dropdownStyle}
+              className="z-[110] rounded-lg border border-border bg-card shadow-xl max-h-48 overflow-y-auto"
+            >
+              {items.map((item) => {
+                const isActive = item.id === activeItemId;
+                return (
+                  <div
+                    key={item.id}
+                    className={cn(
+                      "flex items-center gap-2 px-3 py-2.5 text-sm",
+                      isActive ? "bg-muted/50" : "hover:bg-muted/30"
+                    )}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void onSelect(item.id);
+                        setMobileDropdownOpen(false);
+                      }}
+                      className="flex-1 text-left truncate min-w-0"
+                    >
+                      <span className={cn(isActive && "font-medium")}>
+                        {item.title}
+                      </span>
+                    </button>
+                    {item.meta ? (
+                      <span className="rounded px-1.5 py-0.5 text-[11px] font-semibold tracking-wide bg-muted/55 text-muted-foreground/80 shrink-0">
+                        {item.meta}
+                      </span>
+                    ) : null}
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onClose(event, item.id);
+                      }}
+                      className="rounded p-1 hover:bg-muted-foreground/10 shrink-0 text-muted-foreground"
+                      aria-label={item.closeLabel ?? `Close ${item.title}`}
+                    >
+                      <X className="size-3.5" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>,
+            document.body
+          )}
+      </div>
+
+      {/* Desktop scrollable tab row (md and above) */}
+      <div className="hidden md:block relative h-full w-full min-w-0 overflow-hidden rounded-[inherit]">
         <div
           ref={tabsScrollContainerRef}
           onScroll={updateScrollIndicators}

--- a/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
+++ b/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
@@ -4,10 +4,12 @@ import {
   useEffectEvent,
   useReducer,
   useRef,
+  useState,
 } from "react";
 import {
   BookOpen,
   SquarePen,
+  Menu,
   Palette,
   Settings,
   LogOut,
@@ -154,7 +156,7 @@ function ModeSwitcher({
         type="button"
         onClick={() => setMode("write")}
         className={`flex ${
-          isCollapsed ? "w-full p-2.5" : "flex-1 px-2 py-1.5"
+          isCollapsed ? "w-full p-3.5" : "flex-1 px-2 py-1.5"
         } items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-all ${
           mode === "write"
             ? "text-white bg-[var(--theme-color)]"
@@ -169,7 +171,7 @@ function ModeSwitcher({
         type="button"
         onClick={() => setMode("script")}
         className={`flex ${
-          isCollapsed ? "w-full p-2.5" : "flex-1 px-2 py-1.5"
+          isCollapsed ? "w-full p-3.5" : "flex-1 px-2 py-1.5"
         } items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-all ${
           mode === "script"
             ? "text-white bg-[var(--theme-color)]"
@@ -193,6 +195,8 @@ interface ProjectSelectorProps {
   isOpen: boolean;
   onToggle: () => void;
   onClose: () => void;
+  /** When true, popover opens above the button (for mobile bottom bar) */
+  bottomPopover?: boolean;
 }
 
 /** Project picker. When collapsed, a button that opens a popover.
@@ -206,6 +210,7 @@ function ProjectSelector({
   isOpen,
   onToggle,
   onClose,
+  bottomPopover = false,
 }: ProjectSelectorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   // `onClose` is read inside the click-outside handler but isn't
@@ -241,7 +246,7 @@ function ProjectSelector({
           type="button"
           onClick={onToggle}
           disabled={isLoadingProjects}
-          className={`flex items-center justify-center p-2.5 rounded-md text-sm font-medium transition-colors ${
+          className={`flex items-center justify-center p-3.5 rounded-md text-sm font-medium transition-colors ${
             isOpen
               ? "text-foreground bg-muted/50"
               : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
@@ -251,7 +256,13 @@ function ProjectSelector({
           <FolderOpen className="size-4 flex-shrink-0" />
         </button>
         {isOpen && (
-          <div className="absolute left-full top-0 ml-2 bg-popover border border-border/70 rounded-lg shadow-xl shadow-black/25 ring-1 ring-white/5 min-w-[300px] max-w-[400px] z-50">
+          <div
+            className={`absolute bg-popover border border-border/70 rounded-lg shadow-xl shadow-black/25 ring-1 ring-white/5 min-w-[300px] max-w-[400px] z-50 ${
+              bottomPopover
+                ? "bottom-full left-1/2 -translate-x-1/2 mb-2"
+                : "left-full top-0 ml-2"
+            }`}
+          >
             <div className="p-2 max-h-[400px] overflow-y-auto">
               {isLoadingProjects ? (
                 <div className="px-3 py-2 text-sm text-muted-foreground">
@@ -318,6 +329,8 @@ interface NavButtonsProps {
   showLabel: boolean;
   onOpenProjectSettings: () => void;
   onOpenFlow: () => void;
+  /** Render buttons in a horizontal row (for mobile bottom bar) */
+  horizontal?: boolean;
 }
 
 /** Project Settings + Flow navigation entries. */
@@ -327,16 +340,17 @@ function NavButtons({
   showLabel,
   onOpenProjectSettings,
   onOpenFlow,
+  horizontal = false,
 }: NavButtonsProps) {
   const disabled = !projectId;
   return (
-    <nav className="flex flex-col gap-1">
+    <nav className={`flex gap-1 ${horizontal ? "flex-row" : "flex-col"}`}>
       <button
         type="button"
         onClick={onOpenProjectSettings}
         disabled={disabled}
         className={`flex items-center ${
-          isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+          isCollapsed ? "justify-center p-3.5" : "gap-3 p-2"
         } rounded-md text-sm font-medium transition-colors ${
           disabled
             ? "text-muted-foreground/50 cursor-not-allowed"
@@ -352,7 +366,7 @@ function NavButtons({
         onClick={onOpenFlow}
         disabled={disabled}
         className={`flex items-center ${
-          isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+          isCollapsed ? "justify-center p-3.5" : "gap-3 p-2"
         } rounded-md text-sm font-medium transition-colors ${
           disabled
             ? "text-muted-foreground/50 cursor-not-allowed"
@@ -375,6 +389,8 @@ interface ThemeSwitcherProps {
   isOpen: boolean;
   onToggle: () => void;
   onClose: () => void;
+  /** When true, popover opens above the button (for mobile bottom bar) */
+  bottomPopover?: boolean;
 }
 
 /** Theme palette picker. When collapsed, a button that opens a popover.
@@ -387,6 +403,7 @@ function ThemeSwitcher({
   isOpen,
   onToggle,
   onClose,
+  bottomPopover = false,
 }: ThemeSwitcherProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   // `onClose` is read inside the click-outside handler but isn't
@@ -419,7 +436,7 @@ function ThemeSwitcher({
         <button
           type="button"
           onClick={onToggle}
-          className={`flex items-center justify-center p-2.5 rounded-md text-sm font-medium transition-colors ${
+          className={`flex items-center justify-center p-3.5 rounded-md text-sm font-medium transition-colors ${
             isOpen
               ? "text-foreground bg-muted/50"
               : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
@@ -429,7 +446,13 @@ function ThemeSwitcher({
           <Palette className="size-4 flex-shrink-0" />
         </button>
         {isOpen && (
-          <div className="absolute left-full top-0 ml-2 bg-popover border border-border/70 rounded-lg p-3 shadow-xl shadow-black/25 ring-1 ring-white/5 z-50">
+          <div
+            className={`absolute bg-popover border border-border/70 rounded-lg p-3 shadow-xl shadow-black/25 ring-1 ring-white/5 z-50 ${
+              bottomPopover
+                ? "bottom-full left-1/2 -translate-x-1/2 mb-2"
+                : "left-full top-0 ml-2"
+            }`}
+          >
             <div className="flex gap-2">
               {themePalettes.map((palette) => (
                 <button
@@ -491,7 +514,7 @@ function CollapseButton({ isCollapsed, onToggle }: CollapseButtonProps) {
       type="button"
       onClick={onToggle}
       className={`flex items-center ${
-        isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+        isCollapsed ? "justify-center p-3.5" : "gap-3 p-2"
       } rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors`}
       title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
     >
@@ -529,7 +552,7 @@ function DarkModeToggle({
       aria-label={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
       title={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
       className={`flex items-center ${
-        isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+        isCollapsed ? "justify-center p-3.5" : "gap-3 p-2"
       } rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors`}
     >
       {isDarkMode ? (
@@ -562,7 +585,7 @@ function UserActions({
         type="button"
         onClick={onOpenSettings}
         className={`flex items-center ${
-          isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+          isCollapsed ? "justify-center p-3.5" : "gap-3 p-2"
         } rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors`}
         title="Settings"
       >
@@ -573,7 +596,7 @@ function UserActions({
         type="button"
         onClick={onLogout}
         className={`flex items-center ${
-          isCollapsed ? "justify-center p-2.5" : "gap-3 p-2"
+          isCollapsed ? "justify-center p-3.5" : "gap-3 p-2"
         } rounded-md text-sm font-medium text-muted-foreground hover:text-destructive-muted hover:bg-destructive/10 transition-colors`}
         title="Logout"
       >
@@ -613,6 +636,27 @@ export function LeftSidebar(props: LeftSidebarProps) {
   const isSettingsOpenExternally = props.isSettingsOpenExternally;
   const onSettingsOpenChangeExternally = props.onSettingsOpenChangeExternally;
   const [modals, dispatchModal] = useReducer(modalReducer, initialModalState);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
+  const mobileMenuBtnRef = useRef<HTMLButtonElement>(null);
+  const closeMobileMenuEvent = useEffectEvent(() => setMobileMenuOpen(false));
+
+  // Click-outside dismiss for mobile hamburger menu popover
+  useEffect(() => {
+    if (!mobileMenuOpen) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        mobileMenuRef.current &&
+        !mobileMenuRef.current.contains(event.target as Node) &&
+        mobileMenuBtnRef.current &&
+        !mobileMenuBtnRef.current.contains(event.target as Node)
+      ) {
+        closeMobileMenuEvent();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [mobileMenuOpen]);
   const projectsRef = useRef(projects);
 
   const isSettingsOpen = isSettingsOpenExternally ?? modals.settings;
@@ -678,7 +722,7 @@ export function LeftSidebar(props: LeftSidebarProps) {
   return (
     <>
       <div
-        className={`fixed left-0 top-0 h-screen ${width} bg-card/95 backdrop-blur border-r border-border/30 flex flex-col transition-all duration-300 z-50`}
+        className={`max-md:hidden fixed left-0 top-0 h-screen ${width} bg-card/95 backdrop-blur border-r border-border/30 flex flex-col transition-all duration-300 z-50`}
       >
         {/* Top Section */}
         <div className="flex-1 flex flex-col p-2 gap-2">
@@ -759,6 +803,140 @@ export function LeftSidebar(props: LeftSidebarProps) {
           />
         </div>
       </div>
+
+      {/* Mobile bottom nav bar (below md breakpoint) */}
+      <div className="md:hidden fixed bottom-0 left-0 right-0 h-14 bg-card/95 backdrop-blur border-t border-border/30 flex items-center justify-between px-4 pb-[env(safe-area-inset-bottom)] z-50">
+        {/* Mode switcher – horizontal, icon-only */}
+        <div className="flex bg-muted/50 rounded-md p-0.5">
+          <button
+            type="button"
+            onClick={() => setMode("write")}
+            className={`p-3.5 rounded-md transition-all ${
+              mode === "write"
+                ? "text-white bg-[var(--theme-color)]"
+                : "text-muted-foreground"
+            }`}
+            title="Write Mode"
+          >
+            <BookOpen className="size-4 flex-shrink-0" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("script")}
+            className={`p-3.5 rounded-md transition-all ${
+              mode === "script"
+                ? "text-white bg-[var(--theme-color)]"
+                : "text-muted-foreground"
+            }`}
+            title="Script Mode"
+          >
+            <SquarePen className="size-4 flex-shrink-0" />
+          </button>
+        </div>
+
+        <ProjectSelector
+          projectId={projectId}
+          projects={projects}
+          isLoadingProjects={isLoadingProjects}
+          setCurrentProject={setCurrentProject}
+          isCollapsed={true}
+          isOpen={modals.projectPopover}
+          onToggle={() =>
+            dispatchModal({ type: "TOGGLE", key: "projectPopover" })
+          }
+          onClose={() =>
+            dispatchModal({ type: "CLOSE", key: "projectPopover" })
+          }
+          bottomPopover
+        />
+
+        <div className="flex bg-muted/50 rounded-md p-0.5">
+          <NavButtons
+            projectId={projectId}
+            isCollapsed={true}
+            showLabel={false}
+            horizontal
+            onOpenProjectSettings={() =>
+              dispatchModal({ type: "OPEN", key: "projectSettings" })
+            }
+            onOpenFlow={() => dispatchModal({ type: "OPEN", key: "flow" })}
+          />
+        </div>
+
+        {/* Hamburger menu – replaces dark mode, theme, settings, logout */}
+        <button
+          ref={mobileMenuBtnRef}
+          type="button"
+          onClick={() => setMobileMenuOpen((prev) => !prev)}
+          className={`flex items-center justify-center p-3.5 rounded-md text-sm font-medium transition-colors ${
+            mobileMenuOpen
+              ? "text-foreground bg-muted/50"
+              : "text-muted-foreground"
+          }`}
+          title="Menu"
+          aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
+        >
+          <Menu className="size-4 flex-shrink-0" />
+        </button>
+      </div>
+
+      {/* Mobile hamburger menu popover */}
+      {mobileMenuOpen && (
+        <div
+          ref={mobileMenuRef}
+          className="md:hidden fixed bottom-14 left-0 right-0 bg-popover border-t border-border/70 shadow-xl shadow-black/25 ring-1 ring-white/5 z-[100]"
+        >
+          <div className="flex flex-col">
+            <div className="p-2 rounded-md text-sm font-medium text-muted-foreground border-b border-muted/60 transition-colors">
+              <DarkModeToggle
+                isDarkMode={isDarkMode}
+                onToggle={onToggleDarkMode}
+                isCollapsed={false}
+                showLabel={true}
+              />
+            </div>
+
+            <div className="p-2 rounded-md text-sm font-medium text-muted-foreground border-b border-muted/60 transition-colors">
+              <ThemeSwitcher
+                theme={theme}
+                setTheme={setTheme}
+                themePalettes={themePalettes}
+                isCollapsed={false}
+                isOpen={false}
+                onToggle={() => {}}
+                onClose={() => {}}
+              />
+            </div>
+
+            <div className="p-2 rounded-md text-sm font-medium text-muted-foreground border-b border-muted/60 transition-colors">
+              <button
+                type="button"
+                onClick={() => {
+                  setMobileMenuOpen(false);
+                  setSettingsOpen(true);
+                }}
+                className="flex items-center gap-3 p-2 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                title="Settings"
+              >
+                <Settings className="size-4 flex-shrink-0" />
+                <span>Settings</span>
+              </button>
+            </div>
+
+            <div className="p-2 rounded-md text-sm font-medium text-muted-foreground transition-colors">
+              <button
+                type="button"
+                onClick={onLogout}
+                className="flex items-center gap-3 p-2 rounded-md text-sm font-medium text-muted-foreground hover:text-destructive-muted hover:bg-destructive/10 transition-colors"
+                title="Logout"
+              >
+                <LogOut className="size-4 flex-shrink-0" />
+                <span>Logout</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Modals */}
       <SettingsModal

--- a/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
+++ b/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
@@ -816,6 +816,7 @@ export function LeftSidebar(props: LeftSidebarProps) {
                 ? "text-white bg-[var(--theme-color)]"
                 : "text-muted-foreground"
             }`}
+            aria-label="Write Mode"
             title="Write Mode"
           >
             <BookOpen className="size-4 flex-shrink-0" />
@@ -828,6 +829,7 @@ export function LeftSidebar(props: LeftSidebarProps) {
                 ? "text-white bg-[var(--theme-color)]"
                 : "text-muted-foreground"
             }`}
+            aria-label="Script Mode"
             title="Script Mode"
           >
             <SquarePen className="size-4 flex-shrink-0" />

--- a/apps/frontend/src/components/script-mode/ScriptReferencePanel.tsx
+++ b/apps/frontend/src/components/script-mode/ScriptReferencePanel.tsx
@@ -32,7 +32,7 @@ const panelVariants = cva(
   {
     variants: {
       collapsed: {
-        true: "w-0 opacity-0 translate-x-full pointer-events-none",
+        true: "w-0 opacity-0 translate-x-full pointer-events-none max-md:absolute max-md:z-40 max-md:inset-y-0 max-md:right-0 max-md:h-full max-md:mb-0 max-md:mt-0 max-md:rounded-none",
         false:
           "w-64 opacity-100 translate-x-0 max-md:absolute max-md:z-40 max-md:inset-y-0 max-md:right-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0",
       },
@@ -463,7 +463,7 @@ export function ScriptReferencePanel({
       />
 
       {isCollapsed && onCollapseToggle && (
-        <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:fixed max-md:left-1 max-md:z-50 max-md:mt-0 max-md:-ml-0 max-md:bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))]">
+        <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:hidden">
           <button
             type="button"
             onClick={onCollapseToggle}

--- a/apps/frontend/src/components/script-mode/ScriptReferencePanel.tsx
+++ b/apps/frontend/src/components/script-mode/ScriptReferencePanel.tsx
@@ -33,7 +33,8 @@ const panelVariants = cva(
     variants: {
       collapsed: {
         true: "w-0 opacity-0 translate-x-full pointer-events-none",
-        false: "w-64 opacity-100 translate-x-0",
+        false:
+          "w-64 opacity-100 translate-x-0 max-md:absolute max-md:z-40 max-md:inset-y-0 max-md:right-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0",
       },
     },
   }
@@ -462,7 +463,7 @@ export function ScriptReferencePanel({
       />
 
       {isCollapsed && onCollapseToggle && (
-        <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4">
+        <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:fixed max-md:left-1 max-md:z-50 max-md:mt-0 max-md:-ml-0 max-md:bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))]">
           <button
             type="button"
             onClick={onCollapseToggle}

--- a/apps/frontend/src/components/script-mode/StatusBar.tsx
+++ b/apps/frontend/src/components/script-mode/StatusBar.tsx
@@ -1,11 +1,18 @@
 import { useState, useCallback, useReducer } from "react";
-import { Download, Upload, GitBranch, Loader2 } from "lucide-react";
+import {
+  Download,
+  Upload,
+  GitBranch,
+  Loader2,
+  FolderArchive,
+} from "lucide-react";
 import { useToast } from "@/contexts/ToastContext";
 import {
   GitLabSyncDialog,
   SyncOperationType,
 } from "@/components/script-mode/GitLabSyncDialog";
 import { ConflictReviewDialog } from "@/components/script-mode/ConflictReviewDialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { cn } from "@/lib/utils";
 import { projectFilesApi } from "@/lib/api/project-files";
 import type { SourceOrigin } from "@branchforge/shared";
@@ -100,17 +107,24 @@ export function StatusBar({
   }, [onOpenZipImportDialog]);
 
   /**
-   * Handle ZIP export click - generates export and triggers download
+   * Handle ZIP export click - shows confirm dialog before exporting
    */
   const [isExporting, setIsExporting] = useState(false);
+  const [showExportConfirm, setShowExportConfirm] = useState(false);
   const { error: showErrorToast } = useToast();
-  const handleZipExportClick = useCallback(async () => {
-    if (!projectId || isExporting) return;
 
+  const handleZipExportClick = useCallback(() => {
+    if (!projectId) return;
+    setShowExportConfirm(true);
+  }, [projectId]);
+
+  const handleConfirmExport = useCallback(async () => {
+    if (!projectId || isExporting) return;
     setIsExporting(true);
     try {
       const result = await projectFilesApi.generateExport(projectId);
       await projectFilesApi.downloadExport(projectId, result.id);
+      setShowExportConfirm(false);
     } catch (err) {
       console.error("Export failed:", err);
       showErrorToast("Export failed. Please try again.", "Export Error");
@@ -143,7 +157,7 @@ export function StatusBar({
   return (
     <>
       <div
-        className="flex items-center justify-between px-4 py-2 text-xs bg-card/50 border-t border-dashed transition-opacity duration-300 ease-out"
+        className="flex items-center justify-between px-3 max-sm:px-2 py-2 text-xs bg-card/50 border-t border-dashed transition-opacity duration-300 ease-out gap-2 max-sm:gap-1"
         style={{
           borderColor: "var(--theme-border-subtle)",
           opacity: isFocusMode ? (isHovered ? 1 : 0.6) : 1,
@@ -153,22 +167,22 @@ export function StatusBar({
         onFocusCapture={() => setIsHovered(true)}
         onBlurCapture={() => setIsHovered(false)}
       >
-        <div className="flex items-center gap-4">
-          <div className="text-muted-foreground border-r border-border/30 pr-4">
+        <div className="flex items-center gap-3 max-sm:gap-2">
+          <div className="text-muted-foreground border-r border-border/30 pr-3 max-sm:pr-2">
             {language}
           </div>
           {isGitLabAvailable && (
-            <div className="flex items-center gap-1.5 text-muted-foreground border-r border-border/30 pr-4">
+            <div className="flex items-center gap-1.5 text-muted-foreground border-r border-border/30 pr-3 max-sm:pr-2 max-sm:border-r-0">
               <GitBranch className="size-3" />
               <span>{gitlabBranch ?? "Unknown"}</span>
             </div>
           )}
         </div>
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-3 max-sm:gap-1">
           {/* GitLab import - only show for GITLAB source type */}
           {isGitLabAvailable && (
             <>
-              <div className="flex items-center gap-2 border-l border-border/30 pl-4">
+              <div className="flex items-center gap-2 max-sm:gap-1 border-l border-border/30 pl-3 max-sm:pl-2">
                 <button
                   type="button"
                   onClick={handleImportClick}
@@ -179,10 +193,10 @@ export function StatusBar({
                   title="Import from GitLab"
                 >
                   <Download className="size-3.5" />
-                  <span>Import from GitLab</span>
+                  <span className="max-sm:hidden">Import from GitLab</span>
                 </button>
               </div>
-              <div className="border-l border-border/30 pl-4">
+              <div className="border-l border-border/30 pl-4 max-sm:pl-2">
                 <button
                   type="button"
                   onClick={handleExportClick}
@@ -193,7 +207,7 @@ export function StatusBar({
                   title="Sync to GitLab"
                 >
                   <Upload className="size-3.5" />
-                  <span>Sync to GitLab</span>
+                  <span className="max-sm:hidden">Sync to GitLab</span>
                 </button>
               </div>
             </>
@@ -201,7 +215,7 @@ export function StatusBar({
 
           {/* ZIP import - only show for ZIP source type when callback exists */}
           {isZipAvailable && onOpenZipImportDialog && (
-            <div className="flex items-center gap-2 border-l border-border/30 pl-4">
+            <div className="flex items-center gap-2 border-l border-border/30 pl-4 max-sm:pl-2">
               <button
                 type="button"
                 onClick={handleZipImportClick}
@@ -212,14 +226,14 @@ export function StatusBar({
                 title="Import from Zip"
               >
                 <Download className="size-3.5" />
-                <span>Import from Zip</span>
+                <span className="max-sm:hidden">Import from Zip</span>
               </button>
             </div>
           )}
 
           {/* Export as Zip - available for ALL project types */}
           {projectId && (
-            <div className="border-l border-border/30 pl-4">
+            <div className="border-l border-border/30 pl-4 max-sm:pl-2">
               <button
                 type="button"
                 onClick={handleZipExportClick}
@@ -234,9 +248,11 @@ export function StatusBar({
                 {isExporting ? (
                   <Loader2 className="size-3.5 animate-spin" />
                 ) : (
-                  <Upload className="size-3.5" />
+                  <FolderArchive className="size-3.5" />
                 )}
-                <span>{isExporting ? "Exporting..." : "Export Zip"}</span>
+                <span className="max-sm:hidden">
+                  {isExporting ? "Exporting..." : "Export Zip"}
+                </span>
               </button>
             </div>
           )}
@@ -271,6 +287,18 @@ export function StatusBar({
             onApplyResolutions={handleApplyResolutions}
           />
         )}
+      {/* Export Confirm Dialog */}
+      <ConfirmDialog
+        open={showExportConfirm}
+        onOpenChange={setShowExportConfirm}
+        onConfirm={handleConfirmExport}
+        title="Export Project Files"
+        description="Download all project files as a ZIP archive?"
+        confirmLabel="Export"
+        isLoading={isExporting}
+        loadingLabel="Exporting..."
+        isNonDestructive
+      />
     </>
   );
 }

--- a/apps/frontend/src/components/script-mode/StatusBar.tsx
+++ b/apps/frontend/src/components/script-mode/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useReducer } from "react";
+import { useState, useCallback, useReducer, useRef } from "react";
 import {
   Download,
   Upload,
@@ -110,6 +110,7 @@ export function StatusBar({
    * Handle ZIP export click - shows confirm dialog before exporting
    */
   const [isExporting, setIsExporting] = useState(false);
+  const isExportingRef = useRef(false);
   const [showExportConfirm, setShowExportConfirm] = useState(false);
   const { error: showErrorToast } = useToast();
 
@@ -119,7 +120,8 @@ export function StatusBar({
   }, [projectId]);
 
   const handleConfirmExport = useCallback(async () => {
-    if (!projectId || isExporting) return;
+    if (!projectId || isExporting || isExportingRef.current) return;
+    isExportingRef.current = true;
     setIsExporting(true);
     try {
       const result = await projectFilesApi.generateExport(projectId);
@@ -129,6 +131,7 @@ export function StatusBar({
       console.error("Export failed:", err);
       showErrorToast("Export failed. Please try again.", "Export Error");
     } finally {
+      isExportingRef.current = false;
       setIsExporting(false);
     }
   }, [projectId, isExporting, showErrorToast]);

--- a/apps/frontend/src/components/ui/confirm-dialog.tsx
+++ b/apps/frontend/src/components/ui/confirm-dialog.tsx
@@ -27,6 +27,8 @@ interface ConfirmDialogProps {
   confirmLabel?: string;
   /** Whether the action is in progress */
   isLoading?: boolean;
+  /** Whether the action is non-destructive (default: false) */
+  isNonDestructive?: boolean;
   /** Loading text shown when isLoading is true (default: "Loading...") */
   loadingLabel?: string;
   /** Called when onConfirm throws an error. Receives the error object. */
@@ -44,6 +46,7 @@ export function ConfirmDialog({
   cancelLabel = "Cancel",
   confirmLabel = "Confirm",
   isLoading = false,
+  isNonDestructive = false,
   loadingLabel = "Loading...",
   onError,
   className,
@@ -150,7 +153,7 @@ export function ConfirmDialog({
             {cancelLabel}
           </Button>
           <Button
-            variant="destructive"
+            variant={isNonDestructive ? "default" : "destructive"}
             onClick={handleConfirm}
             disabled={isLoading}
           >

--- a/apps/frontend/src/components/write-mode/LabelPropertiesPanel.tsx
+++ b/apps/frontend/src/components/write-mode/LabelPropertiesPanel.tsx
@@ -21,7 +21,8 @@ const panelVariants = cva(
     variants: {
       collapsed: {
         true: "w-0 opacity-0 translate-x-full pointer-events-none",
-        false: "w-56 opacity-100 translate-x-0",
+        false:
+          "w-56 opacity-100 translate-x-0 max-md:absolute max-md:z-40 max-md:inset-y-0 max-md:right-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0",
       },
     },
   }
@@ -605,7 +606,7 @@ export function LabelPropertiesPanel({
       </div>
 
       {isCollapsed && onCollapseToggle && (
-        <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4">
+        <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:fixed max-md:left-1 max-md:z-50 max-md:mt-0 max-md:-ml-0 max-md:bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))]">
           <button
             type="button"
             onClick={onCollapseToggle}

--- a/apps/frontend/src/components/write-mode/LabelPropertiesPanel.tsx
+++ b/apps/frontend/src/components/write-mode/LabelPropertiesPanel.tsx
@@ -20,7 +20,7 @@ const panelVariants = cva(
   {
     variants: {
       collapsed: {
-        true: "w-0 opacity-0 translate-x-full pointer-events-none",
+        true: "w-0 opacity-0 translate-x-full pointer-events-none max-md:absolute max-md:z-40 max-md:inset-y-0 max-md:right-0 max-md:h-full max-md:mt-0 max-md:rounded-none",
         false:
           "w-56 opacity-100 translate-x-0 max-md:absolute max-md:z-40 max-md:inset-y-0 max-md:right-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0",
       },
@@ -606,7 +606,7 @@ export function LabelPropertiesPanel({
       </div>
 
       {isCollapsed && onCollapseToggle && (
-        <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:fixed max-md:left-1 max-md:z-50 max-md:mt-0 max-md:-ml-0 max-md:bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))]">
+        <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:hidden">
           <button
             type="button"
             onClick={onCollapseToggle}

--- a/apps/frontend/src/components/write-mode/ProseEditor.tsx
+++ b/apps/frontend/src/components/write-mode/ProseEditor.tsx
@@ -792,7 +792,7 @@ export const ProseEditor = function ProseEditor({
       {/* Goal Pill */}
       {writingGoalSettings?.dailyWritingGoal != null && (
         <div
-          className="relative z-10 -mt-12 px-4 pt-10 pb-2 border-b border-border bg-gradient-to-b from-transparent via-card/30 to-card/80 transition-opacity duration-300 ease-out"
+          className="relative z-10 -mt-12 px-4 pt-10 pb-2 border-b border-border bg-gradient-to-b from-transparent via-card/30 to-card/80 transition-opacity duration-300 ease-out flex justify-end"
           style={{
             opacity: isFocusMode ? (isBottomBarHovered ? 1 : 0.4) : 1,
           }}
@@ -847,7 +847,7 @@ export const ProseEditor = function ProseEditor({
             <FontSizeSwitcher mode="write" direction="up" />
           </div>
 
-          <div className="flex items-center gap-4 text-sm">
+          <div className="flex items-center gap-4 text-sm max-md:hidden">
             <span className="text-muted-foreground">
               <span className="text-foreground font-medium">{wordCount}</span>{" "}
               word{wordCount !== 1 ? "s" : ""}

--- a/apps/frontend/src/components/write-mode/WritingGoalPill.tsx
+++ b/apps/frontend/src/components/write-mode/WritingGoalPill.tsx
@@ -73,8 +73,8 @@ export const WritingGoalPill = memo(function WritingGoalPill({
         </svg>
       </div>
 
-      {/* Text indicator */}
-      <span className="text-xs font-medium shrink-0 text-muted-foreground max-sm:whitespace-normal whitespace-nowrap">
+      {/* Text indicator — hidden on small screens */}
+      <span className="text-xs font-medium shrink-0 text-muted-foreground whitespace-nowrap max-md:hidden">
         {remaining} words to go
       </span>
 
@@ -82,18 +82,6 @@ export const WritingGoalPill = memo(function WritingGoalPill({
       <span className="text-xs text-muted-foreground/60 shrink-0">
         {progressPercent}%
       </span>
-
-      {/* Goal indicator */}
-      <span className="text-xs text-muted-foreground/60 shrink-0">
-        {goal} words
-      </span>
-
-      {/* Click hint */}
-      {onClick && (
-        <span className="text-xs text-muted-foreground/40 shrink-0 max-sm:hidden">
-          Click for stats
-        </span>
-      )}
     </div>
   );
 });

--- a/apps/frontend/src/hooks/__tests__/useResponsiveSidebarState.unit.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useResponsiveSidebarState.unit.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the useResponsiveSidebarState hook.
+ *
+ * Covers initial state on mobile/desktop, toggle routing, resize
+ * transitions, and functional updater support.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useResponsiveSidebarState } from "../useResponsiveSidebarState";
+
+/** Typed stub for matchMedia.addEventListener/removeEventListener */
+type MqlHandler = (e: MediaQueryListEvent) => void;
+
+/** Stub returned by our matchMedia mock — callable to fire a change event. */
+interface StubMql {
+  matches: boolean;
+  addEventListener: ReturnType<
+    typeof vi.fn<(event: string, handler: MqlHandler) => void>
+  >;
+  removeEventListener: ReturnType<
+    typeof vi.fn<(event: string, handler: MqlHandler) => void>
+  >;
+  fireChange: () => void;
+}
+
+function createStubMql(matches: boolean): StubMql {
+  let handlers: MqlHandler[] = [];
+  const stub: StubMql = {
+    matches,
+    addEventListener: vi.fn((_event: string, handler: MqlHandler) => {
+      handlers.push(handler);
+    }),
+    removeEventListener: vi.fn((_event: string, handler: MqlHandler) => {
+      handlers = handlers.filter((h) => h !== handler);
+    }),
+    fireChange: () => {
+      // MediaQueryListEvent is not available in jsdom; create a plain
+      // object with the properties the handler inspects.
+      const event = {
+        matches: stub.matches,
+        media: "(min-width: 768px)",
+      } as MediaQueryListEvent;
+      for (const h of handlers) {
+        h(event);
+      }
+    },
+  };
+  return stub;
+}
+
+describe("useResponsiveSidebarState", () => {
+  let stubMql: StubMql;
+
+  beforeEach(() => {
+    stubMql = createStubMql(true); // desktop default
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockReturnValue(stubMql as unknown as MediaQueryList),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  function setStored(key: string, value: boolean) {
+    window.localStorage.setItem(`branchforge:${key}`, String(value));
+  }
+
+  function getStored(key: string): boolean | null {
+    const v = window.localStorage.getItem(`branchforge:${key}`);
+    if (v === "true") return true;
+    if (v === "false") return false;
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Initial state
+  // ---------------------------------------------------------------------------
+
+  it("defaults to collapsed on mobile (<768px), regardless of localStorage", () => {
+    stubMql.matches = false; // mobile
+    setStored("test:sidebar", false); // stored as "expanded"
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    expect(result.current[0]).toBe(true); // collapsed
+  });
+
+  it("respects localStorage collapsed value on desktop", () => {
+    setStored("test:sidebar", true); // stored as "collapsed"
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("respects localStorage expanded value on desktop", () => {
+    setStored("test:sidebar", false);
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("falls back to defaultValue on desktop when localStorage is empty", () => {
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar", true)
+    );
+    expect(result.current[0]).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Toggle routing
+  // ---------------------------------------------------------------------------
+
+  it("toggling on mobile changes the effective value but not localStorage", () => {
+    stubMql.matches = false;
+    setStored("test:sidebar", false);
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    // starts collapsed
+    expect(result.current[0]).toBe(true);
+
+    act(() => result.current[1](false)); // expand
+    expect(result.current[0]).toBe(false);
+    // localStorage should still be false (unchanged)
+    expect(getStored("test:sidebar")).toBe(false);
+  });
+
+  it("toggling on desktop writes to localStorage", () => {
+    setStored("test:sidebar", false);
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    act(() => result.current[1](true)); // collapse
+    expect(result.current[0]).toBe(true);
+    expect(getStored("test:sidebar")).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Resize transitions
+  // ---------------------------------------------------------------------------
+
+  it("resets to collapsed when switching from desktop to mobile", () => {
+    setStored("test:sidebar", false); // expanded on desktop
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    expect(result.current[0]).toBe(false); // desktop: expanded
+
+    // switch to mobile
+    stubMql.matches = false;
+    act(() => stubMql.fireChange());
+    expect(result.current[0]).toBe(true); // collapsed on mobile
+  });
+
+  it("restores stored value when switching from mobile to desktop", () => {
+    stubMql.matches = false; // mobile
+    setStored("test:sidebar", false); // stored as expanded
+
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    expect(result.current[0]).toBe(true); // mobile: collapsed
+
+    // expand on mobile
+    act(() => result.current[1](false));
+    expect(result.current[0]).toBe(false); // expanded on mobile
+
+    // switch to desktop
+    stubMql.matches = true;
+    act(() => stubMql.fireChange());
+    // desktop restores stored (false = expanded)
+    expect(result.current[0]).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Functional updater
+  // ---------------------------------------------------------------------------
+
+  it("supports functional updater on mobile", () => {
+    stubMql.matches = false;
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    expect(result.current[0]).toBe(true);
+    act(() => result.current[1]((prev) => !prev));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("supports functional updater on desktop", () => {
+    setStored("test:sidebar", false);
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    act(() => result.current[1]((prev) => !prev));
+    expect(result.current[0]).toBe(true);
+    expect(getStored("test:sidebar")).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cleanup
+  // ---------------------------------------------------------------------------
+
+  it("removes the matchMedia listener on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    unmount();
+    expect(stubMql.removeEventListener).toHaveBeenCalledWith(
+      "change",
+      expect.any(Function)
+    );
+  });
+});

--- a/apps/frontend/src/hooks/__tests__/useResponsiveSidebarState.unit.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useResponsiveSidebarState.unit.test.ts
@@ -217,4 +217,36 @@ describe("useResponsiveSidebarState", () => {
       expect.any(Function)
     );
   });
+
+  // ---------------------------------------------------------------------------
+  // isMobile flag (third tuple element)
+  // ---------------------------------------------------------------------------
+
+  it("exposes isMobile=true on mobile", () => {
+    stubMql.matches = false; // mobile
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    expect(result.current[2]).toBe(true);
+  });
+
+  it("exposes isMobile=false on desktop", () => {
+    stubMql.matches = true; // desktop
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    expect(result.current[2]).toBe(false);
+  });
+
+  it("updates isMobile when the viewport changes", () => {
+    stubMql.matches = true; // desktop
+    const { result } = renderHook(() =>
+      useResponsiveSidebarState("test:sidebar")
+    );
+    expect(result.current[2]).toBe(false);
+
+    stubMql.matches = false; // switch to mobile
+    act(() => stubMql.fireChange());
+    expect(result.current[2]).toBe(true);
+  });
 });

--- a/apps/frontend/src/hooks/useResponsiveSidebarState.ts
+++ b/apps/frontend/src/hooks/useResponsiveSidebarState.ts
@@ -1,0 +1,67 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useState,
+  useCallback,
+  useRef,
+} from "react";
+import { useLocalStorageBoolean } from "./useLocalStorage";
+
+/**
+ * Sidebar collapse state that respects responsive breakpoints.
+ *
+ * On mobile (< 768px / `max-md`): sidebars default to collapsed (true)
+ * regardless of the persisted localStorage value. The user can toggle
+ * the overlay open, but the toggle is not persisted – switching back to
+ * desktop restores the desktop-persisted state.
+ *
+ * On desktop (>= 768px): the persisted localStorage value is used.
+ */
+export function useResponsiveSidebarState(key: string, defaultValue = false) {
+  const [stored, setStored] = useLocalStorageBoolean(key, defaultValue);
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return !window.matchMedia("(min-width: 768px)").matches;
+  });
+  // Mobile-local toggle state – only used when isMobile is true.
+  // Always starts collapsed on mobile.
+  const [mobileCollapsed, setMobileCollapsed] = useState(true);
+  const isMobileRef = useRef(isMobile);
+
+  useLayoutEffect(() => {
+    isMobileRef.current = isMobile;
+  }, [isMobile]);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 768px)");
+    const handler = () => {
+      const nowMobile = !mql.matches;
+      setIsMobile(nowMobile);
+      if (nowMobile) {
+        setMobileCollapsed(true);
+      }
+    };
+    // Set initial – use matchMedia to avoid SSR mismatch
+    handler();
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  // Effective collapsed state:
+  //  - Mobile: use mobileCollapsed (local, starts collapsed)
+  //  - Desktop: use stored (persisted)
+  const effective = isMobile ? mobileCollapsed : stored;
+
+  const setValue = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) => {
+      if (isMobileRef.current) {
+        setMobileCollapsed(value);
+      } else {
+        setStored(value);
+      }
+    },
+    [setStored]
+  );
+
+  return [effective, setValue] as const;
+}

--- a/apps/frontend/src/hooks/useResponsiveSidebarState.ts
+++ b/apps/frontend/src/hooks/useResponsiveSidebarState.ts
@@ -16,6 +16,12 @@ import { useLocalStorageBoolean } from "./useLocalStorage";
  * desktop restores the desktop-persisted state.
  *
  * On desktop (>= 768px): the persisted localStorage value is used.
+ *
+ * Returns a readonly tuple `[collapsed, setCollapsed, isMobile]`. The third
+ * element is the live mobile flag so callers can enforce mobile-only
+ * behaviour (e.g. mutual exclusivity between left/right overlays) without
+ * subscribing to matchMedia themselves. Existing two-element destructuring
+ * `[a, b] = ...` continues to work.
  */
 export function useResponsiveSidebarState(key: string, defaultValue = false) {
   const [stored, setStored] = useLocalStorageBoolean(key, defaultValue);
@@ -63,5 +69,5 @@ export function useResponsiveSidebarState(key: string, defaultValue = false) {
     [setStored]
   );
 
-  return [effective, setValue] as const;
+  return [effective, setValue, isMobile] as const;
 }

--- a/apps/frontend/src/pages/ide/ScriptMode.tsx
+++ b/apps/frontend/src/pages/ide/ScriptMode.tsx
@@ -53,7 +53,7 @@ export function ScriptMode({
   const [showSyncDialog, setShowSyncDialog] = useState(false);
   const [showZipImportDialog, setShowZipImportDialog] = useState(false);
 
-  const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] =
+  const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed, isMobile] =
     useResponsiveSidebarState("script:left-sidebar-collapsed");
   const [isRightSidebarCollapsed, setIsRightSidebarCollapsed] =
     useResponsiveSidebarState("script:right-sidebar-collapsed");
@@ -387,6 +387,7 @@ export function ScriptMode({
         setIsLeftSidebarCollapsed={setIsLeftSidebarCollapsed}
         isRightSidebarCollapsed={isRightSidebarCollapsed}
         setIsRightSidebarCollapsed={setIsRightSidebarCollapsed}
+        isMobile={isMobile}
         focusModeState={focusModeState}
         editorRef={editorRef}
         onFocusModeToggle={handleFocusModeToggle}

--- a/apps/frontend/src/pages/ide/ScriptMode.tsx
+++ b/apps/frontend/src/pages/ide/ScriptMode.tsx
@@ -16,7 +16,7 @@ import { useScriptModeRefresh } from "@/hooks/useScriptModeRefresh";
 import { useToast } from "@/contexts/ToastContext";
 import type { SourceOrigin } from "@branchforge/shared";
 import type { ScriptEditorRef } from "@/components/script-mode/ScriptEditor";
-import { useLocalStorageBoolean } from "@/hooks/useLocalStorage";
+import { useResponsiveSidebarState } from "@/hooks/useResponsiveSidebarState";
 import { ScriptModeEditorLayout } from "./components/ScriptModeEditorLayout";
 import { ScriptModeEmptyState } from "./components/ScriptModeEmptyState";
 import { useTextUndo } from "@/hooks/useTextUndo";
@@ -54,9 +54,9 @@ export function ScriptMode({
   const [showZipImportDialog, setShowZipImportDialog] = useState(false);
 
   const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] =
-    useLocalStorageBoolean("script:left-sidebar-collapsed", false);
+    useResponsiveSidebarState("script:left-sidebar-collapsed");
   const [isRightSidebarCollapsed, setIsRightSidebarCollapsed] =
-    useLocalStorageBoolean("script:right-sidebar-collapsed", false);
+    useResponsiveSidebarState("script:right-sidebar-collapsed");
 
   const focusModeState = useFocusModeState("script:focus-mode");
   const {
@@ -340,7 +340,7 @@ export function ScriptMode({
 
   if (isLoadingLabels || isLoadingFiles) {
     return (
-      <div className="h-screen flex flex-col overflow-hidden">
+      <div className="h-full flex flex-col overflow-hidden">
         <div className="flex-1 flex flex-col pt-16">
           <div className="flex-1 flex items-center justify-center">
             <p className="text-muted-foreground">Loading project…</p>
@@ -352,7 +352,7 @@ export function ScriptMode({
 
   if (!projectFiles.length) {
     return (
-      <div className="h-screen flex flex-col overflow-hidden">
+      <div className="h-full flex flex-col overflow-hidden">
         <ScriptModeEmptyState
           projectId={projectId}
           projectName={projectName}
@@ -369,7 +369,7 @@ export function ScriptMode({
   }
 
   return (
-    <div className="h-screen flex flex-col overflow-hidden">
+    <div className="h-full flex flex-col overflow-hidden">
       <ScriptModeEditorLayout
         projectName={projectName}
         projectId={projectId}

--- a/apps/frontend/src/pages/ide/WriteMode.tsx
+++ b/apps/frontend/src/pages/ide/WriteMode.tsx
@@ -25,7 +25,7 @@ import { useRouteConfigs } from "@/hooks/useRouteConfigs";
 import { useProject } from "@/hooks/useProject";
 import { useToast } from "@/contexts/ToastContext";
 import { cva } from "class-variance-authority";
-import { useLocalStorageBoolean } from "@/hooks/useLocalStorage";
+import { useResponsiveSidebarState } from "@/hooks/useResponsiveSidebarState";
 import { useStats } from "@/hooks/useStats";
 import { usePairGroups } from "@/hooks/usePairGroups";
 import {
@@ -100,9 +100,9 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
   );
 
   const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] =
-    useLocalStorageBoolean("write:left-sidebar-collapsed", false);
+    useResponsiveSidebarState("write:left-sidebar-collapsed");
   const [isRightSidebarCollapsed, setIsRightSidebarCollapsed] =
-    useLocalStorageBoolean("write:right-sidebar-collapsed", false);
+    useResponsiveSidebarState("write:right-sidebar-collapsed");
 
   // Lifted dialog state (from LabelNavigator)
   const [editDialog, setEditDialog] = useState<{
@@ -269,7 +269,7 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
 
   if (!currentProject) {
     return (
-      <div className="h-screen flex flex-col items-center justify-center">
+      <div className="h-full flex flex-col items-center justify-center">
         <div className="size-20 rounded-full bg-gradient-to-br from-muted/50 to-muted/30 flex items-center justify-center mb-4">
           <FileText className="size-10 text-muted-foreground/60" />
         </div>
@@ -288,7 +288,7 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
 
   if (isLoadingLabels) {
     return (
-      <div className="h-screen flex flex-col items-center justify-center">
+      <div className="h-full flex flex-col items-center justify-center">
         <div className="relative">
           <div className="size-16 rounded-full bg-[var(--theme-color)]/10 flex items-center justify-center">
             <Loader2 className="size-8 text-[var(--theme-color)] animate-spin" />
@@ -302,7 +302,7 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
 
   if (!labels.length) {
     return (
-      <div className="h-screen flex flex-col items-center justify-center">
+      <div className="h-full flex flex-col items-center justify-center">
         <div className="size-20 rounded-full bg-gradient-to-br from-muted/50 to-muted/30 flex items-center justify-center mb-4">
           <FileText className="size-10 text-muted-foreground/60" />
         </div>
@@ -315,7 +315,7 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
   }
 
   return (
-    <div className="h-screen flex flex-col overflow-hidden">
+    <div className="h-full flex flex-col overflow-hidden">
       {isFocusMode && (
         <div className="fixed top-2 right-2 z-[100] pointer-events-auto">
           <FocusModeToggle
@@ -326,7 +326,17 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
         </div>
       )}
 
-      <div className="flex-1 flex gap-4 px-4 pb-4 overflow-hidden min-h-0 min-w-0 relative">
+      <div className="flex-1 flex gap-4 px-4 max-md:px-0 pb-0 overflow-hidden min-h-0 min-w-0 relative">
+        {/* Mobile scrim backdrop – collapses open overlays on tap */}
+        {(!isLeftSidebarCollapsed || !isRightSidebarCollapsed) && (
+          <div
+            className="max-md:fixed max-md:inset-0 max-md:bg-black/40 max-md:z-30"
+            onClick={() => {
+              if (!isLeftSidebarCollapsed) setIsLeftSidebarCollapsed(true);
+              if (!isRightSidebarCollapsed) setIsRightSidebarCollapsed(true);
+            }}
+          />
+        )}
         <div
           aria-hidden={isFocusMode}
           className={sidebarVariants({
@@ -360,7 +370,7 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
         </div>
 
         {isLeftSidebarCollapsed && !isFocusMode && (
-          <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4">
+          <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:fixed max-md:left-1 max-md:z-50 max-md:mt-0 max-md:-ml-0 max-md:bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))]">
             <button
               type="button"
               onClick={() => setIsLeftSidebarCollapsed(false)}

--- a/apps/frontend/src/pages/ide/WriteMode.tsx
+++ b/apps/frontend/src/pages/ide/WriteMode.tsx
@@ -341,15 +341,16 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
 
       <div className="flex-1 flex gap-4 px-4 max-md:px-0 pb-0 overflow-hidden min-h-0 min-w-0 relative">
         {/* Mobile scrim backdrop – collapses open overlays on tap */}
-        {(!isLeftSidebarCollapsed || !isRightSidebarCollapsed) && (
-          <div
-            className="max-md:fixed max-md:inset-0 max-md:bg-black/40 max-md:z-30"
-            onClick={() => {
-              if (!isLeftSidebarCollapsed) setIsLeftSidebarCollapsed(true);
-              if (!isRightSidebarCollapsed) setIsRightSidebarCollapsed(true);
-            }}
-          />
-        )}
+        {!isFocusMode &&
+          (!isLeftSidebarCollapsed || !isRightSidebarCollapsed) && (
+            <div
+              className="hidden max-md:block max-md:fixed max-md:inset-0 max-md:bg-black/40 max-md:z-30"
+              onClick={() => {
+                if (!isLeftSidebarCollapsed) setIsLeftSidebarCollapsed(true);
+                if (!isRightSidebarCollapsed) setIsRightSidebarCollapsed(true);
+              }}
+            />
+          )}
         <div
           aria-hidden={isFocusMode}
           className={sidebarVariants({

--- a/apps/frontend/src/pages/ide/WriteMode.tsx
+++ b/apps/frontend/src/pages/ide/WriteMode.tsx
@@ -16,7 +16,7 @@ import { FocusModeToggle } from "@/components/write-mode/FocusModeToggle";
 import { LabelEditDialog } from "@/components/write-mode/LabelEditDialog.lazy";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { CharacterEditDialog } from "@/components/CharacterEditDialog.lazy";
-import { ChevronRight, FileText, Loader2 } from "lucide-react";
+import { ChevronRight, ChevronLeft, FileText, Loader2 } from "lucide-react";
 import { EditorTabBar } from "@/components/ide-shared";
 import { Button } from "@/components/ui/button";
 import { useLabels } from "@/hooks/useLabels";
@@ -44,9 +44,10 @@ const sidebarVariants = cva(
   {
     variants: {
       variant: {
-        collapsed: "w-0 opacity-0 -translate-x-full pointer-events-none",
+        collapsed:
+          "w-0 opacity-0 -translate-x-full pointer-events-none max-md:absolute max-md:z-50 max-md:left-0 max-md:top-0 max-md:h-full max-md:mt-0 max-md:rounded-none",
         expanded:
-          "w-48 opacity-100 translate-x-0 max-md:absolute max-md:z-50 max-md:left-0 max-md:top-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0",
+          "w-48 opacity-100 translate-x-0 max-md:absolute max-md:z-50 max-md:left-0 max-md:top-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0 max-md:bg-card",
       },
     },
     defaultVariants: {
@@ -99,7 +100,7 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
     [pairGroups]
   );
 
-  const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] =
+  const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed, isMobile] =
     useResponsiveSidebarState("write:left-sidebar-collapsed");
   const [isRightSidebarCollapsed, setIsRightSidebarCollapsed] =
     useResponsiveSidebarState("write:right-sidebar-collapsed");
@@ -129,6 +130,18 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
       setIsRightSidebarCollapsed,
       editorRef,
     });
+
+  // On mobile, only one overlay sidebar may be open at a time. Opening one
+  // closes the other so the two panels never stack on a narrow viewport.
+  const openLeftSidebar = useCallback(() => {
+    setIsLeftSidebarCollapsed(false);
+    if (isMobile) setIsRightSidebarCollapsed(true);
+  }, [isMobile, setIsLeftSidebarCollapsed, setIsRightSidebarCollapsed]);
+
+  const toggleRightSidebar = useCallback(() => {
+    setIsRightSidebarCollapsed((prev) => !prev);
+    if (isMobile) setIsLeftSidebarCollapsed(true);
+  }, [isMobile, setIsLeftSidebarCollapsed, setIsRightSidebarCollapsed]);
 
   const [currentDraft, setCurrentDraft] = useState<LabelDialogueDraft>(() => ({
     labelId: activeLabel?.id ?? activeLabelId,
@@ -315,7 +328,7 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
   }
 
   return (
-    <div className="h-full flex flex-col overflow-hidden">
+    <div className="h-full flex flex-col overflow-hidden max-md:px-2">
       {isFocusMode && (
         <div className="fixed top-2 right-2 z-[100] pointer-events-auto">
           <FocusModeToggle
@@ -370,10 +383,10 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
         </div>
 
         {isLeftSidebarCollapsed && !isFocusMode && (
-          <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:fixed max-md:left-1 max-md:z-50 max-md:mt-0 max-md:-ml-0 max-md:bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))]">
+          <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:hidden">
             <button
               type="button"
-              onClick={() => setIsLeftSidebarCollapsed(false)}
+              onClick={openLeftSidebar}
               className="size-12 rounded-lg border border-border bg-card/50 hover:bg-muted/80 transition-colors flex items-center justify-center"
               aria-label="Expand label navigator sidebar"
               title="Expand label navigator sidebar"
@@ -385,8 +398,19 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
 
         <div className="flex-1 flex flex-col min-h-0 min-w-0 mt-3">
           {!isFocusMode && (
-            <div className="mb-2 flex gap-2">
-              <div className="flex-1 min-w-0">
+            <div className="mb-2 flex gap-2 items-center">
+              {isLeftSidebarCollapsed && (
+                <button
+                  type="button"
+                  onClick={openLeftSidebar}
+                  className="md:hidden h-12 w-9 shrink-0 rounded-lg border border-border/80 bg-card/55 backdrop-blur-sm flex items-center justify-center"
+                  aria-label="Expand label navigator sidebar"
+                  title="Expand label navigator sidebar"
+                >
+                  <ChevronRight className="size-4 text-muted-foreground" />
+                </button>
+              )}
+              <div className="flex-1 min-w-0 h-12 overflow-hidden">
                 <EditorTabBar
                   items={tabItems}
                   activeItemId={activeLabelId}
@@ -405,6 +429,17 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
                   />
                 </div>
               </div>
+              {isRightSidebarCollapsed && (
+                <button
+                  type="button"
+                  onClick={toggleRightSidebar}
+                  className="md:hidden h-12 w-9 shrink-0 rounded-lg border border-border/80 bg-card/55 backdrop-blur-sm flex items-center justify-center"
+                  aria-label="Expand properties sidebar"
+                  title="Expand properties sidebar"
+                >
+                  <ChevronLeft className="size-4 text-muted-foreground" />
+                </button>
+              )}
             </div>
           )}
 
@@ -432,11 +467,7 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
           routeConfigs={routeConfigs}
           pairGroups={pairGroupSummaries}
           isCollapsed={isRightSidebarCollapsed || isFocusMode}
-          onCollapseToggle={
-            !isFocusMode
-              ? () => setIsRightSidebarCollapsed((prev) => !prev)
-              : undefined
-          }
+          onCollapseToggle={!isFocusMode ? toggleRightSidebar : undefined}
           onEdit={handleEditFromPanel}
           onCharacterEdit={setEditingCharacterId}
         />

--- a/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
+++ b/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
@@ -138,7 +138,17 @@ export function ScriptModeEditorLayout({
         </div>
       )}
 
-      <div className="flex-1 flex gap-4 px-4 pb-4 overflow-hidden min-h-0 min-w-0 relative">
+      <div className="flex-1 flex gap-4 px-4 max-md:px-0 pb-4 overflow-hidden min-h-0 min-w-0 relative">
+        {/* Mobile scrim backdrop – collapses open overlays on tap */}
+        {(!isLeftSidebarCollapsed || !isRightSidebarCollapsed) && (
+          <div
+            className="max-md:fixed max-md:inset-0 max-md:bg-black/40 max-md:z-30"
+            onClick={() => {
+              if (!isLeftSidebarCollapsed) setIsLeftSidebarCollapsed(true);
+              if (!isRightSidebarCollapsed) setIsRightSidebarCollapsed(true);
+            }}
+          />
+        )}
         <div
           aria-hidden={isFocusMode}
           className={sidebarVariants({
@@ -197,7 +207,7 @@ export function ScriptModeEditorLayout({
         </div>
 
         {isLeftSidebarCollapsed && !isFocusMode && (
-          <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4">
+          <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:fixed max-md:left-1 max-md:z-50 max-md:mt-0 max-md:-ml-0 max-md:bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))]">
             <button
               type="button"
               onClick={() => setIsLeftSidebarCollapsed(false)}

--- a/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
+++ b/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
@@ -153,7 +153,7 @@ export function ScriptModeEditorLayout({
         {!isFocusMode &&
           (!isLeftSidebarCollapsed || !isRightSidebarCollapsed) && (
             <div
-              className="max-md:fixed max-md:inset-0 max-md:bg-black/40 max-md:z-30"
+              className="hidden max-md:block max-md:fixed max-md:inset-0 max-md:bg-black/40 max-md:z-30"
               onClick={() => {
                 if (!isLeftSidebarCollapsed) setIsLeftSidebarCollapsed(true);
                 if (!isRightSidebarCollapsed) setIsRightSidebarCollapsed(true);

--- a/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
+++ b/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
@@ -31,9 +31,10 @@ const sidebarVariants = cva(
   {
     variants: {
       variant: {
-        collapsed: "w-0 opacity-0 -translate-x-full pointer-events-none",
+        collapsed:
+          "w-0 opacity-0 -translate-x-full pointer-events-none max-md:absolute max-md:z-50 max-md:left-0 max-md:top-0 max-md:h-full max-md:mt-0 max-md:rounded-none",
         expanded:
-          "w-56 opacity-100 translate-x-0 max-md:absolute max-md:z-50 max-md:left-0 max-md:top-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0",
+          "w-56 opacity-100 translate-x-0 max-md:absolute max-md:z-50 max-md:left-0 max-md:top-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0 max-md:bg-card",
       },
     },
     defaultVariants: {
@@ -59,6 +60,7 @@ interface ScriptModeEditorLayoutProps {
   setIsLeftSidebarCollapsed: Dispatch<SetStateAction<boolean>>;
   isRightSidebarCollapsed: boolean;
   setIsRightSidebarCollapsed: Dispatch<SetStateAction<boolean>>;
+  isMobile: boolean;
   focusModeState: FocusModeState;
   editorRef: RefObject<ScriptEditorRef | null>;
   onFocusModeToggle: () => void;
@@ -97,6 +99,7 @@ export function ScriptModeEditorLayout({
   setIsLeftSidebarCollapsed,
   isRightSidebarCollapsed,
   setIsRightSidebarCollapsed,
+  isMobile,
   focusModeState,
   editorRef,
   onFocusModeToggle,
@@ -121,10 +124,17 @@ export function ScriptModeEditorLayout({
     null
   );
 
-  const toggleRightSidebar = useCallback(
-    () => setIsRightSidebarCollapsed((previous) => !previous),
-    [setIsRightSidebarCollapsed]
-  );
+  // On mobile, only one overlay sidebar may be open at a time. Opening
+  // one closes the other so the two panels never stack on a narrow viewport.
+  const openLeftSidebar = useCallback(() => {
+    setIsLeftSidebarCollapsed(false);
+    if (isMobile) setIsRightSidebarCollapsed(true);
+  }, [isMobile, setIsLeftSidebarCollapsed, setIsRightSidebarCollapsed]);
+
+  const toggleRightSidebar = useCallback(() => {
+    setIsRightSidebarCollapsed((previous) => !previous);
+    if (isMobile) setIsLeftSidebarCollapsed(true);
+  }, [isMobile, setIsLeftSidebarCollapsed, setIsRightSidebarCollapsed]);
 
   return (
     <>
@@ -138,17 +148,18 @@ export function ScriptModeEditorLayout({
         </div>
       )}
 
-      <div className="flex-1 flex gap-4 px-4 max-md:px-0 pb-4 overflow-hidden min-h-0 min-w-0 relative">
+      <div className="flex-1 flex gap-4 px-4 max-md:px-2 pb-4 max-md:pb-0 overflow-hidden min-h-0 min-w-0 relative ">
         {/* Mobile scrim backdrop – collapses open overlays on tap */}
-        {(!isLeftSidebarCollapsed || !isRightSidebarCollapsed) && (
-          <div
-            className="max-md:fixed max-md:inset-0 max-md:bg-black/40 max-md:z-30"
-            onClick={() => {
-              if (!isLeftSidebarCollapsed) setIsLeftSidebarCollapsed(true);
-              if (!isRightSidebarCollapsed) setIsRightSidebarCollapsed(true);
-            }}
-          />
-        )}
+        {!isFocusMode &&
+          (!isLeftSidebarCollapsed || !isRightSidebarCollapsed) && (
+            <div
+              className="max-md:fixed max-md:inset-0 max-md:bg-black/40 max-md:z-30"
+              onClick={() => {
+                if (!isLeftSidebarCollapsed) setIsLeftSidebarCollapsed(true);
+                if (!isRightSidebarCollapsed) setIsRightSidebarCollapsed(true);
+              }}
+            />
+          )}
         <div
           aria-hidden={isFocusMode}
           className={sidebarVariants({
@@ -207,10 +218,10 @@ export function ScriptModeEditorLayout({
         </div>
 
         {isLeftSidebarCollapsed && !isFocusMode && (
-          <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:fixed max-md:left-1 max-md:z-50 max-md:mt-0 max-md:-ml-0 max-md:bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))]">
+          <div className="min-h-0 shrink-0 mt-3 flex items-start -ml-4 max-md:hidden">
             <button
               type="button"
-              onClick={() => setIsLeftSidebarCollapsed(false)}
+              onClick={openLeftSidebar}
               className="size-12 rounded-lg border border-border bg-card/50 hover:bg-muted/80 transition-colors flex items-center justify-center"
               aria-label="Expand project files sidebar"
               title="Expand project files sidebar"
@@ -222,8 +233,19 @@ export function ScriptModeEditorLayout({
 
         <div className="flex-1 flex flex-col min-h-0 min-w-0 mt-3">
           {!isFocusMode && (
-            <div className="mb-2 flex gap-2">
-              <div className="flex-1 min-w-0">
+            <div className="mb-2 flex gap-2 items-center">
+              {isLeftSidebarCollapsed && (
+                <button
+                  type="button"
+                  onClick={openLeftSidebar}
+                  className="md:hidden h-12 w-9 shrink-0 rounded-lg border border-border/80 bg-card/55 backdrop-blur-sm flex items-center justify-center"
+                  aria-label="Expand project files sidebar"
+                  title="Expand project files sidebar"
+                >
+                  <ChevronRight className="size-4 text-muted-foreground" />
+                </button>
+              )}
+              <div className="flex-1 min-w-0 h-12 overflow-hidden">
                 <EditorTabBar
                   items={tabItems}
                   activeItemId={activeFileId}
@@ -248,6 +270,17 @@ export function ScriptModeEditorLayout({
                   />
                 </div>
               </div>
+              {isRightSidebarCollapsed && (
+                <button
+                  type="button"
+                  onClick={toggleRightSidebar}
+                  className="md:hidden h-12 w-9 shrink-0 rounded-lg border border-border/80 bg-card/55 backdrop-blur-sm flex items-center justify-center"
+                  aria-label="Expand reference sidebar"
+                  title="Expand reference sidebar"
+                >
+                  <ChevronLeft className="size-4 text-muted-foreground" />
+                </button>
+              )}
             </div>
           )}
 

--- a/apps/frontend/src/pages/ide/index.tsx
+++ b/apps/frontend/src/pages/ide/index.tsx
@@ -225,7 +225,7 @@ export function HomePageIDE() {
 
       {/* Main content area */}
       <div
-        className={`h-full overflow-hidden transition-all duration-300 max-md:ml-0 max-md:w-full max-md:pb-14 ${
+        className={`h-full overflow-hidden transition-all duration-300 max-md:ml-0 max-md:w-full max-md:pb-[calc(3.5rem+env(safe-area-inset-bottom,0px))] ${
           isSidebarCollapsed
             ? "md:ml-14 md:w-[calc(100%-3.5rem)]"
             : "md:ml-56 md:w-[calc(100%-14rem)]"

--- a/apps/frontend/src/pages/ide/index.tsx
+++ b/apps/frontend/src/pages/ide/index.tsx
@@ -225,10 +225,10 @@ export function HomePageIDE() {
 
       {/* Main content area */}
       <div
-        className={`h-full overflow-hidden transition-all duration-300 ${
+        className={`h-full overflow-hidden transition-all duration-300 max-md:ml-0 max-md:w-full max-md:pb-14 ${
           isSidebarCollapsed
-            ? "ml-14 w-[calc(100%-3.5rem)]"
-            : "ml-56 w-[calc(100%-14rem)]"
+            ? "md:ml-14 md:w-[calc(100%-3.5rem)]"
+            : "md:ml-56 md:w-[calc(100%-14rem)]"
         }`}
       >
         {mode === "write" ? (


### PR DESCRIPTION
Closes #267

## What changed
- **Mobile bottom nav bar**: Replaces the desktop sidebar on small screens with a touch-optimized bar (44px targets). Mode switcher, project selector, nav buttons, and a hamburger menu for dark mode/theme/settings/logout.
- **Responsive sidebar state**: New `useResponsiveSidebarState` hook — mobile defaults to collapsed, desktop uses persisted localStorage value. Handles resize transitions.
- **Tab bar mobile dropdown**: Editor tab bars consolidate into a portal-based hamburger dropdown with close buttons on small screens, avoiding overflow.
- **Overlay panels**: Sidebars and right panels become absolute overlays with scrim backdrops on mobile.
- **Compact action bars**: WritingGoalPill collapses to ring+percentage, StatusBar switches to icon-only buttons with an export confirm dialog, word count hidden on mobile.
- **Bottom-safe content**: `h-screen` changed to `h-full` in mode components so content respects the bottom nav bar padding.

## Verification
- ✅ Typecheck: passes
- ✅ Lint: clean (pre-existing warnings only)
- ✅ Tests: 872/872 pass (includes 11 new tests for `useResponsiveSidebarState`)
- ✅ @oracle review: 0 must-fix, 0 should-fix remaining

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile navigation improvements, including a fixed bottom bar, mobile tab dropdowns, and a hamburger menu popover.
  * ZIP export now prompts for confirmation before downloading.
* **Bug Fixes**
  * Sidebar collapse/expand state now correctly differentiates mobile vs. desktop and updates reliably when resizing.
  * Improved mobile dropdown dismissal (click outside / Escape) and better focus behavior.
* **UI/Content Updates**
  * Refined small-screen layouts across the IDE, including responsive sidebar panels, writing goal pill simplification, and status/prose controls visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->