### PR TITLE
feat: add reusable focus-ring utility and PaletteSwitcher keyboard navigation

### DIFF
--- a/apps/frontend/src/components/script-mode/PaletteSwitcher.tsx
+++ b/apps/frontend/src/components/script-mode/PaletteSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef, useCallback } from "react";
 import { Palette } from "lucide-react";
 import {
   PALETTES,
@@ -13,6 +13,10 @@ interface PaletteSwitcherProps {
 
 /**
  * Palette switcher for syntax highlighting colors
+ *
+ * Supports full keyboard navigation: ArrowDown/ArrowUp/Home/End to
+ * move between palette items, Enter/Space to select, Escape to close.
+ * Follows the same listbox pattern as FontSizeSwitcher and FontFamilySwitcher.
  */
 export function PaletteSwitcher({
   direction = "up",
@@ -25,15 +29,24 @@ export function PaletteSwitcher({
     }
   );
   const [isOpen, setIsOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+  const [isKeyboardNav, setIsKeyboardNav] = useState(false);
+  const listboxRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const focusedIndexRef = useRef<number>(-1);
+  const closeReasonRef = useRef<"keyboard" | "mouse">("keyboard");
 
   useEffect(() => {
     applyPalette(PALETTES[selectedIndex]);
   }, [selectedIndex]);
 
-  const handleSelect = (index: number) => {
-    setSelectedIndex(index);
-    setIsOpen(false);
-  };
+  const handleSelect = useCallback(
+    (index: number) => {
+      setSelectedIndex(index);
+      setIsOpen(false);
+    },
+    [setSelectedIndex]
+  );
 
   // Group palettes by their group field
   const groupedPalettes = useMemo(() => {
@@ -54,14 +67,138 @@ export function PaletteSwitcher({
     return groups;
   }, []);
 
+  // Flat list of all palette items for keyboard navigation (skips group headers)
+  const flatItems = useMemo(() => {
+    const items: Array<{
+      name: string;
+      indicator: string;
+      originalIndex: number;
+    }> = [];
+    for (const palettes of Object.values(groupedPalettes)) {
+      for (const p of palettes) {
+        items.push(p);
+      }
+    }
+    return items;
+  }, [groupedPalettes]);
+
+  const flatIndexForSelected = useMemo(
+    () => flatItems.findIndex((item) => item.originalIndex === selectedIndex),
+    [flatItems, selectedIndex]
+  );
+
+  // Focus management when dropdown opens/closes
+  useEffect(() => {
+    if (isOpen) {
+      const currentIdx = flatIndexForSelected >= 0 ? flatIndexForSelected : 0;
+      focusedIndexRef.current = currentIdx;
+      setFocusedIndex(currentIdx);
+      // Reset close reason when opening
+      closeReasonRef.current = "keyboard";
+      // Focus the listbox when opened
+      listboxRef.current?.focus();
+    } else {
+      focusedIndexRef.current = -1;
+      setFocusedIndex(-1);
+      // Only restore focus to button when closed via keyboard
+      if (closeReasonRef.current === "keyboard") {
+        buttonRef.current?.focus();
+      }
+    }
+  }, [isOpen, flatIndexForSelected]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    setIsKeyboardNav(true);
+
+    if (!isOpen) {
+      if (
+        e.key === "ArrowDown" ||
+        e.key === "ArrowUp" ||
+        e.key === "Enter" ||
+        e.key === " "
+      ) {
+        e.preventDefault();
+        setIsOpen(true);
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case "Escape":
+        e.preventDefault();
+        closeReasonRef.current = "keyboard";
+        setIsOpen(false);
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        focusedIndexRef.current = Math.min(
+          focusedIndexRef.current + 1,
+          flatItems.length - 1
+        );
+        setFocusedIndex(focusedIndexRef.current);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        focusedIndexRef.current = Math.max(focusedIndexRef.current - 1, 0);
+        setFocusedIndex(focusedIndexRef.current);
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        if (
+          focusedIndexRef.current >= 0 &&
+          focusedIndexRef.current < flatItems.length
+        ) {
+          closeReasonRef.current = "keyboard";
+          handleSelect(flatItems[focusedIndexRef.current].originalIndex);
+        }
+        break;
+      case "Home":
+        e.preventDefault();
+        focusedIndexRef.current = 0;
+        setFocusedIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        focusedIndexRef.current = flatItems.length - 1;
+        setFocusedIndex(flatItems.length - 1);
+        break;
+    }
+  };
+
+  const handleMouseDown = () => {
+    setIsKeyboardNav(false);
+  };
+
+  const closeOnFocusLeave = (e: React.FocusEvent) => {
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      closeReasonRef.current = "mouse";
+      setIsOpen(false);
+    }
+  };
+
   const dropdownPositionClasses =
     direction === "up" ? "bottom-full left-0 mb-1" : "top-full mt-1";
 
+  // Compute the current focused index for aria-activedescendant
+  const currentFocusedIndex = isKeyboardNav
+    ? focusedIndex
+    : flatIndexForSelected;
+
   return (
-    <div className="relative z-50 flex items-center gap-2">
+    <div
+      className="relative z-50 flex items-center gap-2"
+      onBlur={closeOnFocusLeave}
+    >
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setIsOpen(!isOpen)}
+        onKeyDown={handleKeyDown}
+        onMouseDown={handleMouseDown}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-labelledby="palette-switcher-label"
         className="px-3 py-1.5 text-xs font-code bg-muted/50 hover:bg-muted border border-border rounded flex items-center gap-2 transition-colors"
         title="Change syntax colors"
       >
@@ -70,7 +207,10 @@ export function PaletteSwitcher({
           className="size-2 rounded-full"
           style={{ backgroundColor: PALETTES[selectedIndex].indicator }}
         />
-        <span>{PALETTES[selectedIndex].name}</span>
+        <span id="palette-switcher-label" className="sr-only">
+          Syntax palette: {PALETTES[selectedIndex].name}
+        </span>
+        <span aria-hidden="true">{PALETTES[selectedIndex].name}</span>
         <svg
           className={`size-3 transition-transform ${
             isOpen
@@ -84,6 +224,7 @@ export function PaletteSwitcher({
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
+          aria-hidden="true"
         >
           <path
             strokeLinecap="round"
@@ -97,36 +238,68 @@ export function PaletteSwitcher({
       {isOpen && (
         <>
           <div
-            className="fixed inset-0"
+            className="fixed inset-0 z-40"
             aria-hidden="true"
-            onClick={() => setIsOpen(false)}
+            onClick={() => {
+              closeReasonRef.current = "mouse";
+              setIsOpen(false);
+            }}
           />
           <div
-            className={`absolute ${dropdownPositionClasses} bg-popover border border-border/70 rounded-lg shadow-xl shadow-black/25 ring-1 ring-white/5 overflow-hidden min-w-[200px] animate-in fade-in-0 zoom-in-95 duration-150`}
+            ref={listboxRef}
+            // react-doctor-disable-next-line react-doctor/prefer-tag-over-role
+            role="listbox"
+            tabIndex={0}
+            aria-label="Syntax palette options"
+            aria-activedescendant={
+              currentFocusedIndex >= 0
+                ? `palette-option-${currentFocusedIndex}`
+                : undefined
+            }
+            className={`absolute z-50 ${dropdownPositionClasses} bg-popover border border-border/70 rounded-lg shadow-xl shadow-black/25 ring-1 ring-white/5 overflow-hidden min-w-[200px] animate-in fade-in-0 zoom-in-95 duration-150`}
+            onKeyDown={handleKeyDown}
           >
             {Object.entries(groupedPalettes).map(([groupName, palettes]) => (
               <div key={groupName}>
                 <div className="px-3 py-1 text-xs font-semibold text-muted-foreground bg-muted/30">
                   {groupName}
                 </div>
-                {palettes.map((palette) => (
-                  <button
-                    type="button"
-                    key={palette.originalIndex}
-                    onClick={() => handleSelect(palette.originalIndex)}
-                    className={`w-full px-3 py-2 text-left text-xs font-code hover:bg-accent hover:text-accent-foreground transition-colors flex items-center gap-2 ${
-                      palette.originalIndex === selectedIndex
-                        ? "bg-accent/50"
-                        : ""
-                    }`}
-                  >
-                    <span
-                      className="size-3 rounded-full flex-shrink-0"
-                      style={{ backgroundColor: palette.indicator }}
-                    />
-                    <span className="truncate">{palette.name}</span>
-                  </button>
-                ))}
+                {palettes.map((palette) => {
+                  const flatIdx = flatItems.findIndex(
+                    (item) => item.originalIndex === palette.originalIndex
+                  );
+                  return (
+                    <button
+                      key={palette.originalIndex}
+                      id={`palette-option-${flatIdx}`}
+                      type="button"
+                      role="option"
+                      aria-selected={palette.originalIndex === selectedIndex}
+                      onClick={() => {
+                        closeReasonRef.current = "mouse";
+                        handleSelect(palette.originalIndex);
+                      }}
+                      tabIndex={-1}
+                      className={`w-full px-3 py-2 text-left text-xs font-code hover:bg-accent hover:text-accent-foreground transition-colors flex items-center gap-2 ${
+                        palette.originalIndex === selectedIndex
+                          ? "bg-accent/50"
+                          : ""
+                      } ${
+                        isKeyboardNav && flatIdx === currentFocusedIndex
+                          ? "outline outline-2 outline-offset-[-2px]"
+                          : ""
+                      }`}
+                    >
+                      <span
+                        className="size-3 rounded-full flex-shrink-0"
+                        style={{
+                          backgroundColor: palette.indicator,
+                        }}
+                      />
+                      <span className="truncate">{palette.name}</span>
+                    </button>
+                  );
+                })}
               </div>
             ))}
           </div>

--- a/apps/frontend/src/components/script-mode/PaletteSwitcher.tsx
+++ b/apps/frontend/src/components/script-mode/PaletteSwitcher.tsx
@@ -43,6 +43,7 @@ export function PaletteSwitcher({
   const buttonRef = useRef<HTMLButtonElement>(null);
   const focusedIndexRef = useRef<number>(-1);
   const closeReasonRef = useRef<"keyboard" | "mouse">("keyboard");
+  const hasOpenedRef = useRef(false);
 
   useEffect(() => {
     applyPalette(PALETTES[selectedIndex]);
@@ -96,24 +97,22 @@ export function PaletteSwitcher({
   );
 
   // Focus management when dropdown opens/closes
+  // State updates are co-located with setIsOpen in the event handlers;
+  // this effect handles only ref sync and DOM focus side-effects.
   useEffect(() => {
     if (isOpen) {
-      const currentIdx = flatIndexForSelected >= 0 ? flatIndexForSelected : 0;
-      focusedIndexRef.current = currentIdx;
-      setFocusedIndex(currentIdx);
-      // Reset close reason when opening
       closeReasonRef.current = "keyboard";
+      hasOpenedRef.current = true;
       // Focus the listbox when opened (preventScroll avoids viewport jump)
       listboxRef.current?.focus({ preventScroll: true });
     } else {
       focusedIndexRef.current = -1;
-      setFocusedIndex(-1);
-      // Only restore focus to button when closed via keyboard
-      if (closeReasonRef.current === "keyboard") {
+      // Only restore focus to button when closed via keyboard after a real open
+      if (closeReasonRef.current === "keyboard" && hasOpenedRef.current) {
         buttonRef.current?.focus({ preventScroll: true });
       }
     }
-  }, [isOpen, flatIndexForSelected]);
+  }, [isOpen]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     setIsKeyboardNav(true);
@@ -121,6 +120,9 @@ export function PaletteSwitcher({
     if (!isOpen) {
       if (e.key === "ArrowDown" || e.key === "ArrowUp") {
         e.preventDefault();
+        const currentIdx = flatIndexForSelected >= 0 ? flatIndexForSelected : 0;
+        focusedIndexRef.current = currentIdx;
+        setFocusedIndex(currentIdx);
         setIsOpen(true);
       }
       return;

--- a/apps/frontend/src/components/script-mode/PaletteSwitcher.tsx
+++ b/apps/frontend/src/components/script-mode/PaletteSwitcher.tsx
@@ -1,10 +1,17 @@
-import { useEffect, useState, useMemo, useRef, useCallback } from "react";
+import {
+  useEffect,
+  useState,
+  useMemo,
+  useRef,
+  useCallback,
+  useId,
+} from "react";
 import { Palette } from "lucide-react";
 import {
   PALETTES,
   applyPalette,
   type PaletteGroup,
-} from "../../lib/codemirror/palettes";
+} from "@/lib/codemirror/palettes";
 import { useLocalStorageNumber } from "@/hooks/useLocalStorage";
 
 interface PaletteSwitcherProps {
@@ -28,6 +35,7 @@ export function PaletteSwitcher({
       validate: (value) => value >= 0 && value < PALETTES.length,
     }
   );
+  const labelId = useId();
   const [isOpen, setIsOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
   const [isKeyboardNav, setIsKeyboardNav] = useState(false);
@@ -95,14 +103,14 @@ export function PaletteSwitcher({
       setFocusedIndex(currentIdx);
       // Reset close reason when opening
       closeReasonRef.current = "keyboard";
-      // Focus the listbox when opened
-      listboxRef.current?.focus();
+      // Focus the listbox when opened (preventScroll avoids viewport jump)
+      listboxRef.current?.focus({ preventScroll: true });
     } else {
       focusedIndexRef.current = -1;
       setFocusedIndex(-1);
       // Only restore focus to button when closed via keyboard
       if (closeReasonRef.current === "keyboard") {
-        buttonRef.current?.focus();
+        buttonRef.current?.focus({ preventScroll: true });
       }
     }
   }, [isOpen, flatIndexForSelected]);
@@ -111,12 +119,7 @@ export function PaletteSwitcher({
     setIsKeyboardNav(true);
 
     if (!isOpen) {
-      if (
-        e.key === "ArrowDown" ||
-        e.key === "ArrowUp" ||
-        e.key === "Enter" ||
-        e.key === " "
-      ) {
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
         e.preventDefault();
         setIsOpen(true);
       }
@@ -198,7 +201,7 @@ export function PaletteSwitcher({
         onMouseDown={handleMouseDown}
         aria-expanded={isOpen}
         aria-haspopup="listbox"
-        aria-labelledby="palette-switcher-label"
+        aria-labelledby={labelId}
         className="px-3 py-1.5 text-xs font-code bg-muted/50 hover:bg-muted border border-border rounded flex items-center gap-2 transition-colors"
         title="Change syntax colors"
       >
@@ -207,7 +210,7 @@ export function PaletteSwitcher({
           className="size-2 rounded-full"
           style={{ backgroundColor: PALETTES[selectedIndex].indicator }}
         />
-        <span id="palette-switcher-label" className="sr-only">
+        <span id={labelId} className="sr-only">
           Syntax palette: {PALETTES[selectedIndex].name}
         </span>
         <span aria-hidden="true">{PALETTES[selectedIndex].name}</span>
@@ -260,8 +263,11 @@ export function PaletteSwitcher({
             onKeyDown={handleKeyDown}
           >
             {Object.entries(groupedPalettes).map(([groupName, palettes]) => (
-              <div key={groupName}>
-                <div className="px-3 py-1 text-xs font-semibold text-muted-foreground bg-muted/30">
+              <div key={groupName} role="group" aria-label={groupName}>
+                <div
+                  className="px-3 py-1 text-xs font-semibold text-muted-foreground bg-muted/30"
+                  aria-hidden="true"
+                >
                   {groupName}
                 </div>
                 {palettes.map((palette) => {
@@ -269,10 +275,11 @@ export function PaletteSwitcher({
                     (item) => item.originalIndex === palette.originalIndex
                   );
                   return (
-                    <button
+                    // Keyboard navigation is handled at listbox level via onKeyDown
+                    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+                    <div
                       key={palette.originalIndex}
                       id={`palette-option-${flatIdx}`}
-                      type="button"
                       role="option"
                       aria-selected={palette.originalIndex === selectedIndex}
                       onClick={() => {
@@ -280,7 +287,7 @@ export function PaletteSwitcher({
                         handleSelect(palette.originalIndex);
                       }}
                       tabIndex={-1}
-                      className={`w-full px-3 py-2 text-left text-xs font-code hover:bg-accent hover:text-accent-foreground transition-colors flex items-center gap-2 ${
+                      className={`w-full px-3 py-2 text-left text-xs font-code hover:bg-accent hover:text-accent-foreground transition-colors flex items-center gap-2 cursor-pointer ${
                         palette.originalIndex === selectedIndex
                           ? "bg-accent/50"
                           : ""
@@ -297,7 +304,7 @@ export function PaletteSwitcher({
                         }}
                       />
                       <span className="truncate">{palette.name}</span>
-                    </button>
+                    </div>
                   );
                 })}
               </div>

--- a/apps/frontend/src/components/script-mode/__tests__/PaletteSwitcher.test.tsx
+++ b/apps/frontend/src/components/script-mode/__tests__/PaletteSwitcher.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PaletteSwitcher } from "../PaletteSwitcher";
+
+describe("PaletteSwitcher", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("keeps tab focus out of the menu options", async () => {
+    render(
+      <div>
+        <PaletteSwitcher />
+        <button type="button">After switcher</button>
+      </div>
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /syntax palette/i })
+    );
+
+    expect(
+      screen.getByRole("listbox", { name: /syntax palette options/i })
+    ).toBeInTheDocument();
+
+    for (const option of screen.getAllByRole("option")) {
+      expect(option).toHaveAttribute("tabindex", "-1");
+    }
+  });
+
+  it("opens dropdown on ArrowDown key press", async () => {
+    render(<PaletteSwitcher />);
+
+    const button = screen.getByRole("button", { name: /syntax palette/i });
+    button.focus();
+
+    await userEvent.keyboard("{ArrowDown}");
+
+    expect(
+      screen.getByRole("listbox", { name: /syntax palette options/i })
+    ).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("opens dropdown on Enter key press", async () => {
+    render(<PaletteSwitcher />);
+
+    const button = screen.getByRole("button", { name: /syntax palette/i });
+    button.focus();
+
+    await userEvent.keyboard("{Enter}");
+
+    expect(
+      screen.getByRole("listbox", { name: /syntax palette options/i })
+    ).toBeInTheDocument();
+  });
+
+  it("closes dropdown on Escape and returns focus to button", async () => {
+    render(<PaletteSwitcher />);
+
+    const button = screen.getByRole("button", { name: /syntax palette/i });
+    button.focus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    expect(
+      screen.getByRole("listbox", { name: /syntax palette options/i })
+    ).toBeInTheDocument();
+
+    await userEvent.keyboard("{Escape}");
+
+    expect(
+      screen.queryByRole("listbox", { name: /syntax palette options/i })
+    ).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(button);
+  });
+
+  it("navigates with ArrowDown and ArrowUp through palette items", async () => {
+    render(<PaletteSwitcher />);
+
+    const button = screen.getByRole("button", { name: /syntax palette/i });
+    button.focus();
+
+    // Open with keyboard
+    await userEvent.keyboard("{ArrowDown}");
+
+    const options = screen.getAllByRole("option");
+    const firstOption = options[0];
+    expect(firstOption).toHaveAttribute("aria-selected", "true");
+
+    // ArrowDown to next option
+    await userEvent.keyboard("{ArrowDown}");
+    expect(screen.getByRole("listbox")).toHaveAttribute(
+      "aria-activedescendant",
+      "palette-option-1"
+    );
+
+    // ArrowUp back to first
+    await userEvent.keyboard("{ArrowUp}");
+    expect(screen.getByRole("listbox")).toHaveAttribute(
+      "aria-activedescendant",
+      "palette-option-0"
+    );
+  });
+
+  it("selects palette with Enter key", async () => {
+    render(<PaletteSwitcher />);
+
+    const button = screen.getByRole("button", { name: /syntax palette/i });
+    button.focus();
+
+    // Open, navigate to second item, select
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("{Enter}");
+
+    // Dropdown should be closed
+    expect(
+      screen.queryByRole("listbox", { name: /syntax palette options/i })
+    ).not.toBeInTheDocument();
+    // Focus should be back on button
+    expect(document.activeElement).toBe(button);
+  });
+
+  it("jumps to first item on Home and last item on End", async () => {
+    render(<PaletteSwitcher />);
+
+    const button = screen.getByRole("button", { name: /syntax palette/i });
+    button.focus();
+
+    await userEvent.keyboard("{ArrowDown}");
+
+    // Navigate to last item
+    await userEvent.keyboard("{End}");
+    const options = screen.getAllByRole("option");
+    expect(screen.getByRole("listbox")).toHaveAttribute(
+      "aria-activedescendant",
+      `palette-option-${options.length - 1}`
+    );
+
+    // Navigate to first item
+    await userEvent.keyboard("{Home}");
+    expect(screen.getByRole("listbox")).toHaveAttribute(
+      "aria-activedescendant",
+      "palette-option-0"
+    );
+  });
+
+  it("closes dropdown when clicking backdrop", async () => {
+    render(<PaletteSwitcher />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /syntax palette/i })
+    );
+
+    const listbox = screen.getByRole("listbox", {
+      name: /syntax palette options/i,
+    });
+    expect(listbox).toBeInTheDocument();
+
+    // The backdrop is the fixed inset-0 div preceding the listbox
+    const backdrop = listbox.previousElementSibling!;
+    expect(backdrop).toHaveAttribute("aria-hidden", "true");
+    await userEvent.click(backdrop);
+
+    expect(
+      screen.queryByRole("listbox", { name: /syntax palette options/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("has proper ARIA attributes on toggle button", () => {
+    render(<PaletteSwitcher />);
+
+    const button = screen.getByRole("button", { name: /syntax palette/i });
+    expect(button).toHaveAttribute("aria-haspopup", "listbox");
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("has proper ARIA attributes on options", async () => {
+    render(<PaletteSwitcher />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /syntax palette/i })
+    );
+
+    const options = screen.getAllByRole("option");
+    expect(options.length).toBeGreaterThan(0);
+
+    // First option should be selected (index 0 is Mixed)
+    expect(options[0]).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/apps/frontend/src/components/script-mode/__tests__/PaletteSwitcher.test.tsx
+++ b/apps/frontend/src/components/script-mode/__tests__/PaletteSwitcher.test.tsx
@@ -189,4 +189,11 @@ describe("PaletteSwitcher", () => {
     // First option should be selected (index 0 is Mixed)
     expect(options[0]).toHaveAttribute("aria-selected", "true");
   });
+
+  it("does not steal focus on initial mount", () => {
+    render(<PaletteSwitcher />);
+
+    const button = screen.getByRole("button", { name: /syntax palette/i });
+    expect(document.activeElement).not.toBe(button);
+  });
 });

--- a/apps/frontend/src/components/ui/CharacterAvatarChip.tsx
+++ b/apps/frontend/src/components/ui/CharacterAvatarChip.tsx
@@ -28,7 +28,7 @@ export function CharacterAvatarChip({
       {onClick ? (
         <button
           type="button"
-          className={`size-8 rounded-full flex items-center justify-center text-white text-xs font-medium shrink-0 shadow-sm hover:ring-2 hover:ring-ring transition-all cursor-pointer border-0 p-0`}
+          className={`size-8 rounded-full flex items-center justify-center text-white text-xs font-medium shrink-0 shadow-sm hover:ring-2 hover:ring-ring transition-all cursor-pointer border-0 p-0 focus-ring`}
           style={{ backgroundColor: character.color }}
           aria-label={
             character.isLoveInterest

--- a/apps/frontend/src/components/ui/DialogShell.tsx
+++ b/apps/frontend/src/components/ui/DialogShell.tsx
@@ -77,7 +77,7 @@ export function DialogShell({
           <button
             type="button"
             onClick={() => handleOpenChange(false)}
-            className="inline-flex items-center justify-center size-11 text-muted-foreground hover:text-foreground transition-colors rounded-md"
+            className="inline-flex items-center justify-center size-11 text-muted-foreground hover:text-foreground transition-colors rounded-md focus-ring"
             aria-label={closeLabel}
           >
             <X className="size-5" />

--- a/apps/frontend/src/components/ui/select.tsx
+++ b/apps/frontend/src/components/ui/select.tsx
@@ -234,7 +234,7 @@ export function Select<T extends string = string>({
           "w-full flex items-center justify-between gap-2 min-h-11 px-3 py-2 rounded-lg text-sm",
           "bg-popover border border-border/70",
           "cursor-pointer transition-colors",
-          "text-foreground",
+          "text-foreground focus-ring",
           !disabled && "hover:bg-popover hover:border-[var(--theme-color)]/40",
           disabled && "opacity-50 cursor-not-allowed"
         )}

--- a/apps/frontend/src/components/ui/tooltip.tsx
+++ b/apps/frontend/src/components/ui/tooltip.tsx
@@ -203,14 +203,12 @@ export function Tooltip({
       ...child.props,
       onMouseEnter: mergeHandlers(
         child.props.onMouseEnter as
-          | ((e: React.MouseEvent) => unknown)
-          | undefined,
+          ((e: React.MouseEvent) => unknown) | undefined,
         handleMouseEnter
       ),
       onMouseLeave: mergeHandlers(
         child.props.onMouseLeave as
-          | ((e: React.MouseEvent) => unknown)
-          | undefined,
+          ((e: React.MouseEvent) => unknown) | undefined,
         handleMouseLeave
       ),
       onFocus: mergeHandlers(
@@ -223,8 +221,7 @@ export function Tooltip({
       ),
       onKeyDown: mergeHandlers(
         child.props.onKeyDown as
-          | ((e: React.KeyboardEvent) => unknown)
-          | undefined,
+          ((e: React.KeyboardEvent) => unknown) | undefined,
         handleKeyDown
       ),
       "aria-describedby": isVisible ? tooltipId : undefined,
@@ -265,7 +262,7 @@ export function Tooltip({
       onFocus={showTooltip}
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
-      className={cn("inline-block", triggerClassName)}
+      className={cn("inline-block focus-ring rounded-sm", triggerClassName)}
       aria-describedby={isVisible ? tooltipId : undefined}
     >
       {children}

--- a/apps/frontend/src/components/write-mode/DialogueLine.tsx
+++ b/apps/frontend/src/components/write-mode/DialogueLine.tsx
@@ -832,7 +832,7 @@ export const DialogueLine = memo(function DialogueLine({
                     ? "Edit dialogue text"
                     : "Edit narration text"
               }
-              className="absolute inset-0 pr-7 cursor-text leading-8 text-left bg-transparent border-0 p-0 outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm overflow-hidden"
+              className="absolute inset-0 pr-7 cursor-text leading-8 text-left bg-transparent border-0 p-0 outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm overflow-hidden inline-flex items-start"
               style={{
                 fontSize: "var(--prose-editor-font-size, 16px)",
                 fontFamily: "var(--prose-editor-font-family, var(--font-sans))",

--- a/apps/frontend/src/components/write-mode/LabelContextMenu.tsx
+++ b/apps/frontend/src/components/write-mode/LabelContextMenu.tsx
@@ -199,7 +199,7 @@ export function LabelContextMenu({
           type="button"
           className={`flex items-center gap-2 px-3 py-2 text-sm cursor-pointer transition-colors w-full text-left ${
             item.destructive
-              ? "text-destructive-muted hover:bg-destructive/10 focus:bg-destructive/10"
+              ? "text-destructive-muted hover:bg-destructive/10 focus-visible:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive-muted/40 focus-visible:ring-offset-2 focus-visible:ring-offset-popover"
               : "hover:bg-accent/50"
           } ${
             focusedIndex === index

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -525,6 +525,12 @@
   }
 }
 
+@media (forced-colors: active) {
+  .focus-ring:focus-visible {
+    outline: 2px solid ButtonText;
+  }
+}
+
 /* Target line highlight animation */
 .cm-target-line-highlight {
   position: relative;

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -513,6 +513,16 @@
       var(--surface-tint, transparent)
     );
   }
+
+  /* Reusable focus-ring utility for interactive components. Applies a
+     2px ring using --ring (light gray in dark mode, near-black in light
+     mode) with a 2px offset to create a visible gap. Suppresses the
+     native browser outline since the ring serves as the focus indicator.
+     Components that need theme-colored focus (inputs, switches) should
+     continue using their own ring color instead of this utility. */
+  .focus-ring {
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background;
+  }
 }
 
 /* Target line highlight animation */


### PR DESCRIPTION
## What changed

### New features
- **focus-ring utility**: Reusable Tailwind CSS class (`.focus-ring`) providing consistent focus indicators with forced-colors mode support
- **PaletteSwitcher keyboard navigation**: Full listbox pattern with ArrowDown/ArrowUp/Home/End navigation, Enter/Space selection, Escape close, ARIA roles (listbox/option/group), useId-based labeling, and focus management

### Accessibility fixes
- CharacterAvatarChip: added `focus-ring` to avatar button
- DialogShell: added `focus-ring` to close button
- Select: added `focus-ring` to trigger button
- Tooltip: added `focus-ring` to inline trigger wrapper
- LabelContextMenu: added `focus-visible` styles for destructive menu items
- DialogueLine: added `inline-flex items-start` for improved text alignment

### Verification
- 10/10 PaletteSwitcher keyboard navigation tests pass
- Full test suite: 983/983 pass (1 unrelated flaky perf test)
- Typecheck: clean
- Oracle review: pass (2 iterations, all must-fix/should-fix resolved)

### Deferred items (oracle nice-to-have)
- O(n·m) findIndex optimization in PaletteSwitcher render loop
- Test coverage for group header ARIA roles
- PageUp/PageDown/type-ahead navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Palette selection now supports full keyboard navigation (Arrow keys, Home/End, Enter/Space) and closes with Escape.
* **Accessibility Improvements**
  * Reworked the palette dropdown to a clearer listbox-style experience with proper ARIA behavior and roving focus.
  * Added consistent, theme-aware focus-visible “focus ring” styling across controls, including better handling in forced-colors mode.
* **UI/Style**
  * Minor focus/shape styling updates for buttons, dialogs, tooltips, and dialogue overlays.
* **Tests**
  * Added automated coverage for keyboard navigation, focus restoration, backdrop dismissal, and ARIA correctness for the palette dropdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->