### PR TITLE
fix: prevent Write Mode dialogue desync with LCS alignment

### DIFF
--- a/apps/backend/src/routes/__tests__/labels.routes.integration.test.ts
+++ b/apps/backend/src/routes/__tests__/labels.routes.integration.test.ts
@@ -421,7 +421,9 @@ describe("LabelsRoutes (Integration)", () => {
       .where(eq(labelLines.labelId, introLabelId))
       .orderBy(asc(labelLines.sequence));
 
-    // seq 1: updated NARRATION, seq 2: MENU, seq 3: JUMP, seq 4: new DIALOGUE, seq 5: new NARRATION
+    // seq 1: updated NARRATION, seq 2: MENU, seq 3: new DIALOGUE, seq 4: new NARRATION, seq 5: JUMP
+    // New prose lines are inserted after the MENU block (menu-aware ordering)
+    // so Write Mode reload matches Script Mode: prompt → choices → new prose.
     expect(lines).toHaveLength(5);
 
     expect(lines[0].contentType).toBe("NARRATION");
@@ -436,14 +438,14 @@ describe("LabelsRoutes (Integration)", () => {
       },
     ]);
 
-    expect(lines[2].contentType).toBe("JUMP");
-    expect(lines[2].content).toBe("jump ending");
+    expect(lines[2].contentType).toBe("DIALOGUE");
+    expect(lines[2].content).toBe("Second prose");
+    expect(lines[2].speakerId).toBe(testCharacterId);
 
-    expect(lines[3].contentType).toBe("DIALOGUE");
-    expect(lines[3].content).toBe("Second prose");
-    expect(lines[3].speakerId).toBe(testCharacterId);
+    expect(lines[3].contentType).toBe("NARRATION");
+    expect(lines[3].content).toBe("Third prose");
 
-    expect(lines[4].contentType).toBe("NARRATION");
-    expect(lines[4].content).toBe("Third prose");
+    expect(lines[4].contentType).toBe("JUMP");
+    expect(lines[4].content).toBe("jump ending");
   });
 });

--- a/apps/backend/src/routes/labels.routes.ts
+++ b/apps/backend/src/routes/labels.routes.ts
@@ -55,6 +55,7 @@ import { eq, asc, inArray, isNull, and, sql } from "drizzle-orm";
 import { calculateLinesHash, calculateContentHash } from "../lib/hash.js";
 import { updateAuditFields } from "../lib/audit.js";
 import { trackWordsForLabel } from "../services/word-count.service.js";
+import { planDialogueLineUpdates } from "../services/rpy/plan-dialogue-updates.js";
 
 // ============================================================================
 // Types
@@ -346,68 +347,80 @@ async function updateLabelDialogueHandler(
         )
         .orderBy(asc(labelLines.sequence));
 
