### PR TITLE
fix: mobile dialog layout consistency, pair groups dialog extraction

### DIFF
--- a/apps/frontend/src/components/CharacterDialog.tsx
+++ b/apps/frontend/src/components/CharacterDialog.tsx
@@ -50,7 +50,7 @@ export function CharacterDialog({
     >
       <DialogContent className="max-w-3xl w-full max-h-[90vh] p-0 gap-0 flex flex-col">
         {/* Header */}
-        <div className="p-6 max-mobile:p-4 border-b border-border/30 flex items-start justify-between">
+        <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between">
           <div>
             <h2 className="text-lg font-medium">Character Management</h2>
             <p className="text-sm text-muted-foreground mt-1">
@@ -69,7 +69,7 @@ export function CharacterDialog({
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6 max-mobile:p-4">
+        <div className="flex-1 overflow-y-auto p-6 max-sm:p-4">
           <CharacterSettingsContent
             projectId={projectId}
             duoEndingEnabled={currentProject?.duoEndingEnabled ?? false}
@@ -78,7 +78,7 @@ export function CharacterDialog({
         </div>
 
         {/* Footer */}
-        <div className="p-6 max-mobile:p-4 border-t border-border/30 flex justify-end">
+        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end">
           <Button
             type="button"
             variant="outline"

--- a/apps/frontend/src/components/CharacterDialog.tsx
+++ b/apps/frontend/src/components/CharacterDialog.tsx
@@ -15,8 +15,6 @@ import { X } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { CharacterSettingsContent } from "@/components/CharacterSettingsContent";
-import { useProject } from "@/hooks/useProject";
-import { useToast } from "@/contexts/ToastContext";
 
 interface CharacterDialogProps {
   open: boolean;
@@ -29,17 +27,6 @@ export function CharacterDialog({
   onOpenChange,
   projectId,
 }: CharacterDialogProps) {
-  const { currentProject, updateProject } = useProject();
-  const { error: showErrorToast } = useToast();
-
-  const handleToggleDuoEnding = async (enabled: boolean) => {
-    try {
-      await updateProject(projectId, { duoEndingEnabled: enabled });
-    } catch {
-      showErrorToast("Failed to update duo ending setting");
-    }
-  };
-
   return (
     <Dialog
       open={open}
@@ -48,9 +35,9 @@ export function CharacterDialog({
         else onOpenChange(nextOpen);
       }}
     >
-      <DialogContent className="max-w-3xl w-full max-h-[90vh] p-0 gap-0 flex flex-col">
+      <DialogContent className="max-w-3xl w-full max-h-[90vh] p-0 gap-0 flex flex-col overflow-hidden">
         {/* Header */}
-        <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between">
+        <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between shrink-0">
           <div>
             <h2 className="text-lg font-medium">Character Management</h2>
             <p className="text-sm text-muted-foreground mt-1">
@@ -70,15 +57,11 @@ export function CharacterDialog({
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-6 max-sm:p-4">
-          <CharacterSettingsContent
-            projectId={projectId}
-            duoEndingEnabled={currentProject?.duoEndingEnabled ?? false}
-            onToggleDuoEnding={handleToggleDuoEnding}
-          />
+          <CharacterSettingsContent projectId={projectId} />
         </div>
 
         {/* Footer */}
-        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end">
+        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end shrink-0">
           <Button
             type="button"
             variant="outline"

--- a/apps/frontend/src/components/CharacterEditDialog.tsx
+++ b/apps/frontend/src/components/CharacterEditDialog.tsx
@@ -10,7 +10,6 @@ import { Loader2, Upload, BookOpen, Heart } from "lucide-react";
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
@@ -366,8 +365,9 @@ export function CharacterEditDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="max-w-2xl w-full max-h-[90vh] p-0 gap-0 flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="p-6 max-sm:p-4 border-b border-border/30 shrink-0">
           <DialogTitle>
             {isEditMode ? "Edit Character" : "Add Character"}
           </DialogTitle>
@@ -376,265 +376,272 @@ export function CharacterEditDialog({
               ? "Update character details and avatar."
               : "Create a new character for your project."}
           </DialogDescription>
-        </DialogHeader>
+        </div>
 
-        <div className="space-y-4 mt-4">
-          {/* Name + Display Name */}
-          <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
-            <div className="space-y-1">
-              <Label htmlFor="edit-char-name" className="text-xs">
-                Name *
-              </Label>
-              <Input
-                id="edit-char-name"
-                type="text"
-                placeholder="Eileen"
-                value={form.name}
-                onChange={(e) => handleFieldChange("name", e.target.value)}
-                disabled={isSaving}
-              />
-              {form.nameError && (
-                <p className="text-xs text-destructive">{form.nameError}</p>
-              )}
-            </div>
-
-            <div className="space-y-1">
-              <Label htmlFor="edit-char-display-name" className="text-xs">
-                Display Name *
-              </Label>
-              <Input
-                id="edit-char-display-name"
-                type="text"
-                placeholder="Eileen"
-                value={form.displayName}
-                onChange={(e) =>
-                  handleFieldChange("displayName", e.target.value)
-                }
-                disabled={isSaving}
-              />
-              {form.displayNameError && (
-                <p className="text-xs text-destructive">
-                  {form.displayNameError}
-                </p>
-              )}
-            </div>
-          </div>
-
-          {/* Ren'Py Tag + Color */}
-          <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
-            <div className="space-y-1">
-              <Label htmlFor="edit-char-tag" className="text-xs">
-                Ren'Py Tag *
-              </Label>
-              <Input
-                id="edit-char-tag"
-                type="text"
-                placeholder="a"
-                value={form.renpyTag}
-                onChange={(e) => handleFieldChange("renpyTag", e.target.value)}
-                disabled={isSaving || isEditMode}
-              />
-              <p className="text-xs text-muted-foreground">
-                Unique identifier (e.g., "a", "lucas")
-              </p>
-              {form.renpyTagError && (
-                <p className="text-xs text-destructive">{form.renpyTagError}</p>
-              )}
-            </div>
-
-            <div className="space-y-1">
-              <Label htmlFor="edit-char-color" className="text-xs">
-                Color *
-              </Label>
-              <div className="flex gap-2">
+        {/* Scrollable form content */}
+        <div className="flex-1 overflow-y-auto p-6 max-sm:p-4">
+          <div className="space-y-4">
+            {/* Name + Display Name */}
+            <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="edit-char-name" className="text-xs">
+                  Name *
+                </Label>
                 <Input
-                  id="edit-char-color"
+                  id="edit-char-name"
                   type="text"
-                  placeholder="#FF6B6B"
-                  value={form.color}
-                  onChange={(e) => handleFieldChange("color", e.target.value)}
+                  placeholder="Eileen"
+                  value={form.name}
+                  onChange={(e) => handleFieldChange("name", e.target.value)}
                   disabled={isSaving}
                 />
-                <Input
-                  type="color"
-                  value={form.color}
-                  onChange={(e) => handleFieldChange("color", e.target.value)}
-                  disabled={isSaving}
-                  className="w-12 h-9 p-0.5"
-                />
-              </div>
-              {form.colorError && (
-                <p className="text-xs text-destructive">{form.colorError}</p>
-              )}
-            </div>
-          </div>
-
-          {/* Avatar Upload */}
-          <div className="space-y-2">
-            <Label htmlFor="edit-char-avatar" className="text-xs">
-              Avatar Image
-            </Label>
-            <div className="flex items-center gap-4">
-              <div className="relative size-20 flex-shrink-0">
-                {form.avatarPreview || form.avatarUrl ? (
-                  <img
-                    src={form.avatarPreview || form.avatarUrl}
-                    alt="Avatar preview"
-                    className="w-full h-full rounded-full object-cover border-4"
-                    style={{ borderColor: form.color }}
-                  />
-                ) : (
-                  <div
-                    className="w-full h-full rounded-full border-4 border-dashed flex items-center justify-center"
-                    style={{ borderColor: form.color }}
-                  >
-                    <Upload className="size-6 text-muted-foreground" />
-                  </div>
+                {form.nameError && (
+                  <p className="text-xs text-destructive">{form.nameError}</p>
                 )}
               </div>
 
-              <div className="flex-1 space-y-2">
+              <div className="space-y-1">
+                <Label htmlFor="edit-char-display-name" className="text-xs">
+                  Display Name *
+                </Label>
                 <Input
-                  id="edit-char-avatar"
-                  type="file"
-                  accept="image/png,image/jpeg,image/webp,image/gif"
-                  onChange={handleAvatarSelect}
+                  id="edit-char-display-name"
+                  type="text"
+                  placeholder="Eileen"
+                  value={form.displayName}
+                  onChange={(e) =>
+                    handleFieldChange("displayName", e.target.value)
+                  }
                   disabled={isSaving}
-                  className="text-sm"
-                  ref={fileInputRef}
+                />
+                {form.displayNameError && (
+                  <p className="text-xs text-destructive">
+                    {form.displayNameError}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {/* Ren'Py Tag + Color */}
+            <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="edit-char-tag" className="text-xs">
+                  Ren'Py Tag *
+                </Label>
+                <Input
+                  id="edit-char-tag"
+                  type="text"
+                  placeholder="a"
+                  value={form.renpyTag}
+                  onChange={(e) =>
+                    handleFieldChange("renpyTag", e.target.value)
+                  }
+                  disabled={isSaving || isEditMode}
                 />
                 <p className="text-xs text-muted-foreground">
-                  PNG, JPEG, WebP, or GIF (max {AVATAR_MAX_SIZE_MB}MB)
+                  Unique identifier (e.g., "a", "lucas")
                 </p>
-                {(form.avatarPreview || form.avatarUrl) && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleAvatarRemove}
+                {form.renpyTagError && (
+                  <p className="text-xs text-destructive">
+                    {form.renpyTagError}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1">
+                <Label htmlFor="edit-char-color" className="text-xs">
+                  Color *
+                </Label>
+                <div className="flex gap-2">
+                  <Input
+                    id="edit-char-color"
+                    type="text"
+                    placeholder="#FF6B6B"
+                    value={form.color}
+                    onChange={(e) => handleFieldChange("color", e.target.value)}
                     disabled={isSaving}
-                    className="text-destructive h-8 px-2 text-xs"
-                  >
-                    Remove Avatar
-                  </Button>
+                  />
+                  <Input
+                    type="color"
+                    value={form.color}
+                    onChange={(e) => handleFieldChange("color", e.target.value)}
+                    disabled={isSaving}
+                    className="w-12 h-9 p-0.5"
+                  />
+                </div>
+                {form.colorError && (
+                  <p className="text-xs text-destructive">{form.colorError}</p>
                 )}
               </div>
             </div>
-          </div>
 
-          {/* Route + Conditional Prefix */}
-          <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
+            {/* Avatar Upload */}
+            <div className="space-y-2">
+              <Label htmlFor="edit-char-avatar" className="text-xs">
+                Avatar Image
+              </Label>
+              <div className="flex items-center gap-4">
+                <div className="relative size-20 flex-shrink-0">
+                  {form.avatarPreview || form.avatarUrl ? (
+                    <img
+                      src={form.avatarPreview || form.avatarUrl}
+                      alt="Avatar preview"
+                      className="w-full h-full rounded-full object-cover border-4"
+                      style={{ borderColor: form.color }}
+                    />
+                  ) : (
+                    <div
+                      className="w-full h-full rounded-full border-4 border-dashed flex items-center justify-center"
+                      style={{ borderColor: form.color }}
+                    >
+                      <Upload className="size-6 text-muted-foreground" />
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex-1 space-y-2">
+                  <Input
+                    id="edit-char-avatar"
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp,image/gif"
+                    onChange={handleAvatarSelect}
+                    disabled={isSaving}
+                    className="text-sm"
+                    ref={fileInputRef}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    PNG, JPEG, WebP, or GIF (max {AVATAR_MAX_SIZE_MB}MB)
+                  </p>
+                  {(form.avatarPreview || form.avatarUrl) && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleAvatarRemove}
+                      disabled={isSaving}
+                      className="text-destructive h-8 px-2 text-xs"
+                    >
+                      Remove Avatar
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Route + Conditional Prefix */}
+            <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="edit-char-route" className="text-xs">
+                  Route Affiliation
+                </Label>
+                <Input
+                  id="edit-char-route"
+                  type="text"
+                  placeholder="EILEEN"
+                  value={form.routeAffiliation}
+                  onChange={(e) =>
+                    handleFieldChange("routeAffiliation", e.target.value)
+                  }
+                  disabled={isSaving}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="edit-char-prefix" className="text-xs">
+                  Conditional Prefix
+                </Label>
+                <Input
+                  id="edit-char-prefix"
+                  type="text"
+                  placeholder="lucas_"
+                  value={form.conditionalPrefix}
+                  onChange={(e) =>
+                    handleFieldChange("conditionalPrefix", e.target.value)
+                  }
+                  disabled={isSaving}
+                />
+              </div>
+            </div>
+
             <div className="space-y-1">
-              <Label htmlFor="edit-char-route" className="text-xs">
-                Route Affiliation
+              <Label htmlFor="edit-char-notes" className="text-xs">
+                Notes
               </Label>
-              <Input
-                id="edit-char-route"
-                type="text"
-                placeholder="EILEEN"
-                value={form.routeAffiliation}
-                onChange={(e) =>
-                  handleFieldChange("routeAffiliation", e.target.value)
-                }
+              <textarea
+                id="edit-char-notes"
+                rows={4}
+                className="flex min-h-[250px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                placeholder="Backstory, personality notes, voice references..."
+                value={form.notes}
+                onChange={(e) => handleFieldChange("notes", e.target.value)}
                 disabled={isSaving}
+                maxLength={10000}
               />
-            </div>
-            <div className="space-y-1">
-              <Label htmlFor="edit-char-prefix" className="text-xs">
-                Conditional Prefix
-              </Label>
-              <Input
-                id="edit-char-prefix"
-                type="text"
-                placeholder="lucas_"
-                value={form.conditionalPrefix}
-                onChange={(e) =>
-                  handleFieldChange("conditionalPrefix", e.target.value)
-                }
-                disabled={isSaving}
-              />
-            </div>
-          </div>
-
-          <div className="space-y-1">
-            <Label htmlFor="edit-char-notes" className="text-xs">
-              Notes
-            </Label>
-            <textarea
-              id="edit-char-notes"
-              rows={4}
-              className="flex min-h-[250px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-              placeholder="Backstory, personality notes, voice references..."
-              value={form.notes}
-              onChange={(e) => handleFieldChange("notes", e.target.value)}
-              disabled={isSaving}
-              maxLength={10000}
-            />
-            {form.notesError && (
-              <p className="text-xs text-destructive">{form.notesError}</p>
-            )}
-          </div>
-
-          {/* Love Interest + Narrator */}
-          <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
-            <div className="flex items-center gap-2 pt-5">
-              <input
-                type="checkbox"
-                id="edit-char-love"
-                checked={form.isLoveInterest}
-                onChange={(e) =>
-                  handleFieldChange("isLoveInterest", e.target.checked)
-                }
-                disabled={isSaving}
-                className="size-4"
-                aria-label="Love Interest"
-              />
-              <Label
-                htmlFor="edit-char-love"
-                className="text-xs cursor-pointer flex items-center gap-1"
-              >
-                <Heart className="size-3" />
-                Love Interest
-              </Label>
+              {form.notesError && (
+                <p className="text-xs text-destructive">{form.notesError}</p>
+              )}
             </div>
 
-            <div className="flex items-center gap-2 pt-5">
-              <input
-                type="checkbox"
-                id="edit-char-narrator"
-                checked={form.isNarrator}
-                onChange={(e) =>
-                  handleFieldChange("isNarrator", e.target.checked)
-                }
-                disabled={isSaving}
-                className="size-4 accent-purple-500"
-                aria-label="Narrator"
-              />
-              <Label
-                htmlFor="edit-char-narrator"
-                className="text-xs cursor-pointer flex items-center gap-1"
-              >
-                <BookOpen className="size-3" />
-                Narrator
-              </Label>
+            {/* Love Interest + Narrator */}
+            <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
+              <div className="flex items-center gap-2 pt-5">
+                <input
+                  type="checkbox"
+                  id="edit-char-love"
+                  checked={form.isLoveInterest}
+                  onChange={(e) =>
+                    handleFieldChange("isLoveInterest", e.target.checked)
+                  }
+                  disabled={isSaving}
+                  className="size-4"
+                  aria-label="Love Interest"
+                />
+                <Label
+                  htmlFor="edit-char-love"
+                  className="text-xs cursor-pointer flex items-center gap-1"
+                >
+                  <Heart className="size-3" />
+                  Love Interest
+                </Label>
+              </div>
+
+              <div className="flex items-center gap-2 pt-5">
+                <input
+                  type="checkbox"
+                  id="edit-char-narrator"
+                  checked={form.isNarrator}
+                  onChange={(e) =>
+                    handleFieldChange("isNarrator", e.target.checked)
+                  }
+                  disabled={isSaving}
+                  className="size-4 accent-purple-500"
+                  aria-label="Narrator"
+                />
+                <Label
+                  htmlFor="edit-char-narrator"
+                  className="text-xs cursor-pointer flex items-center gap-1"
+                >
+                  <BookOpen className="size-3" />
+                  Narrator
+                </Label>
+              </div>
             </div>
           </div>
+        </div>
 
-          {/* Footer */}
-          <div className="flex justify-end gap-2 pt-4 border-t border-border/30">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSaving}
-            >
-              Cancel
-            </Button>
-            <Button type="button" onClick={handleSave} disabled={isSaving}>
-              {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
-              Save
-            </Button>
-          </div>
+        {/* Footer — sticky on mobile */}
+        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end gap-2 shrink-0">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={isSaving}>
+            {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
+            Save
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/frontend/src/components/CharacterSettingsContent.tsx
+++ b/apps/frontend/src/components/CharacterSettingsContent.tsx
@@ -7,30 +7,22 @@
  * chrome here — the parent (`ProjectSettingsDialog` or the
  * standalone `CharacterDialog`) provides that.
  *
- * Also includes a collapsible "Duo Endings (Pair Groups)" section
- * below the character list, with inline edit/delete actions and
- * a `PairGroupEditDialog` for the create-or-edit flow.
+ * Pair groups have their own dialog opened via the "Pair Groups"
+ * button next to the "Add Character" button.
  */
 
 import { useState } from "react";
-import { Loader2, Plus, Pencil, Trash2 } from "lucide-react";
+import { Loader2, Plus, UsersRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { InlineMessage } from "@/components/ui/inline-error";
-import { CollapsibleSection } from "@/components/ide-shared/CollapsibleSection";
-import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { CharacterList } from "./CharacterList";
 import { CharacterEditDialog } from "./CharacterEditDialog.lazy";
-import { PairGroupEditDialog } from "./PairGroupEditDialog.lazy";
+import { PairGroupsDialog } from "./PairGroupsDialog";
 import { useCharacters } from "@/hooks/useCharacters";
-import { usePairGroups } from "@/hooks/usePairGroups";
-import type { PairGroupWithNames } from "@branchforge/shared";
 
 interface CharacterSettingsContentProps {
   projectId: string;
   columns?: 1 | 2;
-  duoEndingEnabled: boolean;
-  onToggleDuoEnding: (enabled: boolean) => void;
 }
 
 const MODE_NEW = "__new__" as const;
@@ -39,8 +31,6 @@ type EditMode = null | typeof MODE_NEW | string;
 export function CharacterSettingsContent({
   projectId,
   columns = 1,
-  duoEndingEnabled,
-  onToggleDuoEnding,
 }: CharacterSettingsContentProps) {
   const {
     characters,
@@ -54,19 +44,8 @@ export function CharacterSettingsContent({
     deleteCharacter,
   } = useCharacters(projectId);
 
-  const {
-    pairGroups,
-    isLoading: isLoadingPairGroups,
-    isDeleting: isDeletingPairGroup,
-    deletePairGroup,
-  } = usePairGroups(projectId, { enabled: duoEndingEnabled });
-
   const [editingCharacterId, setEditingCharacterId] = useState<EditMode>(null);
-  const [editingPairGroupId, setEditingPairGroupId] = useState<EditMode>(null);
-  const [deleteTarget, setDeleteTarget] = useState<PairGroupWithNames | null>(
-    null
-  );
-  const [isDeletingConfirm, setIsDeletingConfirm] = useState(false);
+  const [pairGroupsOpen, setPairGroupsOpen] = useState(false);
 
   const isSaving =
     isCreatingCharacter ||
@@ -83,42 +62,9 @@ export function CharacterSettingsContent({
     }
   };
 
-  const handleDeletePairGroup = async () => {
-    if (!deleteTarget) return;
-    setIsDeletingConfirm(true);
-    try {
-      await deletePairGroup(deleteTarget.id);
-      setDeleteTarget(null);
-    } finally {
-      setIsDeletingConfirm(false);
-    }
-  };
-
-  const isEditModePair = editingPairGroupId !== null;
-
   return (
     <>
       <div className="space-y-6">
-        {/* Duo ending toggle */}
-        <div className="flex items-center gap-2 pb-4 border-b border-border/30">
-          <input
-            type="checkbox"
-            id="duo-ending-toggle"
-            checked={duoEndingEnabled}
-            onChange={(e) => onToggleDuoEnding(e.target.checked)}
-            className="h-4 w-4 rounded border-border text-[var(--theme-color)] focus:ring-[var(--theme-color)]"
-          />
-          <label
-            htmlFor="duo-ending-toggle"
-            className="text-sm font-medium cursor-pointer"
-          >
-            Enable duo ending tracking
-          </label>
-          <span className="text-xs text-muted-foreground">
-            (pair groups and duo ending labels)
-          </span>
-        </div>
-
         {/* Character list */}
         <div className="space-y-4">
           {isLoadingCharacters ? (
@@ -151,15 +97,29 @@ export function CharacterSettingsContent({
             </div>
           ) : (
             <div className="space-y-4">
-              <Button
-                type="button"
-                onClick={() => setEditingCharacterId(MODE_NEW)}
-                disabled={isSaving}
-                className="w-full"
-              >
-                <Plus className="size-4 mr-2" />
-                Add Another Character
-              </Button>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setEditingCharacterId(MODE_NEW)}
+                  disabled={isSaving}
+                  className="w-full sm:flex-1"
+                >
+                  <Plus className="size-4 mr-2" />
+                  Add Another Character
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setPairGroupsOpen(true)}
+                  disabled={characters.length < 2}
+                  className="w-full sm:w-auto"
+                >
+                  <UsersRound className="size-4 mr-1.5" />
+                  Pair Groups
+                </Button>
+              </div>
+
               <CharacterList
                 characters={characters}
                 isSaving={isSaving}
@@ -170,92 +130,6 @@ export function CharacterSettingsContent({
             </div>
           )}
         </div>
-
-        {duoEndingEnabled && (
-          <>
-            {/* Duo Endings (Pair Groups) — collapsible */}
-            <CollapsibleSection
-              title="Duo Endings (Pair Groups)"
-              defaultOpen={pairGroups.length > 0}
-              headerAction={
-                characters.length >= 2 ? (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setEditingPairGroupId(MODE_NEW)}
-                    disabled={isDeletingPairGroup}
-                    className="h-6 text-xs"
-                  >
-                    <Plus className="size-3 mr-1" />
-                    Add
-                  </Button>
-                ) : null
-              }
-            >
-              {isLoadingPairGroups ? (
-                <div className="flex items-center justify-center py-4">
-                  <Loader2 className="size-4 animate-spin text-muted-foreground" />
-                </div>
-              ) : pairGroups.length === 0 ? (
-                <p className="text-xs text-muted-foreground py-2">
-                  {characters.length < 2
-                    ? "Add at least two characters to create duo endings."
-                    : "No duo endings configured yet."}
-                </p>
-              ) : (
-                <div className="space-y-2">
-                  {pairGroups.map((pg) => (
-                    <div
-                      key={pg.id}
-                      className="flex items-center justify-between rounded-md border border-border/50 p-3"
-                    >
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-0.5">
-                          <Badge variant="outline" className="text-xs">
-                            {pg.characterAName}
-                          </Badge>
-                          <span className="text-xs text-muted-foreground">
-                            &amp;
-                          </span>
-                          <Badge variant="outline" className="text-xs">
-                            {pg.characterBName}
-                          </Badge>
-                        </div>
-                        <p className="text-sm font-medium truncate">
-                          {pg.duoEndingLabel}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-1 ml-2 shrink-0">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setEditingPairGroupId(pg.id)}
-                          disabled={isDeletingPairGroup}
-                          aria-label={`Edit pair group ${pg.duoEndingLabel}`}
-                        >
-                          <Pencil className="size-4" />
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setDeleteTarget(pg)}
-                          disabled={isDeletingPairGroup}
-                          className="text-destructive hover:text-destructive"
-                          aria-label={`Delete pair group ${pg.duoEndingLabel}`}
-                        >
-                          <Trash2 className="size-4" />
-                        </Button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </CollapsibleSection>
-          </>
-        )}
       </div>
 
       <CharacterEditDialog
@@ -271,42 +145,12 @@ export function CharacterSettingsContent({
         }
       />
 
-      {duoEndingEnabled && (
-        <>
-          {/* Pair Group Edit Dialog */}
-          {isEditModePair && (
-            <PairGroupEditDialog
-              open={isEditModePair}
-              onOpenChange={(nextOpen: boolean) => {
-                if (!nextOpen) setEditingPairGroupId(null);
-              }}
-              projectId={projectId}
-              pairGroupId={
-                editingPairGroupId === MODE_NEW
-                  ? undefined
-                  : (editingPairGroupId as string | undefined)
-              }
-            />
-          )}
-
-          {/* Delete confirmation for pair groups */}
-          <ConfirmDialog
-            open={deleteTarget !== null}
-            onOpenChange={(open) => {
-              if (!open && !isDeletingConfirm) {
-                setDeleteTarget(null);
-              }
-            }}
-            onConfirm={handleDeletePairGroup}
-            title="Delete Pair Group"
-            description={`Are you sure you want to delete the duo ending "${deleteTarget?.duoEndingLabel}"? This will unlink any labels using this pair group.`}
-            cancelLabel="Cancel"
-            confirmLabel="Delete Pair Group"
-            isLoading={isDeletingConfirm}
-            loadingLabel="Deleting..."
-          />
-        </>
-      )}
+      <PairGroupsDialog
+        open={pairGroupsOpen}
+        onOpenChange={setPairGroupsOpen}
+        projectId={projectId}
+        characters={characters.map((c) => c.name)}
+      />
     </>
   );
 }

--- a/apps/frontend/src/components/PairGroupsDialog.tsx
+++ b/apps/frontend/src/components/PairGroupsDialog.tsx
@@ -13,7 +13,8 @@
  * opens the PairGroupEditDialog.
  */
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef } from "react";
+import { flushSync } from "react-dom";
 import { Loader2, Plus, Pencil, Trash2, X, Check } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -74,24 +75,18 @@ export function PairGroupsDialog({
 
   const editInputRef = useRef<HTMLInputElement>(null);
 
-  // Reset transient UI state when the dialog closes so stale state
-  // does not carry over to the next open.
-  useEffect(() => {
-    if (!open) {
+  // Reset transient UI state when the dialog closes, handled in the
+  // onOpenChange event handler (not a useEffect) so state resets
+  // happen in the same synchronous event as the close action.
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
       setCreatingNew(false);
       setEditingLabelId(null);
       setEditLabelValue("");
       setDeleteTarget(null);
     }
-  }, [open]);
-
-  // Focus the inline edit input when it appears
-  useEffect(() => {
-    if (editingLabelId) {
-      editInputRef.current?.focus();
-      editInputRef.current?.select();
-    }
-  }, [editingLabelId]);
+    onOpenChange(nextOpen);
+  };
 
   const handleToggleDuoEnding = async (checked: boolean) => {
     try {
@@ -102,8 +97,12 @@ export function PairGroupsDialog({
   };
 
   const handleStartEditLabel = (pg: PairGroupWithNames) => {
-    setEditingLabelId(pg.id);
-    setEditLabelValue(pg.duoEndingLabel);
+    flushSync(() => {
+      setEditingLabelId(pg.id);
+      setEditLabelValue(pg.duoEndingLabel);
+    });
+    editInputRef.current?.focus();
+    editInputRef.current?.select();
   };
 
   const handleSaveLabel = async () => {
@@ -136,6 +135,8 @@ export function PairGroupsDialog({
     try {
       await deletePairGroup(deleteTarget.id);
       setDeleteTarget(null);
+    } catch {
+      // error toast shown by hook's onError — dialog stays open
     } finally {
       setIsDeletingConfirm(false);
     }
@@ -144,7 +145,11 @@ export function PairGroupsDialog({
   const canCreate = characters.length >= 2;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange} aria-label="Pair Groups">
+    <Dialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      aria-label="Pair Groups"
+    >
       {/* p-0 gap-0 + overflow-hidden outer → three-section flex layout */}
       <DialogContent className="max-w-md w-full max-h-[85vh] p-0 gap-0 flex flex-col overflow-hidden">
         {/* === Header (sticky) === */}

--- a/apps/frontend/src/components/PairGroupsDialog.tsx
+++ b/apps/frontend/src/components/PairGroupsDialog.tsx
@@ -14,7 +14,6 @@
  */
 
 import { useState, useRef } from "react";
-import { flushSync } from "react-dom";
 import { Loader2, Plus, Pencil, Trash2, X, Check } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -97,12 +96,8 @@ export function PairGroupsDialog({
   };
 
   const handleStartEditLabel = (pg: PairGroupWithNames) => {
-    flushSync(() => {
-      setEditingLabelId(pg.id);
-      setEditLabelValue(pg.duoEndingLabel);
-    });
-    editInputRef.current?.focus();
-    editInputRef.current?.select();
+    setEditingLabelId(pg.id);
+    setEditLabelValue(pg.duoEndingLabel);
   };
 
   const handleSaveLabel = async () => {
@@ -236,7 +231,11 @@ export function PairGroupsDialog({
                         {isEditing ? (
                           <div className="flex items-center gap-1.5">
                             <Input
-                              ref={editInputRef}
+                              ref={(el) => {
+                                editInputRef.current = el;
+                                el?.focus();
+                                el?.select();
+                              }}
                               value={editLabelValue}
                               onChange={(e) =>
                                 setEditLabelValue(e.target.value)

--- a/apps/frontend/src/components/PairGroupsDialog.tsx
+++ b/apps/frontend/src/components/PairGroupsDialog.tsx
@@ -1,0 +1,339 @@
+/**
+ * Pair Groups Dialog
+ *
+ * Standalone dialog for managing duo ending pair groups. Extracted
+ * from the Characters tab of ProjectSettingsDialog so the character
+ * list stays clean and the pair group management has its own space.
+ *
+ * Uses the three-section flex layout (header / scrollable body)
+ * consistent with other dialogs in the app.
+ *
+ * Editing an existing pair group (changing its label) is done
+ * inline. Creating a new pair group (selecting characters + label)
+ * opens the PairGroupEditDialog.
+ */
+
+import { useState, useRef, useEffect } from "react";
+import { Loader2, Plus, Pencil, Trash2, X, Check } from "lucide-react";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { InlineMessage } from "@/components/ui/inline-error";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { PairGroupEditDialog } from "./PairGroupEditDialog.lazy";
+import { useProject } from "@/hooks/useProject";
+import { usePairGroups } from "@/hooks/usePairGroups";
+import { useToast } from "@/contexts/ToastContext";
+import type { PairGroupWithNames } from "@branchforge/shared";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface PairGroupsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  /** Character names for the pair group editor dropdowns. */
+  characters: string[];
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function PairGroupsDialog({
+  open,
+  onOpenChange,
+  projectId,
+  characters,
+}: PairGroupsDialogProps) {
+  const { currentProject, updateProject } = useProject();
+  const { error: showErrorToast } = useToast();
+  const duoEndingEnabled = currentProject?.duoEndingEnabled ?? false;
+
+  const {
+    pairGroups,
+    isLoading: isLoadingPairGroups,
+    error: pairGroupsError,
+    isDeleting: isDeletingPairGroup,
+    isUpdating: isUpdatingPairGroup,
+    updatePairGroup,
+    deletePairGroup,
+  } = usePairGroups(projectId, { enabled: duoEndingEnabled && open });
+
+  const [creatingNew, setCreatingNew] = useState(false);
+  const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
+  const [editLabelValue, setEditLabelValue] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<PairGroupWithNames | null>(
+    null
+  );
+  const [isDeletingConfirm, setIsDeletingConfirm] = useState(false);
+
+  const editInputRef = useRef<HTMLInputElement>(null);
+
+  // Reset transient UI state when the dialog closes so stale state
+  // does not carry over to the next open.
+  useEffect(() => {
+    if (!open) {
+      setCreatingNew(false);
+      setEditingLabelId(null);
+      setEditLabelValue("");
+      setDeleteTarget(null);
+    }
+  }, [open]);
+
+  // Focus the inline edit input when it appears
+  useEffect(() => {
+    if (editingLabelId) {
+      editInputRef.current?.focus();
+      editInputRef.current?.select();
+    }
+  }, [editingLabelId]);
+
+  const handleToggleDuoEnding = async (checked: boolean) => {
+    try {
+      await updateProject(projectId, { duoEndingEnabled: checked });
+    } catch {
+      showErrorToast("Failed to update duo ending setting");
+    }
+  };
+
+  const handleStartEditLabel = (pg: PairGroupWithNames) => {
+    setEditingLabelId(pg.id);
+    setEditLabelValue(pg.duoEndingLabel);
+  };
+
+  const handleSaveLabel = async () => {
+    if (!editingLabelId) return;
+    try {
+      await updatePairGroup(editingLabelId, {
+        duoEndingLabel: editLabelValue.trim(),
+      });
+      setEditingLabelId(null);
+    } catch {
+      // error toast shown by hook's onError — stay in edit mode
+    }
+  };
+
+  const handleCancelLabel = () => {
+    setEditingLabelId(null);
+  };
+
+  const handleLabelKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      void handleSaveLabel();
+    } else if (e.key === "Escape") {
+      handleCancelLabel();
+    }
+  };
+
+  const handleDeletePairGroup = async () => {
+    if (!deleteTarget) return;
+    setIsDeletingConfirm(true);
+    try {
+      await deletePairGroup(deleteTarget.id);
+      setDeleteTarget(null);
+    } finally {
+      setIsDeletingConfirm(false);
+    }
+  };
+
+  const canCreate = characters.length >= 2;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange} aria-label="Pair Groups">
+      {/* p-0 gap-0 + overflow-hidden outer → three-section flex layout */}
+      <DialogContent className="max-w-md w-full max-h-[85vh] p-0 gap-0 flex flex-col overflow-hidden">
+        {/* === Header (sticky) === */}
+        <div className="p-6 max-sm:p-4 border-b border-border/30 shrink-0">
+          <h2 className="text-lg font-medium">Pair Groups</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Create and manage duo ending pairings between characters.
+          </p>
+        </div>
+
+        {/* === Duo ending toggle (sticky) === */}
+        <div className="flex items-start justify-between p-6 max-sm:p-4 shrink-0 border-b border-border/30">
+          <div className="space-y-0.5 pr-4">
+            <p className="text-sm font-medium">Enable duo ending tracking</p>
+            <p className="text-xs text-muted-foreground">
+              Pair groups and duo ending labels
+            </p>
+          </div>
+          <Switch
+            checked={duoEndingEnabled}
+            onCheckedChange={handleToggleDuoEnding}
+          />
+        </div>
+
+        {/* === Scrollable body: pair groups list === */}
+        {duoEndingEnabled && (
+          <div className="flex-1 overflow-y-auto p-6 max-sm:p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-medium text-foreground/80">
+                Duo Endings
+              </h3>
+              {canCreate && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setCreatingNew(true)}
+                  disabled={isDeletingPairGroup || isUpdatingPairGroup}
+                  className="h-6 text-xs"
+                >
+                  <Plus className="size-3 mr-1" />
+                  Add
+                </Button>
+              )}
+            </div>
+
+            {isLoadingPairGroups ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="size-5 animate-spin text-muted-foreground" />
+              </div>
+            ) : pairGroupsError ? (
+              <InlineMessage variant="error">
+                Failed to load pair groups.
+              </InlineMessage>
+            ) : pairGroups.length === 0 ? (
+              <div className="p-8 border border-dashed border-border/30 rounded-md text-center">
+                <p className="text-xs text-muted-foreground">
+                  {!canCreate
+                    ? "Add at least two characters to create duo endings."
+                    : "No duo endings configured yet."}
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {pairGroups.map((pg) => {
+                  const isEditing = editingLabelId === pg.id;
+                  return (
+                    <div
+                      key={pg.id}
+                      className="flex items-center justify-between rounded-md border border-border/50 p-3"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-0.5">
+                          <Badge variant="outline" className="text-xs">
+                            {pg.characterAName}
+                          </Badge>
+                          <span className="text-xs text-muted-foreground">
+                            &amp;
+                          </span>
+                          <Badge variant="outline" className="text-xs">
+                            {pg.characterBName}
+                          </Badge>
+                        </div>
+                        {isEditing ? (
+                          <div className="flex items-center gap-1.5">
+                            <Input
+                              ref={editInputRef}
+                              value={editLabelValue}
+                              onChange={(e) =>
+                                setEditLabelValue(e.target.value)
+                              }
+                              onKeyDown={handleLabelKeyDown}
+                              disabled={isUpdatingPairGroup}
+                              className="h-7 text-sm"
+                              size="sm"
+                            />
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => void handleSaveLabel()}
+                              disabled={isUpdatingPairGroup}
+                              className="size-7 p-0"
+                              aria-label="Save label"
+                            >
+                              <Check className="size-3.5" />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={handleCancelLabel}
+                              disabled={isUpdatingPairGroup}
+                              className="size-7 p-0"
+                              aria-label="Cancel editing"
+                            >
+                              <X className="size-3.5" />
+                            </Button>
+                          </div>
+                        ) : (
+                          <p className="text-sm font-medium truncate">
+                            {pg.duoEndingLabel}
+                          </p>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-1 ml-2 shrink-0">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleStartEditLabel(pg)}
+                          disabled={
+                            isDeletingPairGroup ||
+                            isUpdatingPairGroup ||
+                            isEditing
+                          }
+                          aria-label={`Edit pair group ${pg.duoEndingLabel}`}
+                        >
+                          <Pencil className="size-4" />
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setDeleteTarget(pg)}
+                          disabled={isDeletingPairGroup || isEditing}
+                          className="text-destructive hover:text-destructive"
+                          aria-label={`Delete pair group ${pg.duoEndingLabel}`}
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+      </DialogContent>
+
+      {/* Pair Group Edit Dialog — for creating new pair groups only */}
+      {creatingNew && (
+        <PairGroupEditDialog
+          open={creatingNew}
+          onOpenChange={(nextOpen: boolean) => {
+            if (!nextOpen) setCreatingNew(false);
+          }}
+          projectId={projectId}
+          pairGroupId={undefined}
+        />
+      )}
+
+      {/* Delete confirmation */}
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen && !isDeletingConfirm) {
+            setDeleteTarget(null);
+          }
+        }}
+        onConfirm={handleDeletePairGroup}
+        title="Delete Pair Group"
+        description={`Are you sure you want to delete the duo ending "${deleteTarget?.duoEndingLabel}"? This will unlink any labels using this pair group.`}
+        cancelLabel="Cancel"
+        confirmLabel="Delete Pair Group"
+        isLoading={isDeletingConfirm}
+        loadingLabel="Deleting..."
+      />
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -119,7 +119,7 @@ export function ProjectSettingsDialog({
     >
       <DialogContent className="max-w-3xl w-full h-[80vh] min-h-[500px] max-md:min-h-0 p-0 gap-0 flex flex-col overflow-hidden">
         {/* Header */}
-        <div className="p-6 max-mobile:p-4 border-b border-border/30 flex items-start justify-between shrink-0">
+        <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between shrink-0">
           <div>
             <h2 className="text-lg font-medium">Project Settings</h2>
             <p className="text-sm text-muted-foreground mt-1">
@@ -159,7 +159,7 @@ export function ProjectSettingsDialog({
             </TabsList>
           </div>
 
-          <div className="flex-1 overflow-y-auto p-6 max-mobile:p-4">
+          <div className="flex-1 overflow-y-auto p-6 max-sm:p-4">
             <TabsPanel value="characters" className="space-y-4">
               <CharactersTabContent projectId={projectId} />
             </TabsPanel>
@@ -176,7 +176,7 @@ export function ProjectSettingsDialog({
         </Tabs>
 
         {/* Footer */}
-        <div className="p-6 max-mobile:p-4 border-t border-border/30 flex justify-end shrink-0">
+        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end shrink-0">
           <Button
             type="button"
             variant="outline"

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -33,7 +33,6 @@ import { CharacterSettingsContent } from "@/components/CharacterSettingsContent"
 import { RouteSettingsContent } from "@/components/RouteSettingsContent";
 import { VisualSystemFormContent } from "@/components/VisualSystemDialog";
 import { WorldElementsSettingsContent } from "@/components/WorldElementsSettingsContent";
-import { useProject } from "@/hooks/useProject";
 import { useVisualSystem } from "@/hooks/useVisualSystem";
 import {
   parseGroupPrefixes,
@@ -61,8 +60,8 @@ export type SettingsTab = "characters" | "routes" | "visual" | "world";
 const TAB_LABELS: Record<SettingsTab, string> = {
   characters: "Characters",
   routes: "Routes",
-  visual: "Visual System",
   world: "World Bible",
+  visual: "Visual System",
 };
 
 const TAB_ICONS: Record<
@@ -71,11 +70,11 @@ const TAB_ICONS: Record<
 > = {
   characters: Users,
   routes: RouteIcon,
-  visual: Wand2,
   world: BookText,
+  visual: Wand2,
 };
 
-const TAB_ORDER: SettingsTab[] = ["characters", "routes", "visual", "world"];
+const TAB_ORDER: SettingsTab[] = ["characters", "routes", "world", "visual"];
 
 // ============================================================================
 // Component
@@ -117,7 +116,7 @@ export function ProjectSettingsDialog({
       onOpenChange={onOpenChange}
       aria-label="Project Settings"
     >
-      <DialogContent className="max-w-3xl w-full h-[80vh] min-h-[500px] max-md:min-h-0 p-0 gap-0 flex flex-col overflow-hidden">
+      <DialogContent className="max-w-3xl w-full max-h-[80vh] min-h-[500px] max-md:min-h-0 p-0 gap-0 flex flex-col overflow-hidden">
         {/* Header */}
         <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between shrink-0">
           <div>
@@ -143,7 +142,7 @@ export function ProjectSettingsDialog({
           onValueChange={(next) => setActiveTab(next as SettingsTab)}
           className="flex flex-col flex-1 min-h-0"
         >
-          <div className="px-3 pt-2 pb-0 shrink-0 sm:px-6">
+          <div className="px-3 pt-2 pb-3 shrink-0 sm:px-6">
             <TabsList ariaLabel="Project settings sections" scrollable>
               {TAB_ORDER.map((tab) => {
                 const Icon = TAB_ICONS[tab];
@@ -166,11 +165,11 @@ export function ProjectSettingsDialog({
             <TabsPanel value="routes" className="space-y-4">
               <RouteSettingsContent projectId={projectId} columns={2} />
             </TabsPanel>
-            <TabsPanel value="visual" className="space-y-4">
-              <VisualSystemTabContent projectId={projectId} />
-            </TabsPanel>
             <TabsPanel value="world" className="space-y-4">
               <WorldElementsSettingsContent projectId={projectId} />
+            </TabsPanel>
+            <TabsPanel value="visual" className="space-y-4">
+              <VisualSystemTabContent projectId={projectId} />
             </TabsPanel>
           </div>
         </Tabs>
@@ -203,20 +202,7 @@ interface CharactersTabContentProps {
 }
 
 function CharactersTabContent({ projectId }: CharactersTabContentProps) {
-  const { currentProject, updateProject } = useProject();
-
-  const handleToggleDuoEnding = async (enabled: boolean) => {
-    await updateProject(projectId, { duoEndingEnabled: enabled });
-  };
-
-  return (
-    <CharacterSettingsContent
-      projectId={projectId}
-      columns={2}
-      duoEndingEnabled={currentProject?.duoEndingEnabled ?? false}
-      onToggleDuoEnding={handleToggleDuoEnding}
-    />
-  );
+  return <CharacterSettingsContent projectId={projectId} columns={2} />;
 }
 
 // ============================================================================

--- a/apps/frontend/src/components/RouteSettingsContent.tsx
+++ b/apps/frontend/src/components/RouteSettingsContent.tsx
@@ -72,11 +72,6 @@ export function RouteSettingsContent({
           </InlineMessage>
         ) : routeConfigs.length === 0 ? (
           <div className="space-y-4">
-            <div className="p-8 border border-dashed border-border/30 rounded-md text-center">
-              <p className="text-sm text-muted-foreground">
-                No routes configured yet. Add your first route to get started.
-              </p>
-            </div>
             <Button
               type="button"
               onClick={() => setEditingRouteId(MODE_NEW)}
@@ -86,6 +81,11 @@ export function RouteSettingsContent({
               <Plus className="size-4 mr-2" />
               Add Route
             </Button>
+            <div className="p-8 border border-dashed border-border/30 rounded-md text-center">
+              <p className="text-sm text-muted-foreground">
+                No routes configured yet. Add your first route to get started.
+              </p>
+            </div>
           </div>
         ) : (
           <div className="space-y-4">

--- a/apps/frontend/src/components/WorldElementsSettingsContent.tsx
+++ b/apps/frontend/src/components/WorldElementsSettingsContent.tsx
@@ -65,12 +65,6 @@ export function WorldElementsSettingsContent({
         </InlineMessage>
       ) : elements.length === 0 ? (
         <div className="space-y-4">
-          <div className="p-8 border border-dashed border-border/30 rounded-md text-center">
-            <p className="text-sm text-muted-foreground">
-              No world elements yet. Add your first location, item, concept, or
-              event to build your world bible.
-            </p>
-          </div>
           <Button
             type="button"
             onClick={() => setEditingElementId(MODE_NEW)}
@@ -80,6 +74,12 @@ export function WorldElementsSettingsContent({
             <Plus className="size-4 mr-2" />
             Add Element
           </Button>
+          <div className="p-8 border border-dashed border-border/30 rounded-md text-center">
+            <p className="text-sm text-muted-foreground">
+              No world elements yet. Add your first location, item, concept, or
+              event to build your world bible.
+            </p>
+          </div>
         </div>
       ) : (
         <div className="space-y-4">

--- a/apps/frontend/src/components/flow/FlowDialog.tsx
+++ b/apps/frontend/src/components/flow/FlowDialog.tsx
@@ -63,7 +63,7 @@ export function FlowDialog({ open, onOpenChange, projectId }: FlowDialogProps) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="w-[95vw] max-w-[2200px] h-[96vh] p-0 gap-0 overflow-hidden flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between px-5 py-3 max-mobile:px-4 max-mobile:py-2 border-b border-border/30 shrink-0">
+        <div className="flex items-center justify-between px-5 py-3 max-sm:px-4 max-sm:py-2 border-b border-border/30 shrink-0">
           <DialogTitle>Flow Graph</DialogTitle>
           <button
             type="button"

--- a/apps/frontend/src/components/ide-shared/CollapsibleSection.tsx
+++ b/apps/frontend/src/components/ide-shared/CollapsibleSection.tsx
@@ -21,7 +21,7 @@ export function CollapsibleSection({
         <button
           type="button"
           onClick={() => setIsOpen(!isOpen)}
-          className="flex items-center gap-1.5"
+          className="flex items-center gap-1.5 max-md:min-h-11 max-md:min-w-11"
         >
           {title}
           <ChevronDown

--- a/apps/frontend/src/components/ide-shared/EditorTabBar.tsx
+++ b/apps/frontend/src/components/ide-shared/EditorTabBar.tsx
@@ -343,7 +343,7 @@ export function EditorTabBar({
                         event.stopPropagation();
                         onClose(event, item.id);
                       }}
-                      className="rounded p-1 hover:bg-muted-foreground/10 shrink-0 text-muted-foreground"
+                      className="rounded p-1 hover:bg-muted-foreground/10 shrink-0 text-muted-foreground max-md:min-h-11"
                       aria-label={item.closeLabel ?? `Close ${item.title}`}
                     >
                       <X className="size-3.5" />

--- a/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
+++ b/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
@@ -336,9 +336,9 @@ export function ConflictReviewDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl w-full max-h-[90vh] p-0 gap-0 flex flex-col">
+      <DialogContent className="max-w-4xl w-full max-h-[90vh] p-0 gap-0 flex flex-col overflow-hidden">
         {/* Header */}
-        <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between">
+        <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between shrink-0">
           <div className="flex-1">
             <div className="flex items-center gap-3">
               <h2 className="text-lg font-medium">Review Sync Conflicts</h2>
@@ -573,7 +573,7 @@ export function ConflictReviewDialog({
         </div>
 
         {/* Footer */}
-        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-between">
+        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-between shrink-0">
           <Button
             type="button"
             variant="outline"

--- a/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
+++ b/apps/frontend/src/components/script-mode/ConflictReviewDialog.tsx
@@ -338,7 +338,7 @@ export function ConflictReviewDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-4xl w-full max-h-[90vh] p-0 gap-0 flex flex-col">
         {/* Header */}
-        <div className="p-6 max-mobile:p-4 border-b border-border/30 flex items-start justify-between">
+        <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between">
           <div className="flex-1">
             <div className="flex items-center gap-3">
               <h2 className="text-lg font-medium">Review Sync Conflicts</h2>
@@ -370,7 +370,7 @@ export function ConflictReviewDialog({
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6 max-mobile:p-4">
+        <div className="flex-1 overflow-y-auto p-6 max-sm:p-4">
           {state.isLoading && state.conflicts.length === 0 ? (
             <div className="flex items-center justify-center h-full">
               <div className="text-center">
@@ -573,7 +573,7 @@ export function ConflictReviewDialog({
         </div>
 
         {/* Footer */}
-        <div className="p-6 max-mobile:p-4 border-t border-border/30 flex justify-between">
+        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-between">
           <Button
             type="button"
             variant="outline"

--- a/apps/frontend/src/components/script-mode/GitLabSyncDialog.tsx
+++ b/apps/frontend/src/components/script-mode/GitLabSyncDialog.tsx
@@ -307,7 +307,7 @@ export function GitLabSyncDialog({
     <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <DialogContent className="max-w-md w-full p-0 gap-0">
         {/* Header */}
-        <div className="p-6 max-mobile:p-4 border-b border-border/30 flex items-start justify-between">
+        <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-muted rounded-md">
               <SyncIcon className="size-5" />
@@ -337,7 +337,7 @@ export function GitLabSyncDialog({
         </div>
 
         {/* Content */}
-        <div className="p-6 max-mobile:p-4 space-y-4">
+        <div className="p-6 max-sm:p-4 space-y-4">
           {/* Progress / Status */}
           {state.isProcessing || state.operation ? (
             <div className="space-y-3">
@@ -495,7 +495,7 @@ export function GitLabSyncDialog({
         </div>
 
         {/* Footer */}
-        <div className="p-6 max-mobile:p-4 border-t border-border/30 flex justify-end gap-2">
+        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end gap-2">
           {!state.isProcessing && !state.operation && (
             <>
               <Button type="button" variant="outline" onClick={handleClose}>

--- a/apps/frontend/src/components/ui/DialogShell.tsx
+++ b/apps/frontend/src/components/ui/DialogShell.tsx
@@ -58,7 +58,7 @@ export function DialogShell({
           contentClassName
         )}
       >
-        <div className="p-6 max-mobile:p-4 border-b border-border/30 flex items-start justify-between shrink-0">
+        <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between shrink-0">
           <div>
             <h2 className="text-lg font-medium">{title}</h2>
             {description && (
@@ -77,12 +77,10 @@ export function DialogShell({
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-6 max-mobile:p-4">
-          {children}
-        </div>
+        <div className="flex-1 overflow-y-auto p-6 max-sm:p-4">{children}</div>
 
         {footerMode !== "none" && (
-          <div className="p-6 max-mobile:p-4 border-t border-border/30 flex justify-end shrink-0">
+          <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end shrink-0">
             {footerMode === "custom" ? (
               footerActions
             ) : (

--- a/apps/frontend/src/components/ui/confirm-dialog.tsx
+++ b/apps/frontend/src/components/ui/confirm-dialog.tsx
@@ -135,7 +135,7 @@ export function ConfirmDialog({
         )}
       >
         {/* Header */}
-        <div className="p-6 max-mobile:p-4 border-b border-border/30">
+        <div className="p-6 max-sm:p-4 border-b border-border/30">
           <h2 id="confirm-dialog-title" className="text-lg font-medium">
             {title}
           </h2>
@@ -148,7 +148,7 @@ export function ConfirmDialog({
         </div>
 
         {/* Footer */}
-        <div className="p-6 max-mobile:p-4 border-t border-border/30 flex justify-end gap-2">
+        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end gap-2">
           <Button variant="outline" onClick={handleCancel} disabled={isLoading}>
             {cancelLabel}
           </Button>

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -115,12 +115,12 @@ export function DialogContent({ children, className }: DialogContentProps) {
   return (
     <div
       className={cn(
-        "relative bg-card border border-border/30 rounded-lg shadow-xl p-6 max-mobile:p-4 w-full max-w-md max-h-[85vh] overflow-y-auto",
+        "relative bg-card border border-border/30 rounded-lg shadow-xl p-6 max-sm:p-4 w-full max-w-md max-h-[85vh] overflow-y-auto",
         // Near-fullscreen card below sm — a thin gap (8px sides,
         // 16px top/bottom) lets the backdrop peek through so the
         // dialog reads as a modal overlay rather than a page
         // transition. Inner sections still carry their own
-        // responsive padding via p-6 max-mobile:p-4.
+        // responsive padding via p-6 max-sm:p-4.
         "max-sm:w-[calc(100%-16px)] max-sm:max-w-[calc(100%-16px)] max-sm:h-[calc(100%-32px)] max-sm:max-h-[calc(100%-32px)] max-sm:rounded-xl",
         className
       )}

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -116,12 +116,14 @@ export function DialogContent({ children, className }: DialogContentProps) {
     <div
       className={cn(
         "relative bg-card border border-border/30 rounded-lg shadow-xl p-6 max-sm:p-4 w-full max-w-md max-h-[85vh] overflow-y-auto",
-        // Near-fullscreen card below sm — a thin gap (8px sides,
+        // Near-fullscreen cap below sm — a thin gap (8px sides,
         // 16px top/bottom) lets the backdrop peek through so the
         // dialog reads as a modal overlay rather than a page
-        // transition. Inner sections still carry their own
-        // responsive padding via p-6 max-sm:p-4.
-        "max-sm:w-[calc(100%-16px)] max-sm:max-w-[calc(100%-16px)] max-sm:h-[calc(100%-32px)] max-sm:max-h-[calc(100%-32px)] max-sm:rounded-xl",
+        // transition. Height is capped (not fixed), so short content
+        // shrinks to fit while tall content fills the viewport.
+        // Inner sections carry their own responsive padding via
+        // p-6 max-sm:p-4.
+        "max-sm:w-[calc(100%-16px)] max-sm:max-w-[calc(100%-16px)] max-sm:max-h-[calc(100%-32px)] max-sm:rounded-xl",
         className
       )}
     >

--- a/apps/frontend/src/components/ui/tabs.tsx
+++ b/apps/frontend/src/components/ui/tabs.tsx
@@ -438,7 +438,7 @@ export function TabsTrigger({
       }}
       onKeyDown={handleKeyDown}
       className={cn(
-        "px-3 min-h-11 py-2 text-sm font-medium transition-colors relative",
+        "px-3 min-h-11 py-2 text-sm font-medium whitespace-nowrap shrink-0 transition-colors relative",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         isActive
           ? "text-foreground"

--- a/apps/frontend/src/components/write-mode/FocusModeToggle.tsx
+++ b/apps/frontend/src/components/write-mode/FocusModeToggle.tsx
@@ -38,7 +38,7 @@ export const FocusModeToggle = memo(function FocusModeToggle({
         "focus-visible:ring-[var(--theme-color)]/35",
         isFocusMode
           ? "gap-2 rounded-full border border-border/70 bg-card/90 px-3.5 py-2 whitespace-nowrap text-sm font-medium text-foreground shadow-lg backdrop-blur-sm hover:border-[var(--theme-color)]/35 hover:bg-card"
-          : "gap-2 rounded-md px-3 py-1.5 text-sm text-muted-foreground bg-muted/30 hover:bg-muted/60 hover:text-foreground hover:border-border/80"
+          : "gap-2 rounded-md px-3 py-1.5 text-sm text-muted-foreground bg-muted/30 hover:bg-muted/60 hover:text-foreground hover:border-border/80 max-md:min-h-11"
       )}
     >
       {isFocusMode ? (

--- a/apps/frontend/src/components/write-mode/LabelPropertiesPanel.tsx
+++ b/apps/frontend/src/components/write-mode/LabelPropertiesPanel.tsx
@@ -16,13 +16,13 @@ import {
 import { FormattedCondition } from "@/components/write-mode/FormattedCondition";
 
 const panelVariants = cva(
-  "min-h-0 shrink-0 rounded-lg border border-border bg-panel-tinted overflow-hidden mt-3 transition-all duration-300 ease-out",
+  "min-h-0 shrink-0 rounded-lg border border-border bg-panel-tinted mt-3 transition-all duration-300 ease-out",
   {
     variants: {
       collapsed: {
         true: "w-0 opacity-0 translate-x-full pointer-events-none max-md:absolute max-md:z-40 max-md:inset-y-0 max-md:right-0 max-md:h-full max-md:mt-0 max-md:rounded-none",
         false:
-          "w-56 opacity-100 translate-x-0 max-md:absolute max-md:z-40 max-md:inset-y-0 max-md:right-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0",
+          "w-60 opacity-100 translate-x-0 max-md:absolute max-md:z-40 max-md:inset-y-0 max-md:right-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0",
       },
     },
   }

--- a/apps/frontend/src/pages/ide/WriteMode.tsx
+++ b/apps/frontend/src/pages/ide/WriteMode.tsx
@@ -108,7 +108,7 @@ const sidebarVariants = cva(
         collapsed:
           "w-0 opacity-0 -translate-x-full pointer-events-none max-md:absolute max-md:z-50 max-md:left-0 max-md:top-0 max-md:h-full max-md:mt-0 max-md:rounded-none",
         expanded:
-          "w-48 opacity-100 translate-x-0 max-md:absolute max-md:z-50 max-md:left-0 max-md:top-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0 max-md:bg-card",
+          "w-60 opacity-100 translate-x-0 max-md:absolute max-md:z-50 max-md:left-0 max-md:top-0 max-md:h-full max-md:w-72 max-md:shadow-xl max-md:rounded-none max-md:mt-0 max-md:bg-card",
       },
     },
     defaultVariants: {

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -23,9 +23,6 @@ export default {
       },
     },
     extend: {
-      screens: {
-        mobile: "375px",
-      },
       fontFamily: {
         sans: ["Kanit", "sans-serif"],
         display: ["Sirin Stencil", "cursive"],


### PR DESCRIPTION
Continuation of the mobile responsiveness improvements series.

## What changed

- **Pair groups extracted** from inline collapsible section into standalone `PairGroupsDialog` with three-section flex layout, error state handling, stale state reset on close, and error handling on mutations
- **Consistent dialog flex layout**: `shrink-0` headers/footers + `flex-1 overflow-y-auto` body applied across all affected dialogs (`CharacterDialog`, `CharacterEditDialog`, `ConflictReviewDialog`)
- **Fixed → max-height**: mobile dialogs now use `max-h` instead of fixed `h`, so short content shrinks to fit while tall content stays capped
- **TabsTrigger**: added `whitespace-nowrap shrink-0` for scrollable tab lists
- **Tab reorder**: World Bible tab moved before Visual System in ProjectSettingsDialog
- **Layout polish**: sidebar/panel widths adjusted, Add buttons moved above empty-state messages

## Verification

- Typecheck: ✅
- Lint: ✅
- Unit tests: ✅ (2 pre-existing flaky perf benchmark failures — unrelated)
- Oracle review: ✅ 3-pass review with all must-fix and should-fix findings resolved

## Files

12 files changed, +437 / -273 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character pair groups management now available in a dedicated, streamlined dialog interface.

* **Improvements**
  * Enhanced mobile responsiveness with improved touch target sizes for better accessibility.
  * Refined dialog layouts with improved scrolling behavior and overflow handling.
  * Optimized sidebar widths across mobile devices for enhanced usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->