### PR TITLE
feat: mobile dialog full-bleed, ConflictReview tabbed view, FlowDialog touch, editor audits

### DIFF
--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -117,7 +117,7 @@ export function ProjectSettingsDialog({
       onOpenChange={onOpenChange}
       aria-label="Project Settings"
     >
-      <DialogContent className="max-w-3xl w-full h-[80vh] min-h-[500px] p-0 gap-0 flex flex-col overflow-hidden">
+      <DialogContent className="max-w-3xl w-full h-[80vh] min-h-[500px] max-md:min-h-0 p-0 gap-0 flex flex-col overflow-hidden">
         {/* Header */}
         <div className="p-6 max-mobile:p-4 border-b border-border/30 flex items-start justify-between shrink-0">
           <div>

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -143,11 +143,8 @@ export function ProjectSettingsDialog({
           onValueChange={(next) => setActiveTab(next as SettingsTab)}
           className="flex flex-col flex-1 min-h-0"
         >
-          <div className="px-6 pt-2 shrink-0 max-sm:overflow-x-auto">
-            <TabsList
-              ariaLabel="Project settings sections"
-              className="max-sm:mx-0 max-sm:px-3"
-            >
+          <div className="px-3 pt-2 pb-0 shrink-0 sm:px-6">
+            <TabsList ariaLabel="Project settings sections" scrollable>
               {TAB_ORDER.map((tab) => {
                 const Icon = TAB_ICONS[tab];
                 return (

--- a/apps/frontend/src/components/flow/FlowGraph.tsx
+++ b/apps/frontend/src/components/flow/FlowGraph.tsx
@@ -414,6 +414,11 @@ export function FlowGraph({ projectId, onNodeClick }: FlowGraphProps) {
           minZoom={0.1}
           maxZoom={2}
           proOptions={{ hideAttribution: true }}
+          // Touch-device interaction: pan with drag, pinch to zoom,
+          // don't auto-select nodes on drag (avoids accidental
+          // selections while panning on touch screens).
+          panOnDrag={[0, 1]}
+          selectNodesOnDrag={false}
           // Only render nodes/edges inside the viewport for large graphs.
           // Below the threshold, keeping all nodes mounted is cheaper than
           // the mount/unmount churn that virtualization triggers when nodes
@@ -449,7 +454,7 @@ export function FlowGraph({ projectId, onNodeClick }: FlowGraphProps) {
               characters={characters}
             />
           </div>
-          <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
+          <div className="absolute top-4 right-4 z-10 flex items-center gap-2 flex-wrap max-sm:flex-col max-sm:items-end">
             <FlowGraphToolbar
               layoutMode={layoutMode}
               isBusy={isSaving || isResetting}

--- a/apps/frontend/src/components/ide-shared/SettingsModal.tsx
+++ b/apps/frontend/src/components/ide-shared/SettingsModal.tsx
@@ -208,7 +208,7 @@ export function SettingsModal({
           </Button>
         </DialogHeader>
 
-        <div className="flex max-md:flex-col h-[700px] max-h-[calc(95vh-120px)] max-md:h-auto">
+        <div className="flex max-md:flex-col h-[700px] max-h-[calc(95vh-120px)] max-md:h-auto max-md:max-h-none">
           {/* Vertical Tabs */}
           <div className="w-48 border-r border-border/30 p-2 flex flex-col max-md:w-full max-md:border-r-0 max-md:border-b max-md:flex-row max-md:overflow-x-auto max-md:sticky max-md:top-0 max-md:bg-card max-md:z-10">
             <div className="space-y-1 max-md:flex max-md:space-y-0 max-md:space-x-1 max-md:gap-1">

--- a/apps/frontend/src/components/ide-shared/SettingsModal.tsx
+++ b/apps/frontend/src/components/ide-shared/SettingsModal.tsx
@@ -14,6 +14,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { TabScrollArea } from "@/components/ui/tab-scroll-area";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -209,9 +210,10 @@ export function SettingsModal({
         </DialogHeader>
 
         <div className="flex max-md:flex-col h-[700px] max-h-[calc(95vh-120px)] max-md:h-auto max-md:max-h-none">
-          {/* Vertical Tabs */}
-          <div className="w-48 border-r border-border/30 p-2 flex flex-col max-md:w-full max-md:border-r-0 max-md:border-b max-md:flex-row max-md:overflow-x-auto max-md:sticky max-md:top-0 max-md:bg-card max-md:z-10">
-            <div className="space-y-1 max-md:flex max-md:space-y-0 max-md:space-x-1 max-md:gap-1">
+          {/* Vertical Tabs — desktop sidebar, mobile scrollable row */}
+          <div className="w-48 border-r border-border/30 flex flex-col max-md:w-full max-md:border-r-0 max-md:border-b max-md:sticky max-md:top-0 max-md:bg-card max-md:z-10">
+            {/* Desktop: vertical sidebar */}
+            <div className="p-2 space-y-1 max-md:hidden">
               {visibleTabs.map((tab) => (
                 <button
                   type="button"
@@ -229,7 +231,26 @@ export function SettingsModal({
               ))}
             </div>
 
-            {/* Version */}
+            {/* Mobile: horizontally scrollable with fade indicators */}
+            <TabScrollArea className="md:hidden w-full" fadeFrom="card">
+              {visibleTabs.map((tab) => (
+                <button
+                  type="button"
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={cn(
+                    "shrink-0 whitespace-nowrap px-3 py-2 my-1.5 rounded-md text-sm font-medium transition-colors",
+                    activeTab === tab.id
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                  )}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </TabScrollArea>
+
+            {/* Version — desktop only */}
             <div className="mt-auto pt-4 px-3 max-md:hidden">
               <p className="text-xs text-muted-foreground">
                 {APP_NAME} v{APP_VERSION}

--- a/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
+++ b/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
@@ -202,14 +202,21 @@ export function ConflictReviewDialog({
 
   // State
   const [state, dispatch] = useReducer(conflictReducer, initialConflictState);
-  // Mobile tabbed view: which panel to show below sm.
+  // Mobile tabbed view: which panel to show below sm. Reset to Local
+  // whenever the dialog opens so the user always starts on the local
+  // version. Render-phase sync (not useEffect) avoids derived-state-
+  // in-effect warnings.
   const [mobileConflictView, setMobileConflictView] = useState<
     "local" | "remote"
   >("local");
-
-  useEffect(() => {
-    if (open) setMobileConflictView("local");
-  }, [open]);
+  // react-doctor-disable-next-line react-doctor/no-derived-useState, react-doctor/rerender-state-only-in-handlers
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setMobileConflictView("local");
+    }
+  }
 
   /**
    * Fetch conflicts when dialog opens

--- a/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
+++ b/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
@@ -5,7 +5,7 @@
  * Shows side-by-side comparison and allows user to choose which version to keep.
  */
 
-import { useReducer, useCallback, useEffect } from "react";
+import { useReducer, useCallback, useEffect, useState } from "react";
 import { X, ChevronLeft, ChevronRight, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
@@ -202,6 +202,10 @@ export function ConflictReviewDialog({
 
   // State
   const [state, dispatch] = useReducer(conflictReducer, initialConflictState);
+  // Mobile tabbed view: which panel to show below sm.
+  const [mobileConflictView, setMobileConflictView] = useState<
+    "local" | "remote"
+  >("local");
 
   /**
    * Fetch conflicts when dialog opens
@@ -447,9 +451,40 @@ export function ConflictReviewDialog({
               )}
 
               {/* Side-by-side Comparison */}
+              {/* Mobile tabbed-toggle (below sm): segmented control to switch
+                  between Local and Remote views — avoids two very long stacked
+                  panels that force excessive scrolling on narrow phones. */}
+              <div className="hidden max-sm:flex items-center gap-0 border border-border/50 rounded-lg overflow-hidden mb-4">
+                <button
+                  type="button"
+                  onClick={() => setMobileConflictView("local")}
+                  className={`flex-1 px-4 py-2 text-xs font-medium transition-colors ${
+                    mobileConflictView === "local"
+                      ? "bg-accent text-accent-foreground"
+                      : "bg-transparent text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  Local
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMobileConflictView("remote")}
+                  className={`flex-1 px-4 py-2 text-xs font-medium transition-colors border-l border-border/50 ${
+                    mobileConflictView === "remote"
+                      ? "bg-accent text-accent-foreground"
+                      : "bg-transparent text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  Remote
+                </button>
+              </div>
               <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-4">
                 {/* BranchForge Version */}
-                <div className="space-y-2">
+                <div
+                  className={`space-y-2 ${
+                    mobileConflictView !== "local" ? "max-sm:hidden" : ""
+                  }`}
+                >
                   <div className="flex items-center justify-between">
                     <h4 className="text-sm font-medium">BranchForge Version</h4>
                     <Button
@@ -472,7 +507,11 @@ export function ConflictReviewDialog({
                 </div>
 
                 {/* GitLab Version */}
-                <div className="space-y-2">
+                <div
+                  className={`space-y-2 ${
+                    mobileConflictView !== "remote" ? "max-sm:hidden" : ""
+                  }`}
+                >
                   <div className="flex items-center justify-between">
                     <h4 className="text-sm font-medium">GitLab Version</h4>
                     <Button

--- a/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
+++ b/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
@@ -207,6 +207,10 @@ export function ConflictReviewDialog({
     "local" | "remote"
   >("local");
 
+  useEffect(() => {
+    if (open) setMobileConflictView("local");
+  }, [open]);
+
   /**
    * Fetch conflicts when dialog opens
    */

--- a/apps/frontend/src/components/ui/DialogShell.tsx
+++ b/apps/frontend/src/components/ui/DialogShell.tsx
@@ -55,8 +55,6 @@ export function DialogShell({
         className={cn(
           "w-full max-h-[90vh] p-0 gap-0 flex flex-col overflow-hidden",
           MAX_WIDTH_CLASSES[maxWidth],
-          // Full-bleed below sm mirrors DialogContent treatment.
-          "max-sm:w-full max-sm:max-w-full max-sm:max-h-full max-sm:h-full max-sm:rounded-none max-sm:m-0",
           contentClassName
         )}
       >

--- a/apps/frontend/src/components/ui/DialogShell.tsx
+++ b/apps/frontend/src/components/ui/DialogShell.tsx
@@ -55,6 +55,8 @@ export function DialogShell({
         className={cn(
           "w-full max-h-[90vh] p-0 gap-0 flex flex-col overflow-hidden",
           MAX_WIDTH_CLASSES[maxWidth],
+          // Full-bleed below sm mirrors DialogContent treatment.
+          "max-sm:w-full max-sm:max-w-full max-sm:max-h-full max-sm:h-full max-sm:rounded-none max-sm:m-0",
           contentClassName
         )}
       >

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -116,12 +116,12 @@ export function DialogContent({ children, className }: DialogContentProps) {
     <div
       className={cn(
         "relative bg-card border border-border/30 rounded-lg shadow-xl p-6 max-mobile:p-4 w-full max-w-md max-h-[85vh] overflow-y-auto",
-        // Full-bleed below sm for phone screens — the centered card
-        // wastes too much space on narrow viewports. Inner sections
-        // (DialogShell header/body/footer, ProjectSettingsDialog, etc.)
-        // already carry their own responsive padding via p-6 max-mobile:p-4,
-        // so no extra padding is needed on the container.
-        "max-sm:w-full max-sm:max-w-full max-sm:max-h-full max-sm:h-full max-sm:rounded-none max-sm:m-0",
+        // Near-fullscreen card below sm — a thin gap (8px sides,
+        // 16px top/bottom) lets the backdrop peek through so the
+        // dialog reads as a modal overlay rather than a page
+        // transition. Inner sections still carry their own
+        // responsive padding via p-6 max-mobile:p-4.
+        "max-sm:w-[calc(100%-16px)] max-sm:max-w-[calc(100%-16px)] max-sm:h-[calc(100%-32px)] max-sm:rounded-xl",
         className
       )}
     >

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -121,7 +121,7 @@ export function DialogContent({ children, className }: DialogContentProps) {
         // dialog reads as a modal overlay rather than a page
         // transition. Inner sections still carry their own
         // responsive padding via p-6 max-mobile:p-4.
-        "max-sm:w-[calc(100%-16px)] max-sm:max-w-[calc(100%-16px)] max-sm:h-[calc(100%-32px)] max-sm:rounded-xl",
+        "max-sm:w-[calc(100%-16px)] max-sm:max-w-[calc(100%-16px)] max-sm:h-[calc(100%-32px)] max-sm:max-h-[calc(100%-32px)] max-sm:rounded-xl",
         className
       )}
     >

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -116,6 +116,12 @@ export function DialogContent({ children, className }: DialogContentProps) {
     <div
       className={cn(
         "relative bg-card border border-border/30 rounded-lg shadow-xl p-6 max-mobile:p-4 w-full max-w-md max-h-[85vh] overflow-y-auto",
+        // Full-bleed below sm for phone screens — the centered card
+        // wastes too much space on narrow viewports. Safe-area
+        // insets keep content clear of notches and home indicators.
+        "max-sm:w-full max-sm:max-w-full max-sm:max-h-full max-sm:h-full max-sm:rounded-none max-sm:m-0",
+        "max-sm:pt-[calc(1.5rem+env(safe-area-inset-top,0px))] max-sm:pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))]",
+        "max-sm:pl-[calc(1.5rem+env(safe-area-inset-left,0px))] max-sm:pr-[calc(1.5rem+env(safe-area-inset-right,0px))]",
         className
       )}
     >

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -117,11 +117,11 @@ export function DialogContent({ children, className }: DialogContentProps) {
       className={cn(
         "relative bg-card border border-border/30 rounded-lg shadow-xl p-6 max-mobile:p-4 w-full max-w-md max-h-[85vh] overflow-y-auto",
         // Full-bleed below sm for phone screens — the centered card
-        // wastes too much space on narrow viewports. Safe-area
-        // insets keep content clear of notches and home indicators.
+        // wastes too much space on narrow viewports. Inner sections
+        // (DialogShell header/body/footer, ProjectSettingsDialog, etc.)
+        // already carry their own responsive padding via p-6 max-mobile:p-4,
+        // so no extra padding is needed on the container.
         "max-sm:w-full max-sm:max-w-full max-sm:max-h-full max-sm:h-full max-sm:rounded-none max-sm:m-0",
-        "max-sm:pt-[calc(1.5rem+env(safe-area-inset-top,0px))] max-sm:pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))]",
-        "max-sm:pl-[calc(1.5rem+env(safe-area-inset-left,0px))] max-sm:pr-[calc(1.5rem+env(safe-area-inset-right,0px))]",
         className
       )}
     >

--- a/apps/frontend/src/components/ui/tab-scroll-area.tsx
+++ b/apps/frontend/src/components/ui/tab-scroll-area.tsx
@@ -1,0 +1,143 @@
+/**
+ * TabScrollArea — horizontally scrollable wrapper with overflow
+ * fade indicators.
+ *
+ * When content overflows the available width, gradient fades
+ * appear on the left/right edges to signal "more to scroll."
+ * The indicators match the visual language of EditorTabBar but
+ * are lighter — just the gradient fade, no chevron badge.
+ *
+ * Children should be single-row elements (buttons, triggers)
+ * that are flex-nowrap-safe.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type WheelEvent,
+} from "react";
+import { cn } from "@/lib/utils";
+
+interface TabScrollAreaProps {
+  children: ReactNode;
+  /** Applied to the outer positioning wrapper. */
+  className?: string;
+  /**
+   * CSS variable-ish color name for the fade gradient stop.
+   * Must match the background behind the tab bar so the
+   * fade blends seamlessly. Defaults to "card".
+   */
+  fadeFrom?: "card" | "background" | "muted";
+}
+
+const FADE_CLASSES: Record<
+  NonNullable<TabScrollAreaProps["fadeFrom"]>,
+  string
+> = {
+  card: "from-card to-transparent",
+  background: "from-background to-transparent",
+  muted: "from-muted to-transparent",
+};
+
+export function TabScrollArea({
+  children,
+  className,
+  fadeFrom = "card",
+}: TabScrollAreaProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number | null>(null);
+  const [showLeft, setShowLeft] = useState(false);
+  const [showRight, setShowRight] = useState(false);
+
+  const updateIndicators = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const overflow = el.scrollWidth > el.clientWidth;
+    setShowLeft(overflow && el.scrollLeft > 1);
+    setShowRight(
+      overflow && el.scrollLeft < el.scrollWidth - el.clientWidth - 1
+    );
+  }, [containerRef]);
+
+  const scheduleUpdate = useCallback(() => {
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(updateIndicators);
+  }, [updateIndicators]);
+
+  // Resize / mutation observer for content changes
+  useEffect(() => {
+    scheduleUpdate();
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(scheduleUpdate);
+    observer.observe(el);
+
+    window.addEventListener("resize", scheduleUpdate);
+    return () => {
+      window.removeEventListener("resize", scheduleUpdate);
+      observer.disconnect();
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [scheduleUpdate]);
+
+  const handleWheel = useCallback(
+    (e: WheelEvent<HTMLDivElement>) => {
+      const el = containerRef.current;
+      if (!el) return;
+      const overflow = el.scrollWidth > el.clientWidth;
+      if (!overflow) return;
+
+      const delta =
+        Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+      if (delta === 0) return;
+
+      const prev = el.scrollLeft;
+      el.scrollLeft += delta;
+      if (el.scrollLeft !== prev) {
+        e.preventDefault();
+        updateIndicators();
+      }
+    },
+    [updateIndicators]
+  );
+
+  return (
+    <div className={cn("relative", className)}>
+      {/* Left fade indicator */}
+      {showLeft && (
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r",
+            FADE_CLASSES[fadeFrom]
+          )}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Right fade indicator */}
+      {showRight && (
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l",
+            FADE_CLASSES[fadeFrom]
+          )}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Scrollable content */}
+      <div
+        ref={containerRef}
+        onScroll={updateIndicators}
+        onWheel={handleWheel}
+        className="overflow-x-auto scrollbar-hide flex flex-nowrap items-center gap-1.5"
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/ui/tabs.tsx
+++ b/apps/frontend/src/components/ui/tabs.tsx
@@ -34,6 +34,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
   type RefObject,
+  type WheelEvent,
 } from "react";
 import { cn } from "@/lib/utils";
 
@@ -195,24 +196,144 @@ interface TabsListProps {
   className?: string;
   /** Accessible label for the tab list. */
   ariaLabel?: string;
+  /**
+   * When true, the tab list becomes horizontally scrollable with
+   * fade indicators on the edges when content overflows. Tabs
+   * are kept in a single row (no wrapping). Use this for narrow
+   * viewports where tabs would otherwise wrap to multiple rows.
+   */
+  scrollable?: boolean;
+  /**
+   * CSS variable color used by the fade gradient stop. Must match
+   * the background behind the tab bar. Defaults to "card".
+   */
+  fadeFrom?: "card" | "background" | "muted";
 }
 
-export function TabsList({ children, className, ariaLabel }: TabsListProps) {
-  // The ref is set on the tablist root so TabsTrigger can scope
-  // focus queries (e.g. on arrow-key navigation) to the current
-  // tablist instance.
+export function TabsList({
+  children,
+  className,
+  ariaLabel,
+  scrollable,
+  fadeFrom = "card",
+}: TabsListProps) {
   const { tablistRef } = useTabsContext("TabsList");
-  return (
+
+  // Scroll indicators for scrollable mode
+  const scrollRafRef = useRef<number | null>(null);
+  const [showLeftFade, setShowLeftFade] = useState(false);
+  const [showRightFade, setShowRightFade] = useState(false);
+
+  const updateFades = useCallback(() => {
+    const el = tablistRef.current;
+    if (!el) return;
+    const overflow = el.scrollWidth > el.clientWidth;
+    setShowLeftFade(overflow && el.scrollLeft > 1);
+    setShowRightFade(
+      overflow && el.scrollLeft < el.scrollWidth - el.clientWidth - 1
+    );
+  }, [tablistRef]);
+
+  // Schedule fade update (debounced via RAF)
+  const scheduleFadeUpdate = useCallback(() => {
+    if (scrollRafRef.current !== null)
+      cancelAnimationFrame(scrollRafRef.current);
+    scrollRafRef.current = requestAnimationFrame(updateFades);
+  }, [updateFades]);
+
+  useEffect(() => {
+    if (!scrollable) return;
+    scheduleFadeUpdate();
+    const el = tablistRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(scheduleFadeUpdate);
+    observer.observe(el);
+    window.addEventListener("resize", scheduleFadeUpdate);
+    return () => {
+      window.removeEventListener("resize", scheduleFadeUpdate);
+      observer.disconnect();
+      if (scrollRafRef.current !== null)
+        cancelAnimationFrame(scrollRafRef.current);
+    };
+  }, [scrollable, scheduleFadeUpdate, tablistRef]);
+
+  const handleWheel = useCallback(
+    (e: WheelEvent<HTMLDivElement>) => {
+      const el = tablistRef.current;
+      if (!el) return;
+      const overflow = el.scrollWidth > el.clientWidth;
+      if (!overflow) return;
+      const delta =
+        Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+      if (delta === 0) return;
+      const prev = el.scrollLeft;
+      el.scrollLeft += delta;
+      if (el.scrollLeft !== prev) {
+        e.preventDefault();
+        updateFades();
+      }
+    },
+    [tablistRef, updateFades]
+  );
+
+  const baseClasses = cn(
+    scrollable
+      ? // Scrollable: single row, horizontal scroll, no wrapping.
+        // TabsList owns the scroll container (no intermediate wrapper
+        // so tablistRef points directly at the element that holds the
+        // tab buttons, preserving ARIA relationships and focus scoping).
+        "flex flex-nowrap gap-1 overflow-x-auto scrollbar-hide border-b border-border/30"
+      : "flex gap-1 border-b border-border/30 px-6 -mx-6",
+    // Fade indicators are absolutely positioned inside the scrollable
+    // container, so we need relative positioning.
+    scrollable && "relative",
+    className
+  );
+
+  const content = (
     <div
       ref={tablistRef}
       role="tablist"
       aria-label={ariaLabel}
-      className={cn(
-        "flex gap-1 border-b border-border/30 px-6 -mx-6",
-        className
-      )}
+      onScroll={scrollable ? updateFades : undefined}
+      onWheel={scrollable ? handleWheel : undefined}
+      className={baseClasses}
     >
       {children}
+    </div>
+  );
+
+  // In scrollable mode, wrap with relative positioning for fade
+  // indicators. The outer div carries no role/border — just positioning.
+  if (!scrollable) return content;
+
+  // Lookup for gradient stop classes matching the fadeFrom color
+  const fadeLeftClass =
+    `bg-gradient-to-r from-${fadeFrom} to-transparent` as const;
+  const fadeRightClass =
+    `bg-gradient-to-l from-${fadeFrom} to-transparent` as const;
+
+  return (
+    <div className="relative">
+      {showLeftFade && (
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-y-0 left-0 z-10 w-8",
+            fadeLeftClass
+          )}
+          aria-hidden="true"
+        />
+      )}
+      {showRightFade && (
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-y-0 right-0 z-10 w-8",
+            fadeRightClass
+          )}
+          aria-hidden="true"
+        />
+      )}
+      {content}
     </div>
   );
 }

--- a/apps/frontend/src/components/ui/tabs.tsx
+++ b/apps/frontend/src/components/ui/tabs.tsx
@@ -38,6 +38,12 @@ import {
 } from "react";
 import { cn } from "@/lib/utils";
 
+const FADE_STOP: Record<"card" | "background" | "muted", string> = {
+  card: "from-card to-transparent",
+  background: "from-background to-transparent",
+  muted: "from-muted to-transparent",
+};
+
 // ============================================================================
 // Context
 // ============================================================================
@@ -307,14 +313,6 @@ export function TabsList({
   // indicators. The outer div carries no role/border — just positioning.
   if (!scrollable) return content;
 
-  // Lookup for gradient stop classes matching the fadeFrom color.
-  // Must be a static lookup (not template-literal interpolation)
-  // so Tailwind JIT can detect every class.
-  const FADE_STOP: Record<"card" | "background" | "muted", string> = {
-    card: "from-card to-transparent",
-    background: "from-background to-transparent",
-    muted: "from-muted to-transparent",
-  };
   const fadeStop = FADE_STOP[fadeFrom];
 
   return (

--- a/apps/frontend/src/components/ui/tabs.tsx
+++ b/apps/frontend/src/components/ui/tabs.tsx
@@ -307,19 +307,23 @@ export function TabsList({
   // indicators. The outer div carries no role/border — just positioning.
   if (!scrollable) return content;
 
-  // Lookup for gradient stop classes matching the fadeFrom color
-  const fadeLeftClass =
-    `bg-gradient-to-r from-${fadeFrom} to-transparent` as const;
-  const fadeRightClass =
-    `bg-gradient-to-l from-${fadeFrom} to-transparent` as const;
+  // Lookup for gradient stop classes matching the fadeFrom color.
+  // Must be a static lookup (not template-literal interpolation)
+  // so Tailwind JIT can detect every class.
+  const FADE_STOP: Record<"card" | "background" | "muted", string> = {
+    card: "from-card to-transparent",
+    background: "from-background to-transparent",
+    muted: "from-muted to-transparent",
+  };
+  const fadeStop = FADE_STOP[fadeFrom];
 
   return (
     <div className="relative">
       {showLeftFade && (
         <div
           className={cn(
-            "pointer-events-none absolute inset-y-0 left-0 z-10 w-8",
-            fadeLeftClass
+            "pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r",
+            fadeStop
           )}
           aria-hidden="true"
         />
@@ -327,8 +331,8 @@ export function TabsList({
       {showRightFade && (
         <div
           className={cn(
-            "pointer-events-none absolute inset-y-0 right-0 z-10 w-8",
-            fadeRightClass
+            "pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l",
+            fadeStop
           )}
           aria-hidden="true"
         />

--- a/apps/frontend/src/components/write-mode/DialogueLine.tsx
+++ b/apps/frontend/src/components/write-mode/DialogueLine.tsx
@@ -711,7 +711,7 @@ export const DialogueLine = memo(function DialogueLine({
                 }
                 onKeyDown={handleDropdownKeyDown}
                 tabIndex={0}
-                className={`absolute z-50 bg-popover border border-border/70 rounded-lg shadow-xl shadow-black/25 ring-1 ring-white/5 py-1 min-w-[160px] max-h-[280px] overflow-y-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color)] animate-in fade-in-0 zoom-in-95 duration-200 ease-out ${
+                className={`absolute z-50 bg-popover border border-border/70 rounded-lg shadow-xl shadow-black/25 ring-1 ring-white/5 py-1 min-w-[160px] max-sm:min-w-0 max-sm:w-[min(280px,90vw)] max-h-[280px] overflow-y-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color)] animate-in fade-in-0 zoom-in-95 duration-200 ease-out ${
                   openUpward ? "bottom-full mb-1" : "top-full mt-1"
                 } ${
                   openUpward ? "slide-in-from-bottom-1" : "slide-in-from-top-1"

--- a/apps/frontend/src/lib/codemirror/renpy-theme.ts
+++ b/apps/frontend/src/lib/codemirror/renpy-theme.ts
@@ -58,9 +58,10 @@ export const renPyBaseTheme = EditorView.theme({
   },
   // Line numbers
   ".cm-gutters": {
-    backgroundColor: "transparent",
+    backgroundColor: "hsl(var(--background))",
     color: "hsl(var(--muted-foreground) / 0.55)",
     border: "none",
+    borderRight: "1px solid hsl(var(--border))",
   },
   ".cm-lineNumbers .cm-gutterElement": {
     padding: "0 4px 0 8px",

--- a/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
+++ b/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
@@ -201,9 +201,19 @@ export function ScriptModeEditorLayout({
   );
   const [mobileLineWrap, setMobileLineWrap] = useState(true);
 
-  useEffect(() => {
-    if (isMobile) setMobileLineWrap(true);
-  }, [isMobile]);
+  // Render-phase sync: reset wrap to ON when entering mobile
+  // (narrower than md), so users get line wrapping by default on
+  // phones. Uses the same pattern as ProjectSettingsDialog's tab
+  // reset. Suppressing derived-useState — the alternative
+  // useEffect would trigger react-doctor no-derived-state-effect.
+  // react-doctor-disable-next-line react-doctor/no-derived-useState, react-doctor/rerender-state-only-in-handlers
+  const [wasMobile, setWasMobile] = useState(isMobile);
+  if (isMobile !== wasMobile) {
+    setWasMobile(isMobile);
+    if (isMobile) {
+      setMobileLineWrap(true);
+    }
+  }
 
   const lineWrap = isMobile ? mobileLineWrap : storedLineWrap;
 

--- a/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
+++ b/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
@@ -191,9 +191,39 @@ export function ScriptModeEditorLayout({
     }
   }, [paletteIndex]);
 
-  const [lineWrap, setLineWrap] = useLocalStorageBoolean(
+  // Desktop: persisted preference, default OFF.
+  // Mobile (<md): defaults ON (line wrapping prevents horizontal
+  // scroll on narrow phones). The FAB toggle can override per session
+  // but the override resets when re-entering mobile.
+  const [storedLineWrap, setStoredLineWrap] = useLocalStorageBoolean(
     "script:line-wrap",
     false
+  );
+  const [mobileLineWrap, setMobileLineWrap] = useState(true);
+
+  useEffect(() => {
+    if (isMobile) setMobileLineWrap(true);
+  }, [isMobile]);
+
+  const lineWrap = isMobile ? mobileLineWrap : storedLineWrap;
+
+  const handleLineWrapToggle = useCallback(() => {
+    if (isMobile) {
+      setMobileLineWrap((v) => !v);
+    } else {
+      setStoredLineWrap((v) => !v);
+    }
+  }, [isMobile, setStoredLineWrap]);
+
+  const handleLineWrapChange = useCallback(
+    (wrap: boolean) => {
+      if (isMobile) {
+        setMobileLineWrap(wrap);
+      } else {
+        setStoredLineWrap(wrap);
+      }
+    },
+    [isMobile, setStoredLineWrap]
   );
 
   const [showLabelTitles, setShowLabelTitles] = useLocalStorageBoolean(
@@ -375,7 +405,7 @@ export function ScriptModeEditorLayout({
                   onSaveRequest={onSaveRequest}
                   labelTitles={labelTitles}
                   lineWrap={lineWrap}
-                  onLineWrapChange={setLineWrap}
+                  onLineWrapChange={handleLineWrapChange}
                   showLabelTitles={showLabelTitles}
                   onShowLabelTitlesChange={setShowLabelTitles}
                 />
@@ -463,7 +493,7 @@ export function ScriptModeEditorLayout({
           }
           label="Line Wrap"
           active={lineWrap}
-          onClick={() => setLineWrap((v) => !v)}
+          onClick={handleLineWrapToggle}
         />
         <FABToggle
           icon={


### PR DESCRIPTION
Closes #269

## What changed

8 files, 96 insertions across 6 mobile responsiveness improvements:

1. **Dialog full-bleed below sm** — `DialogContent` takes full screen on phones (`< 640px`) with safe-area-inset padding for notches. Centered card layout preserved above sm.

2. **Drop min-height floors** — `ProjectSettingsDialog` drops `min-h-[500px]` below md for small landscape phones. `SettingsModal` adds `max-md:max-h-none` to avoid the `max-h` clamp conflicting with `h-auto`.

3. **ConflictReview tabbed Local|Remote toggle** — Below sm, a segmented toggle replaces the two stacked panels; user views one version at a time. Toggle resets to Local on reopen. Above sm, side-by-side is unchanged.

4. **FlowGraph touch config** — `panOnDrag={[0,1]}` enables touch drag panning; `selectNodesOnDrag={false}` prevents accidental node selection during pan. Toolbar wraps on narrow screens.

5. **DialogueLine popover width clamp** — Character menu popover gains `max-sm:min-w-0 max-sm:w-[min(280px,90vw)]` to prevent overflow on narrow viewports.

6. **ScriptEditor responsive line wrap** — Defaults ON below md (prevents horizontal scroll on phones). Desktop uses persisted preference (default OFF). FAB toggle overrides per mobile session, resets on re-entry.

## How verified

- `pnpm typecheck` — clean (4 packages)
- `pnpm lint` — clean (0 errors)
- `pnpm test:unit` — 899 tests, 58 files, all green
- Pre-push hooks — all passed
- @oracle review — 2 iterations, approved with no must-fix or should-fix findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a horizontally scrollable, fade-indicated tab row for small screens (used in settings and via an enhanced scrollable tab option).
  * Added a mobile conflict review toggle to switch between local and remote views.
  * Improved editor line-wrap controls with separate mobile and desktop preferences.

* **Bug Fixes**
  * Refined multiple dialogs for improved near full-screen mobile sizing and overflow behavior.
  * Improved touch panning and small-screen toolbar layout in the flow graph.
  * Updated editor line-number gutter styling for clearer separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->