-      // Separate prose lines (DIALOGUE/NARRATION) from non-prose lines (MENU/JUMP).
-      // Non-prose lines are structural and must be preserved during prose edits –
-      // the frontend only sends DIALOGUE/NARRATION entries, so mapping 1:1 by
-      // sequence would overwrite or delete MENU/JUMP lines.
-      const proseLines = existingLines.filter(
-        (line) =>
-          line.contentType === "DIALOGUE" || line.contentType === "NARRATION"
-      );
-      const _nonProseLines = existingLines.filter(
-        (line) =>
-          line.contentType !== "DIALOGUE" && line.contentType !== "NARRATION"
+      // Align prose against the incoming list so mid-list inserts/deletes keep
+      // VISUAL/MENU rows interleaved correctly (not appended at max sequence).
+      const plan = planDialogueLineUpdates(
+        existingLines.map((line) => ({
+          id: line.id,
+          sequence: line.sequence,
+          contentType: line.contentType,
+          content: line.content,
+          speakerId: line.speakerId,
+        })),
+        dialogue
       );
 
-      const maxExistingSequence = Math.max(
-        ...existingLines.map((l) => l.sequence),
-        0
-      );
-      let nextSequence = maxExistingSequence + 1;
+      // 2. Delete removed prose rows (structural MENU/JUMP/VISUAL are never deleted)
+      if (plan.deleteIds.length > 0) {
+        await tx
+          .delete(labelLines)
+          .where(inArray(labelLines.id, plan.deleteIds));
+      }
 
-      // 2. Update existing prose lines by position among prose lines, insert new ones
-      for (const [index, entry] of dialogue.entries()) {
-        const existingProseLine = proseLines[index];
+      // 3. Update matched prose rows in place
+      for (const update of plan.updates) {
+        await tx
+          .update(labelLines)
+          .set({
+            contentType: (update.speakerId ? "DIALOGUE" : "NARRATION") as
+              "DIALOGUE" | "NARRATION",
+            content: update.text,
+            speakerId: update.speakerId,
+            demoNotes: null,
+            isDirty: true,
+            projectFileId: lockedProjectFile.id,
+            contentHash: calculateContentHash(update.text),
+            lastSyncedHash: null,
+            sequence: plan.sequenceByKey.get(update.id)!,
+          })
+          .where(eq(labelLines.id, update.id));
+      }
 
-        const values = {
-          contentType: (entry.speakerId ? "DIALOGUE" : "NARRATION") as
+      // 4. Insert new prose rows at planned sequences
+      for (const insert of plan.inserts) {
+        await tx.insert(labelLines).values({
+          labelId,
+          sequence: insert.sequence,
+          contentType: (insert.speakerId ? "DIALOGUE" : "NARRATION") as
             "DIALOGUE" | "NARRATION",
-          content: entry.text,
-          speakerId: entry.speakerId,
+          content: insert.text,
+          speakerId: insert.speakerId,
           demoNotes: null,
           isDirty: true,
           projectFileId: lockedProjectFile.id,
-          contentHash: calculateContentHash(entry.text),
+          contentHash: calculateContentHash(insert.text),
           lastSyncedHash: null,
-        };
+        });
+      }
 
-        if (existingProseLine) {
-          // Update existing prose line, preserving its sequence position
-          // so non-prose lines at other sequences remain undisturbed
+      // 5. Reindex non-prose rows that shifted due to inserts/deletes
+      for (const line of existingLines) {
+        if (
+          line.contentType === "DIALOGUE" ||
+          line.contentType === "NARRATION"
+        ) {
+          continue;
+        }
+        const newSequence = plan.sequenceByKey.get(line.id);
+        if (newSequence !== undefined && newSequence !== line.sequence) {
           await tx
             .update(labelLines)
-            .set(values)
-            .where(eq(labelLines.id, existingProseLine.id));
-        } else {
-          // Insert new line after all existing sequences
-          await tx.insert(labelLines).values({
-            labelId,
-            sequence: nextSequence++,
-            ...values,
-          });
+            .set({ sequence: newSequence })
+            .where(eq(labelLines.id, line.id));
         }
       }
 
-      // 3. Delete only prose lines beyond the dialogue entry count.
-      // Non-prose lines (MENU/JUMP) are never deleted during prose edits.
-      const proseLinesToDelete = proseLines.slice(dialogue.length);
-      const idsToDelete = proseLinesToDelete.map((line) => line.id);
-
-      if (idsToDelete.length > 0) {
-        await tx.delete(labelLines).where(inArray(labelLines.id, idsToDelete));
-      }
-
-      // 3.5. Process menu blocks - update MENU lines' menuOptions
+      // 6. Process menu blocks - update MENU lines' menuOptions
       if (menuBlocks && menuBlocks.length > 0) {
         for (const block of menuBlocks) {
           const menuContentHash = calculateContentHash(
@@ -437,7 +450,7 @@ async function updateLabelDialogueHandler(
         }
       }
 
-      // 4. Compute content hash from the actual persisted label_lines
+      // 7. Compute content hash from the actual persisted label_lines
       // (includes MENU/JUMP rows preserved during prose edits) so the hash
       // stays consistent with sync/import flows that use calculateLinesHash.
       const finalLines = await tx
@@ -449,7 +462,7 @@ async function updateLabelDialogueHandler(
         .orderBy(asc(labelLines.sequence));
       const contentHash = calculateLinesHash(finalLines);
 
-      // 5. Update label with audit fields and sync status
+      // 8. Update label with audit fields and sync status
       const auditFields = updateAuditFields(lockedCurrentVersion, user.id);
       await tx
         .update(labels)

--- a/apps/backend/src/routes/labels.routes.ts
+++ b/apps/backend/src/routes/labels.routes.ts
@@ -367,58 +367,70 @@ async function updateLabelDialogueHandler(
           .where(inArray(labelLines.id, plan.deleteIds));
       }
 
-      // 3. Update matched prose rows in place
-      for (const update of plan.updates) {
-        await tx
-          .update(labelLines)
-          .set({
-            contentType: (update.speakerId ? "DIALOGUE" : "NARRATION") as
+      // 3. Update matched prose rows in place (independent writes)
+      await Promise.all(
+        plan.updates.map((update) =>
+          tx
+            .update(labelLines)
+            .set({
+              contentType: (update.speakerId ? "DIALOGUE" : "NARRATION") as
+                "DIALOGUE" | "NARRATION",
+              content: update.text,
+              speakerId: update.speakerId,
+              demoNotes: null,
+              isDirty: true,
+              projectFileId: lockedProjectFile.id,
+              contentHash: calculateContentHash(update.text),
+              lastSyncedHash: null,
+              sequence: plan.sequenceByKey.get(update.id)!,
+            })
+            .where(eq(labelLines.id, update.id))
+        )
+      );
+
+      // 4. Insert new prose rows at planned sequences (bulk)
+      if (plan.inserts.length > 0) {
+        await tx.insert(labelLines).values(
+          plan.inserts.map((insert) => ({
+            labelId,
+            sequence: insert.sequence,
+            contentType: (insert.speakerId ? "DIALOGUE" : "NARRATION") as
               "DIALOGUE" | "NARRATION",
-            content: update.text,
-            speakerId: update.speakerId,
+            content: insert.text,
+            speakerId: insert.speakerId,
             demoNotes: null,
             isDirty: true,
             projectFileId: lockedProjectFile.id,
-            contentHash: calculateContentHash(update.text),
+            contentHash: calculateContentHash(insert.text),
             lastSyncedHash: null,
-            sequence: plan.sequenceByKey.get(update.id)!,
-          })
-          .where(eq(labelLines.id, update.id));
-      }
-
-      // 4. Insert new prose rows at planned sequences
-      for (const insert of plan.inserts) {
-        await tx.insert(labelLines).values({
-          labelId,
-          sequence: insert.sequence,
-          contentType: (insert.speakerId ? "DIALOGUE" : "NARRATION") as
-            "DIALOGUE" | "NARRATION",
-          content: insert.text,
-          speakerId: insert.speakerId,
-          demoNotes: null,
-          isDirty: true,
-          projectFileId: lockedProjectFile.id,
-          contentHash: calculateContentHash(insert.text),
-          lastSyncedHash: null,
-        });
+          }))
+        );
       }
 
       // 5. Reindex non-prose rows that shifted due to inserts/deletes
-      for (const line of existingLines) {
+      const structuralReindexes = existingLines.filter((line) => {
         if (
           line.contentType === "DIALOGUE" ||
           line.contentType === "NARRATION"
         ) {
-          continue;
+          return false;
         }
         const newSequence = plan.sequenceByKey.get(line.id);
-        if (newSequence !== undefined && newSequence !== line.sequence) {
-          await tx
+        return newSequence !== undefined && newSequence !== line.sequence;
+      });
+      await Promise.all(
+        structuralReindexes.map((line) =>
+          tx
             .update(labelLines)
-            .set({ sequence: newSequence })
-            .where(eq(labelLines.id, line.id));
-        }
-      }
+            .set({
+              sequence: plan.sequenceByKey.get(line.id)!,
+              projectFileId: lockedProjectFile.id,
+              isDirty: true,
+              lastSyncedHash: null,
+            })
+            .where(eq(labelLines.id, line.id))
+        )
+      );
 
       // 6. Process menu blocks - update MENU lines' menuOptions
       if (menuBlocks && menuBlocks.length > 0) {

--- a/apps/backend/src/services/__tests__/rpy-parser.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/rpy-parser.service.unit.test.ts
@@ -1330,6 +1330,40 @@ label chapter1:
       expect(result).toContain('e "Updated speaker"');
     });
 
+    it("should replace multiple consecutive dialogue lines without shifting visuals", () => {
+      const original = `label start:
+    scene bg1
+    a "one"
+    show a happy
+    b "two"
+    show b sad
+    c "three"
+`;
+
+      const updatedDialogue = new Map([
+        [
+          "start",
+          [
+            { speaker: "a", text: "ONE" },
+            { speaker: "b", text: "TWO" },
+            { speaker: "c", text: "THREE" },
+          ],
+        ],
+      ]);
+
+      const result = reconstructRPYFile({
+        originalContent: original,
+        updatedDialogue,
+      });
+
+      expect(result).toMatch(/scene bg1\n\s*a "ONE"/);
+      expect(result).toMatch(/show a happy\n\s*b "TWO"/);
+      expect(result).toMatch(/show b sad\n\s*c "THREE"/);
+      expect(result).not.toContain('"one"');
+      expect(result).not.toContain('"two"');
+      expect(result).not.toContain('"three"');
+    });
+
     it("should place dialogue inserted after a menu title outside the menu block", () => {
       // Write Mode payload is flat prose: menu title then the new line (choices
       // are not in the dialogue list). Inserts after the title must not land
@@ -1683,6 +1717,44 @@ label second:
         { type: "equal", origIndex: 2, updatedIndex: 1 },
       ]);
     });
+    it("should coalesce multiple consecutive replacements in one edit run", () => {
+      const ops = alignDialogue(
+        [
+          { speaker: "a", text: "one" },
+          { speaker: "b", text: "two" },
+          { speaker: "c", text: "three" },
+        ],
+        [
+          { speaker: "a", text: "ONE" },
+          { speaker: "b", text: "TWO" },
+          { speaker: "c", text: "THREE" },
+        ]
+      );
+      expect(ops).toEqual([
+        { type: "replace", origIndex: 0, updatedIndex: 0 },
+        { type: "replace", origIndex: 1, updatedIndex: 1 },
+        { type: "replace", origIndex: 2, updatedIndex: 2 },
+      ]);
+    });
+
+    it("should pair multi-delete/multi-insert runs without leaving a stray delete", () => {
+      // Old pairwise coalescing turned delete,delete,insert,insert into
+      // delete + replace + insert — wrong. Must be replace, replace.
+      const ops = alignDialogue(
+        [
+          { speaker: null, text: "A" },
+          { speaker: null, text: "B" },
+        ],
+        [
+          { speaker: null, text: "X" },
+          { speaker: null, text: "Y" },
+        ]
+      );
+      expect(ops).toEqual([
+        { type: "replace", origIndex: 0, updatedIndex: 0 },
+        { type: "replace", origIndex: 1, updatedIndex: 1 },
+      ]);
+    });
   });
 
   describe("planDialogueLineUpdates", () => {
@@ -1840,19 +1912,19 @@ label second:
 
       // No prose to delete
       expect(plan.deleteIds).toEqual([]);
-      // Prose inserted after structural rows
+      // MENU → new prose → JUMP (terminal control stays at end)
       expect(plan.sequenceByKey.get(mId)).toBe(1);
-      expect(plan.sequenceByKey.get(jId)).toBe(2);
-      expect(plan.sequenceByKey.get("insert:0")).toBe(3);
-      expect(plan.sequenceByKey.get("insert:1")).toBe(4);
+      expect(plan.sequenceByKey.get("insert:0")).toBe(2);
+      expect(plan.sequenceByKey.get("insert:1")).toBe(3);
+      expect(plan.sequenceByKey.get(jId)).toBe(4);
       expect(plan.inserts).toHaveLength(2);
       expect(plan.inserts[0]).toMatchObject({
-        sequence: 3,
+        sequence: 2,
         speakerId: "char-a",
         text: "First line",
       });
       expect(plan.inserts[1]).toMatchObject({
-        sequence: 4,
+        sequence: 3,
         speakerId: "char-b",
         text: "Second line",
       });

--- a/apps/backend/src/services/__tests__/rpy-parser.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/rpy-parser.service.unit.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { testUuid } from "../../utils/test-ids.js";
 import {
   parseRPYContent,
   extractLabels,
@@ -25,6 +26,8 @@ import {
   reconstructRPYFile,
   addLabelToRPYContent,
   parseLabelBoundaries,
+  alignDialogue,
+  planDialogueLineUpdates,
 } from "../rpy-parser.service.js";
 
 describe("RPYParserService", () => {
@@ -1078,7 +1081,7 @@ label chapter1:
       expect(result).toContain("label chapter1:");
     });
 
-    it("should handle fewer updated entries than original", () => {
+    it("should delete removed dialogue lines when update has fewer entries", () => {
       const updatedDialogue = new Map([
         ["start", [{ speaker: null, text: "Only one line" }]],
       ]);
@@ -1088,10 +1091,9 @@ label chapter1:
         updatedDialogue,
       });
 
-      // Original lines should be preserved when update has fewer entries
       expect(result).toContain('Only one line"');
-      // The second original line should still be there (preserved)
-      expect(result).toContain('s "Original line 2"');
+      // Deleted lines must not linger in the RPY file
+      expect(result).not.toContain('s "Original line 2"');
     });
 
     it("should append extra updated dialogue entries", () => {
@@ -1117,6 +1119,136 @@ label chapter1:
       expect(result).toContain('Line 1"');
       expect(result).toContain('Line 2"');
       expect(result).toContain('Line 3 (extra)"');
+    });
+
+    it("should insert mid-list dialogue without shifting scene/show partners", () => {
+      // Regression: Example 2 — insert between prose lines interleaved with visuals
+      const original = `label start:
+    scene ai1_hw1 with fade
+    "At a certain mansion in Hornwood..."
+    show ai1_hw2 with dissolve
+    play ambiance sfx_breakfast_ambiance
+    "...Nelson was lost in thought."
+    scene ai1_hw3
+    ma "Nelson, I was..."
+    show ai1_hw4
+    ne "(Riley asked me to get coffee with her...)"
+`;
+
+      const updatedDialogue = new Map([
+        [
+          "start",
+          [
+            { speaker: null, text: "At a certain mansion in Hornwood..." },
+            { speaker: null, text: "...Nelson was lost in thought." },
+            { speaker: "le", text: "Added dialogue" },
+            { speaker: "ma", text: "Nelson, I was..." },
+            {
+              speaker: "ne",
+              text: "(Riley asked me to get coffee with her...)",
+            },
+          ],
+        ],
+      ]);
+
+      const result = reconstructRPYFile({
+        originalContent: original,
+        updatedDialogue,
+      });
+
+      // Keywords stay paired with their original dialogue partners
+      expect(result).toMatch(/scene ai1_hw3\n\s*ma "Nelson, I was\.\.\."/);
+      expect(result).toMatch(
+        /show ai1_hw4\n\s*ne "\(Riley asked me to get coffee with her\.\.\.\)"/
+      );
+      // New line sits after the preceding matched prose (Nelson narration), before ma's scene block partners stay intact
+      expect(result).toMatch(
+        /\.\.\.Nelson was lost in thought\."\n\s*le "Added dialogue"\n\s*scene ai1_hw3/
+      );
+    });
+
+    it("should insert mid-list dialogue before menu without stealing the menu title", () => {
+      // Regression: Example 1 — insert before menu title narration
+      const original = `label start:
+    w "Game contains sexually explicit material."
+    w "Narrative also delves into sensitive themes."
+
+    if not persistent.age_verified:
+        hide logo
+        menu:
+            "{i}Are {b}you{/b} over 18?{/i}"
+
+            "Yes, I am.":
+                $ persistent.age_verified = True
+                jump start_continued
+
+            "No, I'm not.":
+                $ persistent.age_verified = False
+                jump not_18
+`;
+
+      const updatedDialogue = new Map([
+        [
+          "start",
+          [
+            {
+              speaker: "w",
+              text: "Game contains sexually explicit material.",
+            },
+            { speaker: "w", text: "Added dialogue" },
+            {
+              speaker: "w",
+              text: "Narrative also delves into sensitive themes.",
+            },
+            { speaker: null, text: "{i}Are {b}you{/b} over 18?{/i}" },
+          ],
+        ],
+      ]);
+
+      const result = reconstructRPYFile({
+        originalContent: original,
+        updatedDialogue,
+      });
+
+      // New line is outside the menu
+      expect(result).toMatch(
+        /w "Added dialogue"\n\s*w "Narrative also delves into sensitive themes\."/
+      );
+      // Menu title stays inside the menu block
+      expect(result).toMatch(
+        /menu:\n\s*"\{i\}Are \{b\}you\{\/b\} over 18\?\{\/i\}"/
+      );
+      // Menu title must not appear as a stray line after the menu
+      const titleMatches = result.match(
+        /"\{i\}Are \{b\}you\{\/b\} over 18\?\{\/i\}"/g
+      );
+      expect(titleMatches).toHaveLength(1);
+      // Narrative must not become the menu title
+      expect(result).not.toMatch(
+        /menu:\n\s*w "Narrative also delves into sensitive themes\."/
+      );
+    });
+
+    it("should delete mid-list dialogue while keeping nearby show statements", () => {
+      const original = `label start:
+    scene ai1_hw3
+    ma "Nelson, I was..."
+    show ai1_hw4
+    ne "(Riley asked me...)"
+`;
+
+      const updatedDialogue = new Map([
+        ["start", [{ speaker: "ne", text: "(Riley asked me...)" }]],
+      ]);
+
+      const result = reconstructRPYFile({
+        originalContent: original,
+        updatedDialogue,
+      });
+
+      expect(result).not.toContain('ma "Nelson, I was..."');
+      expect(result).toContain("show ai1_hw4");
+      expect(result).toContain('ne "(Riley asked me...)"');
     });
 
     it("should preserve original indentation", () => {
@@ -1196,6 +1328,48 @@ label chapter1:
       });
 
       expect(result).toContain('e "Updated speaker"');
+    });
+
+    it("should place dialogue inserted after a menu title outside the menu block", () => {
+      // Write Mode payload is flat prose: menu title then the new line (choices
+      // are not in the dialogue list). Inserts after the title must not land
+      // inside the menu: block.
+      const original = `label start:
+    "Before menu"
+    menu:
+        "Are you sure?"
+        "Yes":
+            jump yes_label
+        "No":
+            jump no_label
+    "After menu"
+`;
+
+      const updatedDialogue = new Map([
+        [
+          "start",
+          [
+            { speaker: null, text: "Before menu" },
+            { speaker: null, text: "Are you sure?" },
+            { speaker: null, text: "Added after menu" },
+            { speaker: null, text: "After menu" },
+          ],
+        ],
+      ]);
+
+      const result = reconstructRPYFile({
+        originalContent: original,
+        updatedDialogue,
+      });
+
+      expect(result).toMatch(
+        /jump no_label\n\s*"Added after menu"\n\s*"After menu"/
+      );
+      expect(result).not.toMatch(
+        /menu:\n\s*"Are you sure\?"\n\s*"Added after menu"/
+      );
+      const titleMatches = result.match(/"Are you sure\?"/g);
+      expect(titleMatches).toHaveLength(1);
     });
 
     it("should NOT duplicate menu title during reconstruction", () => {
@@ -1460,6 +1634,455 @@ label second:
       const result = parseLabelBoundaries(content);
       expect(result[0].startLine).toBe(0);
       expect(result[0].endLine).toBe(4);
+    });
+  });
+
+  describe("alignDialogue", () => {
+    it("should detect mid-list inserts", () => {
+      const ops = alignDialogue(
+        [
+          { speaker: null, text: "A" },
+          { speaker: null, text: "B" },
+        ],
+        [
+          { speaker: null, text: "A" },
+          { speaker: "x", text: "X" },
+          { speaker: null, text: "B" },
+        ]
+      );
+      expect(ops).toEqual([
+        { type: "equal", origIndex: 0, updatedIndex: 0 },
+        { type: "insert", updatedIndex: 1 },
+        { type: "equal", origIndex: 1, updatedIndex: 2 },
+      ]);
+    });
+
+    it("should coalesce in-place edits to replace", () => {
+      const ops = alignDialogue(
+        [{ speaker: "a", text: "old" }],
+        [{ speaker: "a", text: "new" }]
+      );
+      expect(ops).toEqual([{ type: "replace", origIndex: 0, updatedIndex: 0 }]);
+    });
+
+    it("should detect deletes", () => {
+      const ops = alignDialogue(
+        [
+          { speaker: null, text: "A" },
+          { speaker: null, text: "B" },
+          { speaker: null, text: "C" },
+        ],
+        [
+          { speaker: null, text: "A" },
+          { speaker: null, text: "C" },
+        ]
+      );
+      expect(ops).toEqual([
+        { type: "equal", origIndex: 0, updatedIndex: 0 },
+        { type: "delete", origIndex: 1 },
+        { type: "equal", origIndex: 2, updatedIndex: 1 },
+      ]);
+    });
+  });
+
+  describe("planDialogueLineUpdates", () => {
+    // Nested menus (menu inside a menu choice) are out of scope for this function.
+    // The planDialogueLineUpdates function treats each menu: line as an atomic
+    // structural block regardless of nesting depth.
+    it("should insert prose between visuals at the correct sequence", () => {
+      const existing = [
+        {
+          id: "v1",
+          sequence: 1,
+          contentType: "VISUAL",
+          content: "",
+          speakerId: null,
+        },
+        {
+          id: "p1",
+          sequence: 2,
+          contentType: "DIALOGUE",
+          content: "Nelson, I was...",
+          speakerId: "char-ma",
+        },
+        {
+          id: "v2",
+          sequence: 3,
+          contentType: "VISUAL",
+          content: "",
+          speakerId: null,
+        },
+        {
+          id: "p2",
+          sequence: 4,
+          contentType: "DIALOGUE",
+          content: "(Riley...)",
+          speakerId: "char-ne",
+        },
+      ];
+
+      const plan = planDialogueLineUpdates(existing, [
+        { speakerId: "char-ma", text: "Nelson, I was..." },
+        { speakerId: "char-le", text: "Added dialogue" },
+        { speakerId: "char-ne", text: "(Riley...)" },
+      ]);
+
+      expect(plan.deleteIds).toEqual([]);
+      expect(plan.inserts).toHaveLength(1);
+      expect(plan.inserts[0]).toMatchObject({
+        speakerId: "char-le",
+        text: "Added dialogue",
+      });
+      // Order: v1, p1, new, v2, p2
+      expect(plan.sequenceByKey.get("v1")).toBe(1);
+      expect(plan.sequenceByKey.get("p1")).toBe(2);
+      expect(plan.sequenceByKey.get("insert:0")).toBe(3);
+      expect(plan.sequenceByKey.get("v2")).toBe(4);
+      expect(plan.sequenceByKey.get("p2")).toBe(5);
+    });
+
+    it("should place inserts after MENU so Write Mode reload stays after choices", () => {
+      const existing = [
+        {
+          id: "title",
+          sequence: 1,
+          contentType: "NARRATION",
+          content: "Are you sure?",
+          speakerId: null,
+        },
+        {
+          id: "menu-1",
+          sequence: 2,
+          contentType: "MENU",
+          content: "",
+          speakerId: null,
+        },
+        {
+          id: "after",
+          sequence: 3,
+          contentType: "NARRATION",
+          content: "After menu",
+          speakerId: null,
+        },
+      ];
+
+      const plan = planDialogueLineUpdates(existing, [
+        { speakerId: null, text: "Are you sure?" },
+        { speakerId: null, text: "Added after menu" },
+        { speakerId: null, text: "After menu" },
+      ]);
+
+      // Order: title, MENU, new, after — NOT title, new, MENU, after
+      expect(plan.sequenceByKey.get("title")).toBe(1);
+      expect(plan.sequenceByKey.get("menu-1")).toBe(2);
+      expect(plan.sequenceByKey.get("insert:0")).toBe(3);
+      expect(plan.sequenceByKey.get("after")).toBe(4);
+      expect(plan.inserts[0]).toMatchObject({
+        sequence: 3,
+        text: "Added after menu",
+      });
+    });
+
+    it("should handle empty dialogue list — all-delete of existing prose", () => {
+      const nId = testUuid("nan", 1);
+      const mId = testUuid("men", 1);
+      const existing = [
+        {
+          id: nId,
+          sequence: 1,
+          contentType: "NARRATION",
+          content: "Some prose",
+          speakerId: null,
+        },
+        {
+          id: mId,
+          sequence: 2,
+          contentType: "MENU",
+          content: "",
+          speakerId: null,
+        },
+      ];
+
+      const plan = planDialogueLineUpdates(existing, []);
+
+      expect(plan.deleteIds).toEqual([nId]);
+      expect(plan.inserts).toEqual([]);
+      expect(plan.updates).toEqual([]);
+      // MENU row keeps its original sequence (1-based reindexed to position 1)
+      expect(plan.sequenceByKey.get(mId)).toBe(1);
+      expect(plan.sequenceByKey.size).toBe(1);
+    });
+
+    it("should insert all prose into label with only structural lines", () => {
+      const mId = testUuid("men", 1);
+      const jId = testUuid("jmp", 1);
+      const existing = [
+        {
+          id: mId,
+          sequence: 1,
+          contentType: "MENU",
+          content: "",
+          speakerId: null,
+        },
+        {
+          id: jId,
+          sequence: 2,
+          contentType: "JUMP",
+          content: "",
+          speakerId: null,
+        },
+      ];
+
+      const plan = planDialogueLineUpdates(existing, [
+        { speakerId: "char-a", text: "First line" },
+        { speakerId: "char-b", text: "Second line" },
+      ]);
+
+      // No prose to delete
+      expect(plan.deleteIds).toEqual([]);
+      // Prose inserted after structural rows
+      expect(plan.sequenceByKey.get(mId)).toBe(1);
+      expect(plan.sequenceByKey.get(jId)).toBe(2);
+      expect(plan.sequenceByKey.get("insert:0")).toBe(3);
+      expect(plan.sequenceByKey.get("insert:1")).toBe(4);
+      expect(plan.inserts).toHaveLength(2);
+      expect(plan.inserts[0]).toMatchObject({
+        sequence: 3,
+        speakerId: "char-a",
+        text: "First line",
+      });
+      expect(plan.inserts[1]).toMatchObject({
+        sequence: 4,
+        speakerId: "char-b",
+        text: "Second line",
+      });
+    });
+
+    it("should handle interleaved VISUAL/MENU with mid-list deletes", () => {
+      const v1Id = testUuid("vis", 1);
+      const n1Id = testUuid("nar", 1);
+      const mId = testUuid("men", 2);
+      const n2Id = testUuid("nar", 2);
+      const v2Id = testUuid("vis", 2);
+      const existing = [
+        {
+          id: v1Id,
+          sequence: 1,
+          contentType: "VISUAL",
+          content: "",
+          speakerId: null,
+        },
+        {
+          id: n1Id,
+          sequence: 2,
+          contentType: "NARRATION",
+          content: "NARRATION-A",
+          speakerId: null,
+        },
+        {
+          id: mId,
+          sequence: 3,
+          contentType: "MENU",
+          content: "",
+          speakerId: null,
+        },
+        {
+          id: n2Id,
+          sequence: 4,
+          contentType: "NARRATION",
+          content: "NARRATION-B",
+          speakerId: null,
+        },
+        {
+          id: v2Id,
+          sequence: 5,
+          contentType: "VISUAL",
+          content: "",
+          speakerId: null,
+        },
+      ];
+
+      const plan = planDialogueLineUpdates(existing, [
+        { speakerId: null, text: "NARRATION-A" },
+      ]);
+
+      // NARRATION-B is removed
+      expect(plan.deleteIds).toEqual([n2Id]);
+      // VISUAL(1) stays seq 1
+      expect(plan.sequenceByKey.get(v1Id)).toBe(1);
+      // NARRATION-A matches to seq 2
+      expect(plan.sequenceByKey.get(n1Id)).toBe(2);
+      // MENU shifts to seq 3
+      expect(plan.sequenceByKey.get(mId)).toBe(3);
+      // VISUAL(5) shifts to seq 4
+      expect(plan.sequenceByKey.get(v2Id)).toBe(4);
+      // Total: 4 entries, no gaps
+      expect(plan.sequenceByKey.size).toBe(4);
+    });
+
+    it("should delete the menu prompt and keep MENU before surviving prose", () => {
+      const n1Id = testUuid("nar", 1);
+      const mId = testUuid("men", 3);
+      const n2Id = testUuid("nar", 3);
+      const existing = [
+        {
+          id: n1Id,
+          sequence: 1,
+          contentType: "NARRATION",
+          content: "Are you sure?",
+          speakerId: null,
+        },
+        {
+          id: mId,
+          sequence: 2,
+          contentType: "MENU",
+          content: "",
+          speakerId: null,
+        },
+        {
+          id: n2Id,
+          sequence: 3,
+          contentType: "NARRATION",
+          content: "After menu",
+          speakerId: null,
+        },
+      ];
+
+      const plan = planDialogueLineUpdates(existing, [
+        { speakerId: null, text: "After menu" },
+      ]);
+
+      // The NARRATION at seq 1 (menu title) is deleted
+      expect(plan.deleteIds).toEqual([n1Id]);
+      // Order: MENU, NARRATION(3)
+      expect(plan.sequenceByKey.get(mId)).toBe(1);
+      expect(plan.sequenceByKey.get(n2Id)).toBe(2);
+      expect(plan.sequenceByKey.size).toBe(2);
+    });
+
+    it("should preserve all sequences when multiple menus have equal dialogue", () => {
+      const n1Id = testUuid("nar", 1);
+      const m1Id = testUuid("men", 1);
+      const n2Id = testUuid("nar", 2);
+      const m2Id = testUuid("men", 4);
+      const n3Id = testUuid("nar", 5);
+      const existing = [
+        {
+          id: n1Id,
+          sequence: 1,
+          contentType: "NARRATION",
+          content: "Before menu A",
+          speakerId: null,
+        },
+        {
+          id: m1Id,
+          sequence: 2,
+          contentType: "MENU",
+          content: "",
+          speakerId: null,
+        },
+        {
+          id: n2Id,
+          sequence: 3,
+          contentType: "NARRATION",
+          content: "Before menu B",
+          speakerId: null,
+        },
+        {
+          id: m2Id,
+          sequence: 4,
+          contentType: "MENU",
+          content: "",
+          speakerId: null,
+        },
+        {
+          id: n3Id,
+          sequence: 5,
+          contentType: "NARRATION",
+          content: "After menu B",
+          speakerId: null,
+        },
+      ];
+
+      const plan = planDialogueLineUpdates(existing, [
+        { speakerId: null, text: "Before menu A" },
+        { speakerId: null, text: "Before menu B" },
+        { speakerId: null, text: "After menu B" },
+      ]);
+
+      expect(plan.deleteIds).toEqual([]);
+      expect(plan.sequenceByKey.get(n1Id)).toBe(1);
+      expect(plan.sequenceByKey.get(m1Id)).toBe(2);
+      expect(plan.sequenceByKey.get(n2Id)).toBe(3);
+      expect(plan.sequenceByKey.get(m2Id)).toBe(4);
+      expect(plan.sequenceByKey.get(n3Id)).toBe(5);
+    });
+
+    it("should defer insert for first menu but not second with multiple menus", () => {
+      const n1Id = testUuid("nar", 1);
+      const m1Id = testUuid("men", 1);
+      const n2Id = testUuid("nar", 2);
+      const m2Id = testUuid("men", 4);
+      const n3Id = testUuid("nar", 5);
+      const existing = [
+        {
+          id: n1Id,
+          sequence: 1,
+          contentType: "NARRATION",
+          content: "Before menu A",
+          speakerId: null,
+        },
+        {
+          id: m1Id,
+          sequence: 2,
+          contentType: "MENU",
+          content: "",
+          speakerId: null,
+        },
+        {
+          id: n2Id,
+          sequence: 3,
+          contentType: "NARRATION",
+          content: "Before menu B",
+          speakerId: null,
+        },
+        {
+          id: m2Id,
+          sequence: 4,
+          contentType: "MENU",
+          content: "",
+          speakerId: null,
+        },
+        {
+          id: n3Id,
+          sequence: 5,
+          contentType: "NARRATION",
+          content: "After menu B",
+          speakerId: null,
+        },
+      ];
+
+      const plan = planDialogueLineUpdates(existing, [
+        { speakerId: null, text: "Before menu A" },
+        { speakerId: "char-x", text: "New line after menu A" },
+        { speakerId: null, text: "Before menu B" },
+        { speakerId: null, text: "After menu B" },
+      ]);
+
+      expect(plan.deleteIds).toEqual([]);
+      // New line is deferred past MENU-A, landing after it
+      expect(plan.sequenceByKey.get(n1Id)).toBe(1);
+      expect(plan.sequenceByKey.get(m1Id)).toBe(2);
+      expect(plan.sequenceByKey.get("insert:0")).toBe(3);
+      expect(plan.sequenceByKey.get(n2Id)).toBe(4);
+      expect(plan.sequenceByKey.get(m2Id)).toBe(5);
+      expect(plan.sequenceByKey.get(n3Id)).toBe(6);
+      expect(plan.sequenceByKey.size).toBe(6);
+      expect(plan.inserts[0]).toMatchObject({
+        sequence: 3,
+        speakerId: "char-x",
+        text: "New line after menu A",
+      });
     });
   });
 });

--- a/apps/backend/src/services/rpy-parser.service.ts
+++ b/apps/backend/src/services/rpy-parser.service.ts
@@ -45,6 +45,10 @@ export {
 
 export { reconstructRPYFile } from "./rpy/reconstruction.js";
 
+export { alignDialogue, dialogueEntriesEqual } from "./rpy/dialogue-align.js";
+
+export { planDialogueLineUpdates } from "./rpy/plan-dialogue-updates.js";
+
 export {
   removeLabelFromRPYContent,
   parseLabelBoundaries,

--- a/apps/backend/src/services/rpy/dialogue-align.ts
+++ b/apps/backend/src/services/rpy/dialogue-align.ts
@@ -27,7 +27,8 @@ export function dialogueEntriesEqual(
 
 /**
  * Align `original` against `updated` via LCS.
- * Adjacent delete+insert pairs are coalesced into replace (in-place edits).
+ * Contiguous non-equal runs are coalesced by pairing deletes and inserts into
+ * replace ops; unmatched deletes/inserts are preserved in order.
  */
 export function alignDialogue(
   original: DialogueAlignEntry[],
@@ -75,27 +76,42 @@ export function alignDialogue(
     j++;
   }
 
-  // Coalesce adjacent delete+insert into replace
+  // Coalesce each contiguous non-equal run: pair deletes/inserts by position
+  // into replaces, then emit any unmatched deletes or inserts in order.
   const ops: DialogueAlignOp[] = [];
-  for (let k = 0; k < raw.length; k++) {
-    const cur = raw[k];
-    const next = raw[k + 1];
-    if (cur.type === "delete" && next?.type === "insert") {
+  let k = 0;
+  while (k < raw.length) {
+    if (raw[k].type === "equal") {
+      ops.push(raw[k]);
+      k++;
+      continue;
+    }
+
+    const deletes: number[] = [];
+    const inserts: number[] = [];
+    while (k < raw.length && raw[k].type !== "equal") {
+      const op = raw[k];
+      if (op.type === "delete") {
+        deletes.push(op.origIndex);
+      } else if (op.type === "insert") {
+        inserts.push(op.updatedIndex);
+      }
+      k++;
+    }
+
+    const paired = Math.min(deletes.length, inserts.length);
+    for (let p = 0; p < paired; p++) {
       ops.push({
         type: "replace",
-        origIndex: cur.origIndex,
-        updatedIndex: next.updatedIndex,
+        origIndex: deletes[p],
+        updatedIndex: inserts[p],
       });
-      k++;
-    } else if (cur.type === "insert" && next?.type === "delete") {
-      ops.push({
-        type: "replace",
-        origIndex: next.origIndex,
-        updatedIndex: cur.updatedIndex,
-      });
-      k++;
-    } else {
-      ops.push(cur);
+    }
+    for (let p = paired; p < deletes.length; p++) {
+      ops.push({ type: "delete", origIndex: deletes[p] });
+    }
+    for (let p = paired; p < inserts.length; p++) {
+      ops.push({ type: "insert", updatedIndex: inserts[p] });
     }
   }
 

--- a/apps/backend/src/services/rpy/dialogue-align.ts
+++ b/apps/backend/src/services/rpy/dialogue-align.ts
@@ -1,0 +1,103 @@
+/**
+ * Sequence alignment for Write Mode dialogue lists.
+ *
+ * Aligns original dialogue entries against an updated list using LCS,
+ * producing equal / replace / insert / delete ops. Used by RPY reconstruction
+ * and the dialogue-save DB update path so mid-list inserts do not slide
+ * later lines into the wrong scene/show slots.
+ */
+
+export interface DialogueAlignEntry {
+  speaker: string | null;
+  text: string;
+}
+
+export type DialogueAlignOp =
+  | { type: "equal"; origIndex: number; updatedIndex: number }
+  | { type: "replace"; origIndex: number; updatedIndex: number }
+  | { type: "insert"; updatedIndex: number }
+  | { type: "delete"; origIndex: number };
+
+export function dialogueEntriesEqual(
+  a: DialogueAlignEntry,
+  b: DialogueAlignEntry
+): boolean {
+  return a.speaker === b.speaker && a.text === b.text;
+}
+
+/**
+ * Align `original` against `updated` via LCS.
+ * Adjacent delete+insert pairs are coalesced into replace (in-place edits).
+ */
+export function alignDialogue(
+  original: DialogueAlignEntry[],
+  updated: DialogueAlignEntry[]
+): DialogueAlignOp[] {
+  const n = original.length;
+  const m = updated.length;
+
+  // dp[i][j] = LCS length of original[i..] and updated[j..]
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    Array<number>(m + 1).fill(0)
+  );
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      if (dialogueEntriesEqual(original[i], updated[j])) {
+        dp[i][j] = dp[i + 1][j + 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i + 1][j], dp[i][j + 1]);
+      }
+    }
+  }
+
+  const raw: DialogueAlignOp[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (dialogueEntriesEqual(original[i], updated[j])) {
+      raw.push({ type: "equal", origIndex: i, updatedIndex: j });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      raw.push({ type: "delete", origIndex: i });
+      i++;
+    } else {
+      raw.push({ type: "insert", updatedIndex: j });
+      j++;
+    }
+  }
+  while (i < n) {
+    raw.push({ type: "delete", origIndex: i });
+    i++;
+  }
+  while (j < m) {
+    raw.push({ type: "insert", updatedIndex: j });
+    j++;
+  }
+
+  // Coalesce adjacent delete+insert into replace
+  const ops: DialogueAlignOp[] = [];
+  for (let k = 0; k < raw.length; k++) {
+    const cur = raw[k];
+    const next = raw[k + 1];
+    if (cur.type === "delete" && next?.type === "insert") {
+      ops.push({
+        type: "replace",
+        origIndex: cur.origIndex,
+        updatedIndex: next.updatedIndex,
+      });
+      k++;
+    } else if (cur.type === "insert" && next?.type === "delete") {
+      ops.push({
+        type: "replace",
+        origIndex: next.origIndex,
+        updatedIndex: cur.updatedIndex,
+      });
+      k++;
+    } else {
+      ops.push(cur);
+    }
+  }
+
+  return ops;
+}

--- a/apps/backend/src/services/rpy/plan-dialogue-updates.ts
+++ b/apps/backend/src/services/rpy/plan-dialogue-updates.ts
@@ -91,6 +91,12 @@ function nextSurvivingIsMenu(
   return false;
 }
 
+function isTerminalControlFlow(line: ExistingLineForPlan): boolean {
+  if (line.contentType === "JUMP") return true;
+  const trimmed = line.content.trim().toLowerCase();
+  return /^(jump|call|return)\b/.test(trimmed);
+}
+
 /**
  * Plan deletes, updates, inserts, and final sequences for a label's lines
  * after a Write Mode dialogue save.
@@ -160,16 +166,34 @@ export function planDialogueLineUpdates(
     pendingAfterMenu = [];
   };
 
+  /** Flush remaining all-new / trailing inserts from proseResult */
+  const flushRemainingNewProse = () => {
+    while (
+      proseIdx < proseResult.length &&
+      proseResult[proseIdx].kind === "new"
+    ) {
+      pushInsert(
+        merged,
+        proseResult[proseIdx] as Extract<ProseSlot, { kind: "new" }>
+      );
+      proseIdx++;
+    }
+  };
+
   for (let lineIndex = 0; lineIndex < existingLines.length; lineIndex++) {
     const line = existingLines[lineIndex];
 
     if (!isProse(line.contentType)) {
+      // All-new prose goes after MENU and before terminal JUMP/CALL/RETURN
+      if (isTerminalControlFlow(line)) {
+        flushPendingAfterMenu();
+        flushRemainingNewProse();
+      }
       merged.push({
         key: line.id,
         speakerId: line.speakerId,
         text: line.content,
       });
-      // Place deferred post-title inserts immediately after the MENU row
       if (line.contentType === "MENU") {
         flushPendingAfterMenu();
       }

--- a/apps/backend/src/services/rpy/plan-dialogue-updates.ts
+++ b/apps/backend/src/services/rpy/plan-dialogue-updates.ts
@@ -1,0 +1,268 @@
+/**
+ * Plan DB updates for Write Mode dialogue saves.
+ *
+ * Aligns existing prose rows against the incoming dialogue list and produces
+ * delete / update / insert operations with sequences that keep VISUAL/MENU
+ * rows correctly interleaved.
+ *
+ * Inserts that follow a menu title (prose immediately before a MENU row) are
+ * placed after that MENU row so Write Mode reload order matches Script Mode:
+ * prompt → choices → new dialogue, not prompt → new dialogue → choices.
+ */
+
+import { alignDialogue, type DialogueAlignEntry } from "./dialogue-align.js";
+
+export interface ExistingLineForPlan {
+  id: string;
+  sequence: number;
+  contentType: string;
+  content: string;
+  speakerId: string | null;
+}
+
+export interface IncomingDialogueEntry {
+  speakerId: string | null;
+  text: string;
+}
+
+export interface PlannedDialogueUpdates {
+  /** Prose row ids to delete */
+  deleteIds: string[];
+  /** Existing rows to update (content / speaker) */
+  updates: Array<{
+    id: string;
+    speakerId: string | null;
+    text: string;
+  }>;
+  /** New prose rows to insert at the given sequence */
+  inserts: Array<{
+    sequence: number;
+    speakerId: string | null;
+    text: string;
+  }>;
+  /**
+   * Full reindexed sequence map for every surviving / new row id.
+   * New inserts use temporary keys `insert:0`, `insert:1`, … matching
+   * `inserts` array order; the caller assigns real ids on insert.
+   */
+  sequenceByKey: Map<string, number>;
+}
+
+function isProse(contentType: string): boolean {
+  return contentType === "DIALOGUE" || contentType === "NARRATION";
+}
+
+type ProseSlot =
+  | { kind: "existing"; id: string; speakerId: string | null; text: string }
+  | {
+      kind: "new";
+      speakerId: string | null;
+      text: string;
+      insertIndex: number;
+    };
+
+type MergedItem = { key: string; speakerId: string | null; text: string };
+
+function pushInsert(
+  merged: MergedItem[],
+  slot: Extract<ProseSlot, { kind: "new" }>
+) {
+  merged.push({
+    key: `insert:${slot.insertIndex}`,
+    speakerId: slot.speakerId,
+    text: slot.text,
+  });
+}
+
+/**
+ * True when the next surviving line after `fromIndex` is a MENU row.
+ * Used to defer post-title inserts until after the menu (matching RPY reconstruct).
+ */
+function nextSurvivingIsMenu(
+  existingLines: ExistingLineForPlan[],
+  fromIndex: number,
+  deletedSet: Set<string>
+): boolean {
+  for (let i = fromIndex + 1; i < existingLines.length; i++) {
+    const line = existingLines[i];
+    if (deletedSet.has(line.id)) continue;
+    return line.contentType === "MENU";
+  }
+  return false;
+}
+
+/**
+ * Plan deletes, updates, inserts, and final sequences for a label's lines
+ * after a Write Mode dialogue save.
+ */
+export function planDialogueLineUpdates(
+  existingLines: ExistingLineForPlan[],
+  dialogue: IncomingDialogueEntry[]
+): PlannedDialogueUpdates {
+  const proseLines = existingLines.filter((l) => isProse(l.contentType));
+
+  const original: DialogueAlignEntry[] = proseLines.map((l) => ({
+    speaker: l.speakerId,
+    text: l.content,
+  }));
+  const updated: DialogueAlignEntry[] = dialogue.map((d) => ({
+    speaker: d.speakerId,
+    text: d.text,
+  }));
+
+  const ops = alignDialogue(original, updated);
+
+  const proseResult: ProseSlot[] = [];
+  const deleteIds: string[] = [];
+  const updates: PlannedDialogueUpdates["updates"] = [];
+  let insertCount = 0;
+
+  for (const op of ops) {
+    if (op.type === "delete") {
+      deleteIds.push(proseLines[op.origIndex].id);
+      continue;
+    }
+    if (op.type === "equal" || op.type === "replace") {
+      const row = proseLines[op.origIndex];
+      const entry = dialogue[op.updatedIndex];
+      updates.push({
+        id: row.id,
+        speakerId: entry.speakerId,
+        text: entry.text,
+      });
+      proseResult.push({
+        kind: "existing",
+        id: row.id,
+        speakerId: entry.speakerId,
+        text: entry.text,
+      });
+      continue;
+    }
+    const entry = dialogue[op.updatedIndex];
+    proseResult.push({
+      kind: "new",
+      speakerId: entry.speakerId,
+      text: entry.text,
+      insertIndex: insertCount++,
+    });
+  }
+
+  const deletedSet = new Set(deleteIds);
+  const merged: MergedItem[] = [];
+  let proseIdx = 0;
+  /** Inserts deferred until after a following MENU row */
+  let pendingAfterMenu: Array<Extract<ProseSlot, { kind: "new" }>> = [];
+
+  const flushPendingAfterMenu = () => {
+    for (const ins of pendingAfterMenu) {
+      pushInsert(merged, ins);
+    }
+    pendingAfterMenu = [];
+  };
+
+  for (let lineIndex = 0; lineIndex < existingLines.length; lineIndex++) {
+    const line = existingLines[lineIndex];
+
+    if (!isProse(line.contentType)) {
+      merged.push({
+        key: line.id,
+        speakerId: line.speakerId,
+        text: line.content,
+      });
+      // Place deferred post-title inserts immediately after the MENU row
+      if (line.contentType === "MENU") {
+        flushPendingAfterMenu();
+      }
+      continue;
+    }
+
+    if (deletedSet.has(line.id)) {
+      continue;
+    }
+
+    // Leading inserts before this existing prose row
+    while (
+      proseIdx < proseResult.length &&
+      proseResult[proseIdx].kind === "new"
+    ) {
+      pushInsert(
+        merged,
+        proseResult[proseIdx] as Extract<ProseSlot, { kind: "new" }>
+      );
+      proseIdx++;
+    }
+
+    if (
+      proseIdx < proseResult.length &&
+      proseResult[proseIdx].kind === "existing" &&
+      (proseResult[proseIdx] as Extract<ProseSlot, { kind: "existing" }>).id ===
+        line.id
+    ) {
+      const slot = proseResult[proseIdx] as Extract<
+        ProseSlot,
+        { kind: "existing" }
+      >;
+      merged.push({
+        key: slot.id,
+        speakerId: slot.speakerId,
+        text: slot.text,
+      });
+      proseIdx++;
+
+      const followingInserts: Array<Extract<ProseSlot, { kind: "new" }>> = [];
+      while (
+        proseIdx < proseResult.length &&
+        proseResult[proseIdx].kind === "new"
+      ) {
+        followingInserts.push(
+          proseResult[proseIdx] as Extract<ProseSlot, { kind: "new" }>
+        );
+        proseIdx++;
+      }
+
+      if (
+        followingInserts.length > 0 &&
+        nextSurvivingIsMenu(existingLines, lineIndex, deletedSet)
+      ) {
+        pendingAfterMenu.push(...followingInserts);
+      } else {
+        for (const ins of followingInserts) {
+          pushInsert(merged, ins);
+        }
+      }
+    }
+  }
+
+  // Trailing inserts / any deferred inserts if MENU was missing
+  flushPendingAfterMenu();
+  while (proseIdx < proseResult.length) {
+    const slot = proseResult[proseIdx];
+    if (slot.kind === "new") {
+      pushInsert(merged, slot);
+    } else {
+      merged.push({
+        key: slot.id,
+        speakerId: slot.speakerId,
+        text: slot.text,
+      });
+    }
+    proseIdx++;
+  }
+
+  const sequenceByKey = new Map<string, number>();
+  const inserts: PlannedDialogueUpdates["inserts"] = [];
+
+  merged.forEach((item, index) => {
+    const sequence = index + 1;
+    sequenceByKey.set(item.key, sequence);
+    if (item.key.startsWith("insert:")) {
+      inserts.push({
+        sequence,
+        speakerId: item.speakerId,
+        text: item.text,
+      });
+    }
+  });
+
+  return { deleteIds, updates, inserts, sequenceByKey };
+}

--- a/apps/backend/src/services/rpy/reconstruction.ts
+++ b/apps/backend/src/services/rpy/reconstruction.ts
@@ -1,14 +1,142 @@
 import { RENPY_LABEL_REGEX } from "@branchforge/shared";
 import type { ReconstructedFileOptions } from "./types.js";
 import { escapeRenpyString } from "../rpy-generator.service.js";
+import {
+  alignDialogue,
+  type DialogueAlignEntry,
+  type DialogueAlignOp,
+} from "./dialogue-align.js";
+
+interface LabelAlignState {
+  ops: DialogueAlignOp[];
+  opIdx: number;
+  updated: DialogueAlignEntry[];
+}
+
+function formatDialogueLine(
+  entry: DialogueAlignEntry,
+  indent: string,
+  quote: string = '"'
+): string {
+  if (entry.speaker) {
+    return `${indent}${entry.speaker} ${quote}${escapeRenpyString(entry.text)}${quote}`;
+  }
+  return `${indent}${quote}${escapeRenpyString(entry.text)}${quote}`;
+}
+
+function isDialogueOrNarrationLine(trimmed: string): {
+  isDialogue: boolean;
+  isSingleQuoted: boolean;
+} {
+  const dialogueMatch = trimmed.match(
+    /^([a-zA-Z_][a-zA-Z0-9_]*)\s+"([^"\\]*(?:\\.[^"\\]*)*)"$/
+  );
+  const dialogueMatchSingle = trimmed.match(
+    /^([a-zA-Z_][a-zA-Z0-9_]*)\s+'([^'\\]*(?:\\.[^'\\]*)*)'$/
+  );
+  const narrationMatch = trimmed.match(/^"([^"\\]*(?:\\.[^"\\]*)*)"$/);
+  const narrationMatchSingle = trimmed.match(/^'([^'\\]*(?:\\.[^'\\]*)*)'$/);
+
+  const isDialogue = !!(
+    dialogueMatch ||
+    dialogueMatchSingle ||
+    narrationMatch ||
+    narrationMatchSingle
+  );
+  const isSingleQuoted = !!(dialogueMatchSingle || narrationMatchSingle);
+  return { isDialogue, isSingleQuoted };
+}
+
+function parseDialogueEntry(trimmed: string): DialogueAlignEntry | null {
+  const dialogueMatch = trimmed.match(
+    /^([a-zA-Z_][a-zA-Z0-9_]*)\s+"([^"\\]*(?:\\.[^"\\]*)*)"$/
+  );
+  if (dialogueMatch) {
+    return { speaker: dialogueMatch[1], text: dialogueMatch[2] };
+  }
+  const dialogueMatchSingle = trimmed.match(
+    /^([a-zA-Z_][a-zA-Z0-9_]*)\s+'([^'\\]*(?:\\.[^'\\]*)*)'$/
+  );
+  if (dialogueMatchSingle) {
+    return { speaker: dialogueMatchSingle[1], text: dialogueMatchSingle[2] };
+  }
+  const narrationMatch = trimmed.match(/^"([^"\\]*(?:\\.[^"\\]*)*)"$/);
+  if (narrationMatch) {
+    return { speaker: null, text: narrationMatch[1] };
+  }
+  const narrationMatchSingle = trimmed.match(/^'([^'\\]*(?:\\.[^'\\]*)*)'$/);
+  if (narrationMatchSingle) {
+    return { speaker: null, text: narrationMatchSingle[1] };
+  }
+  return null;
+}
+
+/**
+ * Pre-extract dialogue/narration entries per label from RPY content.
+ * Menu titles (quoted lines inside menu blocks) are included; choice lines
+ * ending with `:` are not.
+ */
+function extractOriginalDialogueByLabel(
+  lines: string[]
+): Map<string, DialogueAlignEntry[]> {
+  const byLabel = new Map<string, DialogueAlignEntry[]>();
+  let currentLabel: string | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const labelMatch = line.match(RENPY_LABEL_REGEX);
+    if (labelMatch) {
+      currentLabel = labelMatch[1];
+      if (!byLabel.has(currentLabel)) {
+        byLabel.set(currentLabel, []);
+      }
+      continue;
+    }
+    if (!currentLabel) continue;
+    const entry = parseDialogueEntry(trimmed);
+    if (entry) {
+      byLabel.get(currentLabel)!.push(entry);
+    }
+  }
+
+  return byLabel;
+}
+
+function flushInserts(
+  state: LabelAlignState,
+  result: string[],
+  indent: string
+): void {
+  while (state.opIdx < state.ops.length) {
+    const op = state.ops[state.opIdx];
+    if (op.type !== "insert") {
+      break;
+    }
+    result.push(formatDialogueLine(state.updated[op.updatedIndex], indent));
+    state.opIdx++;
+  }
+}
+
+function flushRemainingInserts(
+  state: LabelAlignState,
+  result: string[],
+  indent: string
+): boolean {
+  const before = state.opIdx;
+  flushInserts(state, result, indent);
+  return state.opIdx > before;
+}
 
 /**
  * Reconstruct RPY file content with updated dialogue while preserving keywords.
  * Used when Write Mode saves dialogue changes - the original keywords (show, scene, play, etc.)
  * are preserved, only dialogue lines are updated.
  *
- * Extra dialogue entries are inserted within their label's block (before return/menu/jump/next label)
- * rather than appended at the end of the file.
+ * Mid-list inserts are placed via LCS alignment (immediately after the preceding
+ * matched dialogue line) so scene/show keywords stay paired with their original
+ * dialogue partners. Inserts that follow a menu title are deferred until the
+ * menu block ends, so they are not written inside `menu:`. Deleted lines are
+ * removed from the file.
  *
  * @param options - The original content and updated dialogue map
  * @returns Reconstructed RPY file content
@@ -18,73 +146,51 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
   const lines = originalContent.split("\n");
   const result: string[] = [];
 
+  const originalByLabel = extractOriginalDialogueByLabel(lines);
+  const alignStates = new Map<string, LabelAlignState>();
+
+  for (const [label, updated] of updatedDialogue.entries()) {
+    const original = originalByLabel.get(label) ?? [];
+    alignStates.set(label, {
+      ops: alignDialogue(original, updated),
+      opIdx: 0,
+      updated,
+    });
+  }
+
   let currentLabel: string | null = null;
-
-  // Track dialogue index per label to know how many updated entries we've output
-  const labelDialogueIndices = new Map<string, number>();
   const labelIndentation = new Map<string, string>();
-  let lastDialogueIndent = "    "; // Default RPY indentation
-
-  // Track labels encountered during processing for validation
+  let lastDialogueIndent = "    ";
   const encounteredLabels = new Set<string>();
-
-  // Track menu block nesting to prevent premature dialogue insertion.
-  // Menu titles are editable dialogue entries, so they must be matched and
-  // replaced inside menu blocks. However, jump/call/return statements inside
-  // menu choice bodies should NOT trigger dialogue insertion — they're part of
-  // the menu structure, not the label's main dialogue flow.
   const menuStack: number[] = [];
+  const menuBlockIndices = new Map<string, number>();
+  const menuChoiceIndices = new Map<string, number>();
 
-  // Track menu choice replacement: per label, track which menu block index
-  // we're in and which choice index within that block.
-  const menuBlockIndices = new Map<string, number>(); // label -> current menu block index
-  const menuChoiceIndices = new Map<string, number>(); // label -> current choice index
-
-  // Keywords that signal the end of a label's dialogue block.
-  // The `menuStack.length === 0` guard below prevents premature insertion at
-  // `menu:` (and any other line inside a menu block). This is the mechanism
-  // that stops the menu title from being inserted before `menu:` and again
-  // matched in place, which would produce duplicate dialogue entries.
   const labelEndKeywords = new Set(["return", "jump", "call"]);
   const isLabelEndKeyword = (trimmed: string): boolean => {
     const firstWord = trimmed.split(/\s+/)[0];
-    // Normalize by stripping trailing colon and other punctuation
     const normalized = firstWord.replace(/:$/, "").toLowerCase();
     return labelEndKeywords.has(normalized);
+  };
+
+  const flushLabelTrailing = (label: string | null): boolean => {
+    if (!label) return false;
+    const state = alignStates.get(label);
+    if (!state) return false;
+    const indent = labelIndentation.get(label) || lastDialogueIndent;
+    return flushRemainingInserts(state, result, indent);
   };
 
   for (const line of lines) {
     const trimmed = line.trim();
 
-    // Track current label
     const labelMatch = line.match(RENPY_LABEL_REGEX);
     if (labelMatch) {
-      // Before switching to new label, insert any remaining dialogue for the previous label
       let insertedDialogue = false;
-      if (currentLabel && updatedDialogue.has(currentLabel)) {
-        const labelDialogue = updatedDialogue.get(currentLabel)!;
-        const currentIndex = labelDialogueIndices.get(currentLabel) ?? 0;
-
-        if (currentIndex < labelDialogue.length) {
-          const indent =
-            labelIndentation.get(currentLabel) || lastDialogueIndent;
-          for (let i = currentIndex; i < labelDialogue.length; i++) {
-            const entry = labelDialogue[i];
-            if (entry.speaker) {
-              result.push(
-                `${indent}${entry.speaker} "${escapeRenpyString(entry.text)}"`
-              );
-            } else {
-              result.push(`${indent}"${escapeRenpyString(entry.text)}"`);
-            }
-          }
-          labelDialogueIndices.set(currentLabel, labelDialogue.length);
-          insertedDialogue = true;
-        }
+      if (currentLabel && alignStates.has(currentLabel)) {
+        insertedDialogue = flushLabelTrailing(currentLabel);
       }
 
-      // Add blank line before new label if we just inserted dialogue
-      // Check if result doesn't already end with a blank line
       if (
         insertedDialogue &&
         result.length > 0 &&
@@ -95,17 +201,16 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
 
       currentLabel = labelMatch[1];
       encounteredLabels.add(currentLabel);
-      labelDialogueIndices.set(currentLabel, 0);
-      // Reset menu tracking on label boundary
       menuStack.length = 0;
       result.push(line);
       continue;
     }
 
-    // Track menu block nesting: push on menu:, pop on dedent
+    // Track menu block nesting: push on menu:, pop on dedent.
+    // Inserts that follow a menu title in the flat dialogue list must not be
+    // emitted inside the menu — flush them when the menu block ends.
     if (trimmed === "menu:") {
       menuStack.push(line.search(/\S/));
-      // Track menu block index for choice text replacement
       if (currentLabel) {
         const blockIdx = menuBlockIndices.get(currentLabel) ?? 0;
         menuBlockIndices.set(currentLabel, blockIdx + 1);
@@ -113,26 +218,31 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
       }
     } else if (menuStack.length > 0 && trimmed) {
       const lineIndent = line.search(/\S/);
+      const wasInMenu = menuStack.length > 0;
       while (
         menuStack.length > 0 &&
         lineIndent <= menuStack[menuStack.length - 1]
       ) {
         menuStack.pop();
       }
+      if (
+        wasInMenu &&
+        menuStack.length === 0 &&
+        currentLabel &&
+        alignStates.has(currentLabel)
+      ) {
+        const state = alignStates.get(currentLabel)!;
+        const indent = labelIndentation.get(currentLabel) || lastDialogueIndent;
+        flushInserts(state, result, indent);
+      }
     }
 
     // Replace menu choice text inside menu blocks.
-    // Choice lines in RPY look like: "Choice text":
-    // or with conditions: "Choice text" if condition:
     if (
       menuStack.length > 0 &&
       currentLabel &&
       updatedMenuChoices?.has(currentLabel)
     ) {
-      // Match a choice line with any quoting style: "text", 'text', or unquoted
-      // Also captures optional "if ..." condition
-      // Negative lookahead excludes Ren'Py control-flow keywords (if/elif/else/jump/etc.)
-      // that appear inside menu blocks at the same indent level as choices.
       const choiceMatch = trimmed.match(
         /^(?:"(.+?)"|'(.+?)'|(?!(?:if|elif|else|pass|jump|call|return|python|while|for|default|define|label|menu|init)\s*:)([a-zA-Z_][a-zA-Z0-9_ ]*?))(?:\s+(if\s+.+))?:(?:\s*)?$/
       );
@@ -148,11 +258,8 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
           const newChoiceText = labelBlocks[blockIdx][choiceIdx].label;
           menuChoiceIndices.set(currentLabel, choiceIdx + 1);
 
-          // Reconstruct the line preserving indentation and any trailing syntax
           const indent = line.match(/^(\s*)/)?.[1] || "";
-          // Preserve condition suffix if present: "text" if condition:
           const conditionPart = choiceMatch[4];
-          // Determine quote style from the original match
           const quote = choiceMatch[1] ? '"' : choiceMatch[2] ? "'" : "";
           if (conditionPart) {
             result.push(
@@ -168,32 +275,10 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
       }
     }
 
-    // Check if this is a dialogue line
-    const dialogueMatch = trimmed.match(
-      /^([a-zA-Z_][a-zA-Z0-9_]*)\s+"([^"\\]*(?:\\.[^"\\]*)*)"$/
-    );
-    const dialogueMatchSingle = trimmed.match(
-      /^([a-zA-Z_][a-zA-Z0-9_]*)\s+'([^'\\]*(?:\\.[^'\\]*)*)'$/
-    );
-    const narrationMatch = trimmed.match(/^"([^"\\]*(?:\\.[^"\\]*)*)"$/);
-    const narrationMatchSingle = trimmed.match(/^'([^'\\]*(?:\\.[^'\\]*)*)'$/);
+    const { isDialogue, isSingleQuoted } = isDialogueOrNarrationLine(trimmed);
 
-    // Match and replace dialogue/narration both outside AND inside menu blocks.
-    // Menu titles are editable entries that should be updated like any other
-    // dialogue. The label-end insertion below handles the case where there are
-    // more entries than original lines.
-    if (
-      (dialogueMatch ||
-        dialogueMatchSingle ||
-        narrationMatch ||
-        narrationMatchSingle) &&
-      currentLabel &&
-      updatedDialogue.has(currentLabel)
-    ) {
-      const labelDialogue = updatedDialogue.get(currentLabel)!;
-      const currentIndex = labelDialogueIndices.get(currentLabel) ?? 0;
-
-      // Track indentation for inserting extra entries later
+    if (isDialogue && currentLabel && alignStates.has(currentLabel)) {
+      const state = alignStates.get(currentLabel)!;
       const indent = line.match(/^(\s*)/)?.[1] || "";
       if (indent) {
         lastDialogueIndent = indent;
@@ -202,84 +287,67 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
         }
       }
 
-      if (currentIndex < labelDialogue.length) {
-        const newDialogue = labelDialogue[currentIndex];
-        labelDialogueIndices.set(currentLabel, currentIndex + 1);
+      // Do not flush inserts inside a menu — the menu title is a dialogue
+      // slot, but Write Mode inserts after it belong after the whole block.
+      if (menuStack.length === 0) {
+        flushInserts(state, result, indent);
+      }
 
-        // Reconstruct dialogue line with original indentation and quote style
-        const isSingleQuoted = !!(dialogueMatchSingle || narrationMatchSingle);
-        const quote = isSingleQuoted ? "'" : '"';
-        if (newDialogue.speaker) {
-          result.push(
-            `${indent}${newDialogue.speaker} ${quote}${escapeRenpyString(newDialogue.text)}${quote}`
-          );
-        } else {
-          result.push(
-            `${indent}${quote}${escapeRenpyString(newDialogue.text)}${quote}`
-          );
+      if (state.opIdx >= state.ops.length) {
+        // No remaining ops for this original line — delete it.
+        continue;
+      }
+
+      const op = state.ops[state.opIdx];
+
+      if (op.type === "delete") {
+        state.opIdx++;
+        if (menuStack.length === 0) {
+          flushInserts(state, result, indent);
         }
         continue;
       }
 
-      // Original dialogue line is preserved because updatedDialogue has fewer entries.
-      // This ensures we don't lose any original content when updates are partial.
-      // The line will be added by the fall-through below.
+      if (op.type === "equal" || op.type === "replace") {
+        const newDialogue = state.updated[op.updatedIndex];
+        state.opIdx++;
+        const quote = isSingleQuoted ? "'" : '"';
+        result.push(formatDialogueLine(newDialogue, indent, quote));
+        if (menuStack.length === 0) {
+          flushInserts(state, result, indent);
+        }
+        continue;
+      }
+
+      // Unexpected insert at this point was already flushed above; fall through.
+    } else if (isDialogue && currentLabel && !alignStates.has(currentLabel)) {
+      // Label not in updatedDialogue — keep original line.
+      result.push(line);
+      continue;
     }
 
-    // Before adding a line that ends the label block, insert any remaining dialogue.
-    // Only do this OUTSIDE menu blocks — jump/call/return inside menu choice
-    // bodies are part of the menu structure, not the label's dialogue flow.
+    // Before label-ending keywords, flush trailing inserts (outside menus).
     if (
       currentLabel &&
-      updatedDialogue.has(currentLabel) &&
-      menuStack.length === 0
+      alignStates.has(currentLabel) &&
+      menuStack.length === 0 &&
+      trimmed.length > 0 &&
+      isLabelEndKeyword(trimmed)
     ) {
-      const labelDialogue = updatedDialogue.get(currentLabel)!;
-      const currentIndex = labelDialogueIndices.get(currentLabel) ?? 0;
-
-      // If we have remaining dialogue entries and we're at a label-ending keyword, insert them first
-      if (
-        currentIndex < labelDialogue.length &&
-        trimmed.length > 0 &&
-        isLabelEndKeyword(trimmed)
-      ) {
-        const indent = labelIndentation.get(currentLabel) || lastDialogueIndent;
-        for (let i = currentIndex; i < labelDialogue.length; i++) {
-          const entry = labelDialogue[i];
-          if (entry.speaker) {
-            result.push(
-              `${indent}${entry.speaker} "${escapeRenpyString(entry.text)}"`
-            );
-          } else {
-            result.push(`${indent}"${escapeRenpyString(entry.text)}"`);
-          }
-        }
-        labelDialogueIndices.set(currentLabel, labelDialogue.length);
-      }
+      flushLabelTrailing(currentLabel);
     }
 
-    // Keep all other lines as-is (keywords, etc.) - includes preserved original dialogue lines
     result.push(line);
   }
 
-  // After processing all lines, insert any remaining dialogue entries
-  for (const [label, labelDialogue] of updatedDialogue.entries()) {
+  // Trailing inserts for the last label / EOF
+  for (const [label, state] of alignStates.entries()) {
     if (!encounteredLabels.has(label)) {
       throw new Error(`Unknown label in updatedDialogue: ${label}`);
     }
-    const currentIndex = labelDialogueIndices.get(label) ?? 0;
-    if (currentIndex < labelDialogue.length) {
+    if (state.opIdx < state.ops.length) {
       const indent = labelIndentation.get(label) || lastDialogueIndent;
-      for (let i = currentIndex; i < labelDialogue.length; i++) {
-        const entry = labelDialogue[i];
-        if (entry.speaker) {
-          result.push(
-            `${indent}${entry.speaker} "${escapeRenpyString(entry.text)}"`
-          );
-        } else {
-          result.push(`${indent}"${escapeRenpyString(entry.text)}"`);
-        }
-      }
+      flushRemainingInserts(state, result, indent);
     }
   }
 

--- a/apps/backend/src/services/rpy/reconstruction.ts
+++ b/apps/backend/src/services/rpy/reconstruction.ts
@@ -6,6 +6,9 @@ import {
   type DialogueAlignEntry,
   type DialogueAlignOp,
 } from "./dialogue-align.js";
+import { parseLabelBoundaries } from "./label-management.js";
+import type { LabelBlock } from "./types.js";
+import { trackBlocks } from "./helpers.js";
 
 interface LabelAlignState {
   ops: DialogueAlignOp[];
@@ -13,20 +16,21 @@ interface LabelAlignState {
   updated: DialogueAlignEntry[];
 }
 
-function formatDialogueLine(
-  entry: DialogueAlignEntry,
-  indent: string,
-  quote: string = '"'
-): string {
+/**
+ * Always emit double-quoted Ren'Py strings. escapeRenpyString only escapes
+ * double quotes / backslashes / newlines — single-quoted output would be
+ * invalid when the text contains apostrophes.
+ */
+function formatDialogueLine(entry: DialogueAlignEntry, indent: string): string {
+  const text = escapeRenpyString(entry.text);
   if (entry.speaker) {
-    return `${indent}${entry.speaker} ${quote}${escapeRenpyString(entry.text)}${quote}`;
+    return `${indent}${entry.speaker} "${text}"`;
   }
-  return `${indent}${quote}${escapeRenpyString(entry.text)}${quote}`;
+  return `${indent}"${text}"`;
 }
 
 function isDialogueOrNarrationLine(trimmed: string): {
   isDialogue: boolean;
-  isSingleQuoted: boolean;
 } {
   const dialogueMatch = trimmed.match(
     /^([a-zA-Z_][a-zA-Z0-9_]*)\s+"([^"\\]*(?:\\.[^"\\]*)*)"$/
@@ -43,8 +47,7 @@ function isDialogueOrNarrationLine(trimmed: string): {
     narrationMatch ||
     narrationMatchSingle
   );
-  const isSingleQuoted = !!(dialogueMatchSingle || narrationMatchSingle);
-  return { isDialogue, isSingleQuoted };
+  return { isDialogue };
 }
 
 function parseDialogueEntry(trimmed: string): DialogueAlignEntry | null {
@@ -73,30 +76,26 @@ function parseDialogueEntry(trimmed: string): DialogueAlignEntry | null {
 
 /**
  * Pre-extract dialogue/narration entries per label from RPY content.
- * Menu titles (quoted lines inside menu blocks) are included; choice lines
- * ending with `:` are not.
+ * Uses explicit label boundaries (and skips screen/init blocks) so dialogue
+ * outside a label body is not attributed to the previous label.
  */
 function extractOriginalDialogueByLabel(
-  lines: string[]
+  lines: string[],
+  labelBlocks: LabelBlock[],
+  skipLines: Set<number>
 ): Map<string, DialogueAlignEntry[]> {
   const byLabel = new Map<string, DialogueAlignEntry[]>();
-  let currentLabel: string | null = null;
 
-  for (const line of lines) {
-    const trimmed = line.trim();
-    const labelMatch = line.match(RENPY_LABEL_REGEX);
-    if (labelMatch) {
-      currentLabel = labelMatch[1];
-      if (!byLabel.has(currentLabel)) {
-        byLabel.set(currentLabel, []);
+  for (const block of labelBlocks) {
+    const entries: DialogueAlignEntry[] = [];
+    for (let i = block.startLine + 1; i <= block.endLine; i++) {
+      if (skipLines.has(i)) continue;
+      const entry = parseDialogueEntry(lines[i].trim());
+      if (entry) {
+        entries.push(entry);
       }
-      continue;
     }
-    if (!currentLabel) continue;
-    const entry = parseDialogueEntry(trimmed);
-    if (entry) {
-      byLabel.get(currentLabel)!.push(entry);
-    }
+    byLabel.set(block.name, entries);
   }
 
   return byLabel;
@@ -146,7 +145,23 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
   const lines = originalContent.split("\n");
   const result: string[] = [];
 
-  const originalByLabel = extractOriginalDialogueByLabel(lines);
+  const labelBlocks = parseLabelBoundaries(originalContent);
+  const labelEndByName = new Map(
+    labelBlocks.map((b) => [b.name, b.endLine] as const)
+  );
+  const labelIndentByName = new Map(
+    labelBlocks.map((b) => {
+      const indentCol = lines[b.startLine]?.search(/\S/) ?? 0;
+      return [b.name, indentCol] as const;
+    })
+  );
+  const { skipLines } = trackBlocks(lines);
+
+  const originalByLabel = extractOriginalDialogueByLabel(
+    lines,
+    labelBlocks,
+    skipLines
+  );
   const alignStates = new Map<string, LabelAlignState>();
 
   for (const [label, updated] of updatedDialogue.entries()) {
@@ -163,6 +178,7 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
   let lastDialogueIndent = "    ";
   const encounteredLabels = new Set<string>();
   const menuStack: number[] = [];
+  const openMenuKeywordIndent = new Map<string, number>();
   const menuBlockIndices = new Map<string, number>();
   const menuChoiceIndices = new Map<string, number>();
 
@@ -181,7 +197,8 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
     return flushRemainingInserts(state, result, indent);
   };
 
-  for (const line of lines) {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
     const trimmed = line.trim();
 
     const labelMatch = line.match(RENPY_LABEL_REGEX);
@@ -206,12 +223,38 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
       continue;
     }
 
+    // Exit the current label body when we leave its parsed range (e.g. top-level
+    // screen / init / sibling block at label indent or above).
+    if (currentLabel && trimmed) {
+      const endLine = labelEndByName.get(currentLabel);
+      const labelIndent = labelIndentByName.get(currentLabel) ?? 0;
+      const lineIndent = line.search(/\S/);
+      if (
+        (endLine !== undefined && lineIndex > endLine) ||
+        lineIndent <= labelIndent
+      ) {
+        if (alignStates.has(currentLabel)) {
+          flushLabelTrailing(currentLabel);
+        }
+        currentLabel = null;
+        menuStack.length = 0;
+      }
+    }
+
+    // Skip screen/init interiors for dialogue mutation (still emit the line)
+    if (skipLines.has(lineIndex)) {
+      result.push(line);
+      continue;
+    }
+
     // Track menu block nesting: push on menu:, pop on dedent.
     // Inserts that follow a menu title in the flat dialogue list must not be
     // emitted inside the menu — flush them when the menu block ends.
     if (trimmed === "menu:") {
-      menuStack.push(line.search(/\S/));
+      const menuIndent = line.search(/\S/);
+      menuStack.push(menuIndent);
       if (currentLabel) {
+        openMenuKeywordIndent.set(currentLabel, menuIndent);
         const blockIdx = menuBlockIndices.get(currentLabel) ?? 0;
         menuBlockIndices.set(currentLabel, blockIdx + 1);
         menuChoiceIndices.set(currentLabel, 0);
@@ -219,20 +262,24 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
     } else if (menuStack.length > 0 && trimmed) {
       const lineIndent = line.search(/\S/);
       const wasInMenu = menuStack.length > 0;
+      let poppedMenuIndent: number | null = null;
       while (
         menuStack.length > 0 &&
         lineIndent <= menuStack[menuStack.length - 1]
       ) {
+        poppedMenuIndent = menuStack[menuStack.length - 1];
         menuStack.pop();
       }
       if (
         wasInMenu &&
         menuStack.length === 0 &&
         currentLabel &&
-        alignStates.has(currentLabel)
+        alignStates.has(currentLabel) &&
+        poppedMenuIndent !== null
       ) {
+        openMenuKeywordIndent.delete(currentLabel);
         const state = alignStates.get(currentLabel)!;
-        const indent = labelIndentation.get(currentLabel) || lastDialogueIndent;
+        const indent = " ".repeat(poppedMenuIndent);
         flushInserts(state, result, indent);
       }
     }
@@ -247,35 +294,33 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
         /^(?:"(.+?)"|'(.+?)'|(?!(?:if|elif|else|pass|jump|call|return|python|while|for|default|define|label|menu|init)\s*:)([a-zA-Z_][a-zA-Z0-9_ ]*?))(?:\s+(if\s+.+))?:(?:\s*)?$/
       );
       if (choiceMatch) {
-        const labelBlocks = updatedMenuChoices.get(currentLabel)!;
+        const labelBlocksChoices = updatedMenuChoices.get(currentLabel)!;
         const blockIdx = (menuBlockIndices.get(currentLabel) ?? 1) - 1;
         const choiceIdx = menuChoiceIndices.get(currentLabel) ?? 0;
 
         if (
-          blockIdx < labelBlocks.length &&
-          choiceIdx < labelBlocks[blockIdx].length
+          blockIdx < labelBlocksChoices.length &&
+          choiceIdx < labelBlocksChoices[blockIdx].length
         ) {
-          const newChoiceText = labelBlocks[blockIdx][choiceIdx].label;
+          const newChoiceText = labelBlocksChoices[blockIdx][choiceIdx].label;
           menuChoiceIndices.set(currentLabel, choiceIdx + 1);
 
           const indent = line.match(/^(\s*)/)?.[1] || "";
           const conditionPart = choiceMatch[4];
-          const quote = choiceMatch[1] ? '"' : choiceMatch[2] ? "'" : "";
+          // Always double-quote — escapeRenpyString handles " safely
           if (conditionPart) {
             result.push(
-              `${indent}${quote}${escapeRenpyString(newChoiceText)}${quote} ${conditionPart}:`
+              `${indent}"${escapeRenpyString(newChoiceText)}" ${conditionPart}:`
             );
           } else {
-            result.push(
-              `${indent}${quote}${escapeRenpyString(newChoiceText)}${quote}:`
-            );
+            result.push(`${indent}"${escapeRenpyString(newChoiceText)}":`);
           }
           continue;
         }
       }
     }
 
-    const { isDialogue, isSingleQuoted } = isDialogueOrNarrationLine(trimmed);
+    const { isDialogue } = isDialogueOrNarrationLine(trimmed);
 
     if (isDialogue && currentLabel && alignStates.has(currentLabel)) {
       const state = alignStates.get(currentLabel)!;
@@ -311,8 +356,7 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
       if (op.type === "equal" || op.type === "replace") {
         const newDialogue = state.updated[op.updatedIndex];
         state.opIdx++;
-        const quote = isSingleQuoted ? "'" : '"';
-        result.push(formatDialogueLine(newDialogue, indent, quote));
+        result.push(formatDialogueLine(newDialogue, indent));
         if (menuStack.length === 0) {
           flushInserts(state, result, indent);
         }
@@ -346,7 +390,11 @@ export function reconstructRPYFile(options: ReconstructedFileOptions): string {
       throw new Error(`Unknown label in updatedDialogue: ${label}`);
     }
     if (state.opIdx < state.ops.length) {
-      const indent = labelIndentation.get(label) || lastDialogueIndent;
+      const menuIndent = openMenuKeywordIndent.get(label);
+      const indent =
+        menuIndent !== undefined
+          ? " ".repeat(menuIndent)
+          : labelIndentation.get(label) || lastDialogueIndent;
       flushRemainingInserts(state, result, indent);
     }
   }

--- a/apps/frontend/src/components/write-mode/ProseEditor.tsx
+++ b/apps/frontend/src/components/write-mode/ProseEditor.tsx
@@ -20,6 +20,7 @@ import { DialogueLine } from "./DialogueLine";
 import {
   areDialogueEntriesEqual,
   menuLineToChoiceEntries,
+  findDialogueInsertIndex,
 } from "@/lib/prose-converter";
 import { WritingGoalPill } from "./WritingGoalPill";
 const WritingStatsDialog = lazy(() =>
@@ -585,39 +586,26 @@ export const ProseEditor = function ProseEditor({
       setEntries((prev) => {
         const newEntries = [...prev];
         const currentEntry = prev[index];
-
-        // If adding from a CHOICE entry, create another CHOICE entry
-        if (currentEntry?.contentType === "CHOICE" && currentEntry.choiceData) {
-          const { lineId, targetLabelId, targetLabelName } =
-            currentEntry.choiceData;
-          const newEntry: DialogueEntry = {
-            id: crypto.randomUUID(),
-            speakerId: null,
-            text: "",
-            contentType: "CHOICE",
-            choiceData: {
-              lineId,
-              optionIndex: index + 1, // Will be recalculated on save
-              targetLabelId,
-              targetLabelName,
-            },
-          };
-          newEntries.splice(index + 1, 0, newEntry);
-        } else {
-          // Default: create a dialogue/narration entry
-          const newEntry: DialogueEntry = {
-            id: crypto.randomUUID(),
-            speakerId: prev[index]?.speakerId || null,
-            text: "",
-          };
-          newEntries.splice(index + 1, 0, newEntry);
-        }
+        // Always insert dialogue/narration. Never create CHOICE rows here —
+        // Script Mode owns menu structure, and empty choice labels fail API
+        // validation. Enter on a menu prompt or choice jumps past the block.
+        const insertAt = findDialogueInsertIndex(prev, index);
+        const speakerId =
+          currentEntry?.contentType === "CHOICE"
+            ? null
+            : (currentEntry?.speakerId ?? null);
+        const newEntry: DialogueEntry = {
+          id: crypto.randomUUID(),
+          speakerId,
+          text: "",
+        };
+        newEntries.splice(insertAt, 0, newEntry);
 
         // Record history snapshot
         recordImmediateHistorySnapshot(newEntries);
 
         // Queue focus operation
-        pendingFocusRef.current = { index: index + 1, scrollIntoView: true };
+        pendingFocusRef.current = { index: insertAt, scrollIntoView: true };
 
         return newEntries;
       });

--- a/apps/frontend/src/lib/__tests__/prose-converter.unit.test.ts
+++ b/apps/frontend/src/lib/__tests__/prose-converter.unit.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { dialogueToPayload } from "../prose-converter";
+import { dialogueToPayload, findDialogueInsertIndex } from "../prose-converter";
 import type { DialogueEntry } from "../prose-types";
 
 describe("dialogueToPayload", () => {
@@ -79,5 +79,66 @@ describe("dialogueToPayload", () => {
   it("should handle empty input array", () => {
     const result = dialogueToPayload([]);
     expect(result).toEqual([]);
+  });
+});
+
+describe("findDialogueInsertIndex", () => {
+  const menuPrompt: DialogueEntry = {
+    id: "prompt",
+    speakerId: null,
+    text: "Are you over 18?",
+  };
+  const choice1: DialogueEntry = {
+    id: "c1",
+    speakerId: null,
+    text: "Yes",
+    contentType: "CHOICE",
+    choiceData: {
+      lineId: "menu-1",
+      optionIndex: 0,
+      targetLabelId: "t1",
+      targetLabelName: "yes",
+    },
+  };
+  const choice2: DialogueEntry = {
+    id: "c2",
+    speakerId: null,
+    text: "No",
+    contentType: "CHOICE",
+    choiceData: {
+      lineId: "menu-1",
+      optionIndex: 1,
+      targetLabelId: "t2",
+      targetLabelName: "no",
+    },
+  };
+  const after: DialogueEntry = {
+    id: "after",
+    speakerId: null,
+    text: "After menu",
+  };
+
+  const entries = [menuPrompt, choice1, choice2, after];
+
+  it("inserts after the choice block when Enter is on the menu prompt", () => {
+    expect(findDialogueInsertIndex(entries, 0)).toBe(3);
+  });
+
+  it("inserts after the choice block when Enter is on the first choice", () => {
+    expect(findDialogueInsertIndex(entries, 1)).toBe(3);
+  });
+
+  it("inserts after the choice block when Enter is on the last choice", () => {
+    expect(findDialogueInsertIndex(entries, 2)).toBe(3);
+  });
+
+  it("inserts at index+1 for normal dialogue", () => {
+    expect(findDialogueInsertIndex(entries, 3)).toBe(4);
+  });
+
+  it("inserts after choices when menu is at end of list", () => {
+    const menuOnly = [menuPrompt, choice1, choice2];
+    expect(findDialogueInsertIndex(menuOnly, 0)).toBe(3);
+    expect(findDialogueInsertIndex(menuOnly, 2)).toBe(3);
   });
 });

--- a/apps/frontend/src/lib/__tests__/prose-converter.unit.test.ts
+++ b/apps/frontend/src/lib/__tests__/prose-converter.unit.test.ts
@@ -141,4 +141,70 @@ describe("findDialogueInsertIndex", () => {
     expect(findDialogueInsertIndex(menuOnly, 0)).toBe(3);
     expect(findDialogueInsertIndex(menuOnly, 2)).toBe(3);
   });
+
+  it("continues across CHOICE entries with missing lineId from the prompt", () => {
+    const missingMeta: DialogueEntry[] = [
+      menuPrompt,
+      {
+        id: "c1",
+        speakerId: null,
+        text: "Yes",
+        contentType: "CHOICE",
+        // no choiceData
+      },
+      {
+        id: "c2",
+        speakerId: null,
+        text: "No",
+        contentType: "CHOICE",
+        choiceData: {
+          lineId: "menu-1",
+          optionIndex: 1,
+          targetLabelId: "t2",
+          targetLabelName: "no",
+        },
+      },
+      after,
+    ];
+    expect(findDialogueInsertIndex(missingMeta, 0)).toBe(3);
+  });
+
+  it("continues across CHOICE entries when starting CHOICE has no lineId", () => {
+    const missingOnChoice: DialogueEntry[] = [
+      menuPrompt,
+      {
+        id: "c1",
+        speakerId: null,
+        text: "Yes",
+        contentType: "CHOICE",
+      },
+      choice2,
+      after,
+    ];
+    // Enter on first choice (no lineId) should still skip the rest of the block
+    expect(findDialogueInsertIndex(missingOnChoice, 1)).toBe(3);
+  });
+
+  it("stops at a different menu when both lineIds exist and differ", () => {
+    const twoMenus: DialogueEntry[] = [
+      menuPrompt,
+      choice1,
+      choice2,
+      {
+        id: "c3",
+        speakerId: null,
+        text: "Other",
+        contentType: "CHOICE",
+        choiceData: {
+          lineId: "menu-2",
+          optionIndex: 0,
+          targetLabelId: "t3",
+          targetLabelName: "other",
+        },
+      },
+      after,
+    ];
+    expect(findDialogueInsertIndex(twoMenus, 0)).toBe(3);
+    expect(findDialogueInsertIndex(twoMenus, 1)).toBe(3);
+  });
 });

--- a/apps/frontend/src/lib/prose-converter.ts
+++ b/apps/frontend/src/lib/prose-converter.ts
@@ -241,11 +241,12 @@ export function findDialogueInsertIndex(
   if (current.contentType === "CHOICE") {
     const lineId = current.choiceData?.lineId;
     let i = index;
-    while (
-      i + 1 < entries.length &&
-      entries[i + 1].contentType === "CHOICE" &&
-      (!lineId || entries[i + 1].choiceData?.lineId === lineId)
-    ) {
+    while (i + 1 < entries.length && entries[i + 1].contentType === "CHOICE") {
+      const nextId = entries[i + 1].choiceData?.lineId;
+      // Stop only when both line IDs exist and differ
+      if (lineId && nextId && lineId !== nextId) {
+        break;
+      }
       i++;
     }
     return i + 1;
@@ -256,11 +257,11 @@ export function findDialogueInsertIndex(
   if (next?.contentType === "CHOICE") {
     const lineId = next.choiceData?.lineId;
     let i = index + 1;
-    while (
-      i < entries.length &&
-      entries[i].contentType === "CHOICE" &&
-      (!lineId || entries[i].choiceData?.lineId === lineId)
-    ) {
+    while (i < entries.length && entries[i].contentType === "CHOICE") {
+      const curId = entries[i].choiceData?.lineId;
+      if (lineId && curId && lineId !== curId) {
+        break;
+      }
       i++;
     }
     return i;

--- a/apps/frontend/src/lib/prose-converter.ts
+++ b/apps/frontend/src/lib/prose-converter.ts
@@ -217,3 +217,54 @@ export function menuLineToChoiceEntries(line: {
   }
   return result;
 }
+
+/**
+ * Find where to insert a new dialogue line after pressing Enter at `index`.
+ *
+ * Write Mode must not insert prose between a menu prompt and its choices, or
+ * create new choices (Script Mode owns that). Enter on a menu prompt or any
+ * CHOICE inserts after the contiguous choice block for that menu.
+ *
+ * @returns Index at which to splice the new dialogue entry
+ */
+export function findDialogueInsertIndex(
+  entries: DialogueEntry[],
+  index: number
+): number {
+  if (index < 0 || index >= entries.length) {
+    return entries.length;
+  }
+
+  const current = entries[index];
+
+  // Enter on a CHOICE → after that menu's contiguous choice run
+  if (current.contentType === "CHOICE") {
+    const lineId = current.choiceData?.lineId;
+    let i = index;
+    while (
+      i + 1 < entries.length &&
+      entries[i + 1].contentType === "CHOICE" &&
+      (!lineId || entries[i + 1].choiceData?.lineId === lineId)
+    ) {
+      i++;
+    }
+    return i + 1;
+  }
+
+  // Enter on prose immediately before CHOICEs (menu prompt) → after that block
+  const next = entries[index + 1];
+  if (next?.contentType === "CHOICE") {
+    const lineId = next.choiceData?.lineId;
+    let i = index + 1;
+    while (
+      i < entries.length &&
+      entries[i].contentType === "CHOICE" &&
+      (!lineId || entries[i].choiceData?.lineId === lineId)
+    ) {
+      i++;
+    }
+    return i;
+  }
+
+  return index + 1;
+}


### PR DESCRIPTION
Replace positional 1:1 prose mapping with LCS-based dialogue alignment so mid-list inserts and deletes don't shift prose lines into wrong scene/show keyword slots in the RPY file.

## What changed

- **Backend**: Add `alignDialogue` (LCS) and `planDialogueLineUpdates` modules for alignment-based dialogue saving
- **Backend**: Refactor `reconstructRPYFile` to use alignment for insert/delete/replace with menu-block-aware placement
- **Backend**: Update `labels.routes.ts` to use `planDialogueLineUpdates` with sequence reindexing of non-prose rows
- **Frontend**: Prevent Enter key from inserting prose between a menu prompt and its choices (`findDialogueInsertIndex`)
- **Tests**: 6 edge-case tests for alignment, regression tests for mid-list insert/deletely, menu title protection, and integration test updated for new menu-aware ordering

## Verification

- All 108 backend unit tests pass (+6 new)
- All 428 integration tests pass
- Frontend unit tests pass (1 pre-existing dagre timeout unrelated)
- TypeCheck and lint clean
- Both `pnpm test:integration` and `pnpm typecheck` pass in pre-push hook

## Oracle review

Strategic + security review completed (2 passes). Verdict: **ready for PR** — 0 remaining must-fix or should-fix findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved write-mode “add line” behavior: adds dialogue prose (not choice rows) and positions new lines using menu/choice-aware insertion rules.
  * Enhanced reconstruction/update logic to keep inserted/edited dialogue correctly ordered relative to menu prompts and choice blocks.

* **Bug Fixes**
  * Fixed reconstruction when dialogue lines are removed, replaced, or inserted mid-list, including complex scenarios around menus, JUMP/call/return blocks, and nearby visual commands.
  * Prevented stale/deleted dialogue from reappearing and ensured structural/menu ordering remains stable.
  * Standardized dialogue output to consistently use double-quoted Ren’Py strings for replaced content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->