### PR TITLE
fix: validation.ts security issues from #279 audit (#313)

### DIFF
--- a/apps/backend/src/lib/__tests__/ip-validation.unit.test.ts
+++ b/apps/backend/src/lib/__tests__/ip-validation.unit.test.ts
@@ -10,6 +10,7 @@ import {
   isPrivateOrLocalHostname,
   isAllowedGitlabHost,
   isValidPublicHost,
+  resolvePublicHost,
 } from "../ip-validation.js";
 
 // Mock node:dns
@@ -55,6 +56,11 @@ describe("isPrivateIP", () => {
   it("should detect multicast addresses", () => {
     expect(isPrivateIP("224.0.0.1")).toBe(true);
     expect(isPrivateIP("ff02::1")).toBe(true);
+  });
+
+  it("should detect unspecified addresses (0.0.0.0 and ::)", () => {
+    expect(isPrivateIP("0.0.0.0")).toBe(true);
+    expect(isPrivateIP("::")).toBe(true);
   });
 
   it("should accept public IPv4", () => {
@@ -133,64 +139,86 @@ describe("isAllowedGitlabHost", () => {
   });
 });
 
+describe("resolvePublicHost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return IP list when all resolved IPs are public", async () => {
+    vi.mocked(dns.resolve4).mockResolvedValue(["8.8.8.8", "1.1.1.1"]);
+    vi.mocked(dns.resolve6).mockResolvedValue(["2001:4860:4860::8888"]);
+
+    const result = await resolvePublicHost("gitlab.com");
+    expect(result).toEqual(["8.8.8.8", "1.1.1.1", "2001:4860:4860::8888"]);
+  });
+
+  it("should return null when any resolved IP is private", async () => {
+    vi.mocked(dns.resolve4).mockResolvedValue(["8.8.8.8", "192.168.1.1"]);
+    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENODATA"));
+
+    const result = await resolvePublicHost("evil.example.com");
+    expect(result).toBeNull();
+  });
+
+  it("should return null when IPv6 ULA resolves", async () => {
+    vi.mocked(dns.resolve4).mockRejectedValue(new Error("ENODATA"));
+    vi.mocked(dns.resolve6).mockResolvedValue(["fd12::1"]);
+
+    const result = await resolvePublicHost("ula.example.com");
+    expect(result).toBeNull();
+  });
+
+  it("should return null when multicast IP resolves", async () => {
+    vi.mocked(dns.resolve4).mockResolvedValue(["224.0.0.1"]);
+    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENODATA"));
+
+    const result = await resolvePublicHost("multicast.example.com");
+    expect(result).toBeNull();
+  });
+
+  it("should return null when DNS fails entirely", async () => {
+    vi.mocked(dns.resolve4).mockRejectedValue(new Error("ENOTFOUND"));
+    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENOTFOUND"));
+
+    const result = await resolvePublicHost("does-not-exist.test");
+    expect(result).toBeNull();
+  });
+
+  it("should return null when one family fails but other has private IP", async () => {
+    vi.mocked(dns.resolve4).mockRejectedValue(new Error("ENODATA"));
+    vi.mocked(dns.resolve6).mockResolvedValue(["::1"]);
+
+    const result = await resolvePublicHost("localhost.example.com");
+    expect(result).toBeNull();
+  });
+
+  it("should return IP list when only IPv4 resolves with public IP", async () => {
+    vi.mocked(dns.resolve4).mockResolvedValue(["8.8.8.8"]);
+    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENODATA"));
+
+    const result = await resolvePublicHost("ipv4-only.example.com");
+    expect(result).toEqual(["8.8.8.8"]);
+  });
+});
+
 describe("isValidPublicHost", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should return true when all resolved IPs are public", async () => {
-    vi.mocked(dns.resolve4).mockResolvedValue(["8.8.8.8", "1.1.1.1"]);
-    vi.mocked(dns.resolve6).mockResolvedValue(["2001:4860:4860::8888"]);
+  it("should return true when resolvePublicHost returns IPs", async () => {
+    vi.mocked(dns.resolve4).mockResolvedValue(["8.8.8.8"]);
+    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENODATA"));
 
     const result = await isValidPublicHost("gitlab.com");
     expect(result).toBe(true);
   });
 
-  it("should return false when any resolved IP is private", async () => {
-    vi.mocked(dns.resolve4).mockResolvedValue(["8.8.8.8", "192.168.1.1"]);
+  it("should return false when resolvePublicHost returns null", async () => {
+    vi.mocked(dns.resolve4).mockResolvedValue(["192.168.1.1"]);
     vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENODATA"));
 
-    const result = await isValidPublicHost("evil.example.com");
+    const result = await isValidPublicHost("private.example.com");
     expect(result).toBe(false);
-  });
-
-  it("should return false when IPv6 ULA resolves", async () => {
-    vi.mocked(dns.resolve4).mockRejectedValue(new Error("ENODATA"));
-    vi.mocked(dns.resolve6).mockResolvedValue(["fd12::1"]);
-
-    const result = await isValidPublicHost("ula.example.com");
-    expect(result).toBe(false);
-  });
-
-  it("should return false when multicast IP resolves", async () => {
-    vi.mocked(dns.resolve4).mockResolvedValue(["224.0.0.1"]);
-    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENODATA"));
-
-    const result = await isValidPublicHost("multicast.example.com");
-    expect(result).toBe(false);
-  });
-
-  it("should return false when DNS fails entirely", async () => {
-    vi.mocked(dns.resolve4).mockRejectedValue(new Error("ENOTFOUND"));
-    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENOTFOUND"));
-
-    const result = await isValidPublicHost("does-not-exist.test");
-    expect(result).toBe(false);
-  });
-
-  it("should return false when one family fails but other has private IP", async () => {
-    vi.mocked(dns.resolve4).mockRejectedValue(new Error("ENODATA"));
-    vi.mocked(dns.resolve6).mockResolvedValue(["::1"]);
-
-    const result = await isValidPublicHost("localhost.example.com");
-    expect(result).toBe(false);
-  });
-
-  it("should return true when only IPv4 resolves with public IP", async () => {
-    vi.mocked(dns.resolve4).mockResolvedValue(["8.8.8.8"]);
-    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENODATA"));
-
-    const result = await isValidPublicHost("ipv4-only.example.com");
-    expect(result).toBe(true);
   });
 });

--- a/apps/backend/src/lib/__tests__/ip-validation.unit.test.ts
+++ b/apps/backend/src/lib/__tests__/ip-validation.unit.test.ts
@@ -126,11 +126,19 @@ describe("isAllowedGitlabHost", () => {
     expect(isAllowedGitlabHost("my-project.gitlab.io")).toBe(false);
   });
 
-  it("should allow hosts from ALLOWED_GITLAB_HOSTS env var", () => {
+  it("should allow hosts from ALLOWED_GITLAB_HOSTS env var", async () => {
+    const original = process.env.ALLOWED_GITLAB_HOSTS;
     process.env.ALLOWED_GITLAB_HOSTS = "example.gitlab.io,custom.host";
-    // Re-import won't re-evaluate the top-level constant, so this test
-    // verifies that the *concept* is documented.  The env-var extension
-    // path is exercised by integration tests.
+    vi.resetModules();
+    const mod = await import("../ip-validation.js");
+    try {
+      expect(mod.isAllowedGitlabHost("example.gitlab.io")).toBe(true);
+      expect(mod.isAllowedGitlabHost("custom.host")).toBe(true);
+      expect(mod.isAllowedGitlabHost("unlisted.gitlab.io")).toBe(false);
+    } finally {
+      process.env.ALLOWED_GITLAB_HOSTS = original;
+      vi.resetModules();
+    }
   });
 
   it("should reject unrelated hosts", () => {

--- a/apps/backend/src/lib/__tests__/ip-validation.unit.test.ts
+++ b/apps/backend/src/lib/__tests__/ip-validation.unit.test.ts
@@ -1,0 +1,196 @@
+/**
+ * IP Validation Unit Tests
+ *
+ * Tests for SSRF protection utilities in src/lib/ip-validation.ts
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  isPrivateIP,
+  isPrivateOrLocalHostname,
+  isAllowedGitlabHost,
+  isValidPublicHost,
+} from "../ip-validation.js";
+
+// Mock node:dns
+vi.mock("node:dns", () => ({
+  promises: {
+    resolve4: vi.fn(),
+    resolve6: vi.fn(),
+  },
+}));
+
+import { promises as dns } from "node:dns";
+
+describe("isPrivateIP", () => {
+  it("should detect loopback IPv4", () => {
+    expect(isPrivateIP("127.0.0.1")).toBe(true);
+    expect(isPrivateIP("127.255.255.255")).toBe(true);
+  });
+
+  it("should detect loopback IPv6", () => {
+    expect(isPrivateIP("::1")).toBe(true);
+  });
+
+  it("should detect private IPv4 (RFC 1918)", () => {
+    expect(isPrivateIP("10.0.0.1")).toBe(true);
+    expect(isPrivateIP("172.16.0.1")).toBe(true);
+    expect(isPrivateIP("172.31.255.255")).toBe(true);
+    expect(isPrivateIP("192.168.1.1")).toBe(true);
+  });
+
+  it("should detect link-local IPv4", () => {
+    expect(isPrivateIP("169.254.1.1")).toBe(true);
+  });
+
+  it("should detect carrier-grade NAT", () => {
+    expect(isPrivateIP("100.64.0.1")).toBe(true);
+  });
+
+  it("should detect IPv6 Unique Local Addresses (ULA)", () => {
+    expect(isPrivateIP("fc00::1")).toBe(true);
+    expect(isPrivateIP("fd12:3456:789a::1")).toBe(true);
+  });
+
+  it("should detect multicast addresses", () => {
+    expect(isPrivateIP("224.0.0.1")).toBe(true);
+    expect(isPrivateIP("ff02::1")).toBe(true);
+  });
+
+  it("should accept public IPv4", () => {
+    expect(isPrivateIP("8.8.8.8")).toBe(false);
+    expect(isPrivateIP("1.1.1.1")).toBe(false);
+  });
+
+  it("should accept public IPv6", () => {
+    expect(isPrivateIP("2001:4860:4860::8888")).toBe(false);
+  });
+
+  it("should handle IPv4-mapped IPv6", () => {
+    expect(isPrivateIP("::ffff:192.168.1.1")).toBe(true);
+    expect(isPrivateIP("::ffff:8.8.8.8")).toBe(false);
+  });
+
+  it("should return false for invalid input", () => {
+    expect(isPrivateIP("not-an-ip")).toBe(false);
+    expect(isPrivateIP("")).toBe(false);
+  });
+});
+
+describe("isPrivateOrLocalHostname", () => {
+  it("should detect localhost variants", () => {
+    expect(isPrivateOrLocalHostname("localhost")).toBe(true);
+    expect(isPrivateOrLocalHostname("myapp.local")).toBe(true);
+    expect(isPrivateOrLocalHostname("myapp.localhost")).toBe(true);
+  });
+
+  it("should detect private IPs", () => {
+    expect(isPrivateOrLocalHostname("10.0.0.1")).toBe(true);
+    expect(isPrivateOrLocalHostname("192.168.1.1")).toBe(true);
+  });
+
+  it("should detect bracketed IPv6", () => {
+    expect(isPrivateOrLocalHostname("[::1]")).toBe(true);
+    expect(isPrivateOrLocalHostname("[fc00::1]")).toBe(true);
+  });
+
+  it("should accept public hostnames", () => {
+    expect(isPrivateOrLocalHostname("gitlab.com")).toBe(false);
+    expect(isPrivateOrLocalHostname("example.com")).toBe(false);
+  });
+});
+
+describe("isAllowedGitlabHost", () => {
+  beforeEach(() => {
+    delete process.env.ALLOWED_GITLAB_HOSTS;
+  });
+
+  it("should allow gitlab.com", () => {
+    expect(isAllowedGitlabHost("gitlab.com")).toBe(true);
+    expect(isAllowedGitlabHost("GITLAB.COM")).toBe(true);
+  });
+
+  it("should allow *.gitlab.com subdomains", () => {
+    expect(isAllowedGitlabHost("company.gitlab.com")).toBe(true);
+    expect(isAllowedGitlabHost("my-company.gitlab.com")).toBe(true);
+  });
+
+  it("should NOT allow *.gitlab.io (user-controlled Pages)", () => {
+    expect(isAllowedGitlabHost("example.gitlab.io")).toBe(false);
+    expect(isAllowedGitlabHost("my-project.gitlab.io")).toBe(false);
+  });
+
+  it("should allow hosts from ALLOWED_GITLAB_HOSTS env var", () => {
+    process.env.ALLOWED_GITLAB_HOSTS = "example.gitlab.io,custom.host";
+    // Re-import won't re-evaluate the top-level constant, so this test
+    // verifies that the *concept* is documented.  The env-var extension
+    // path is exercised by integration tests.
+  });
+
+  it("should reject unrelated hosts", () => {
+    expect(isAllowedGitlabHost("github.com")).toBe(false);
+    expect(isAllowedGitlabHost("gitlab.example.com")).toBe(false);
+  });
+});
+
+describe("isValidPublicHost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return true when all resolved IPs are public", async () => {
+    vi.mocked(dns.resolve4).mockResolvedValue(["8.8.8.8", "1.1.1.1"]);
+    vi.mocked(dns.resolve6).mockResolvedValue(["2001:4860:4860::8888"]);
+
+    const result = await isValidPublicHost("gitlab.com");
+    expect(result).toBe(true);
+  });
+
+  it("should return false when any resolved IP is private", async () => {
+    vi.mocked(dns.resolve4).mockResolvedValue(["8.8.8.8", "192.168.1.1"]);
+    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENODATA"));
+
+    const result = await isValidPublicHost("evil.example.com");
+    expect(result).toBe(false);
+  });
+
+  it("should return false when IPv6 ULA resolves", async () => {
+    vi.mocked(dns.resolve4).mockRejectedValue(new Error("ENODATA"));
+    vi.mocked(dns.resolve6).mockResolvedValue(["fd12::1"]);
+
+    const result = await isValidPublicHost("ula.example.com");
+    expect(result).toBe(false);
+  });
+
+  it("should return false when multicast IP resolves", async () => {
+    vi.mocked(dns.resolve4).mockResolvedValue(["224.0.0.1"]);
+    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENODATA"));
+
+    const result = await isValidPublicHost("multicast.example.com");
+    expect(result).toBe(false);
+  });
+
+  it("should return false when DNS fails entirely", async () => {
+    vi.mocked(dns.resolve4).mockRejectedValue(new Error("ENOTFOUND"));
+    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENOTFOUND"));
+
+    const result = await isValidPublicHost("does-not-exist.test");
+    expect(result).toBe(false);
+  });
+
+  it("should return false when one family fails but other has private IP", async () => {
+    vi.mocked(dns.resolve4).mockRejectedValue(new Error("ENODATA"));
+    vi.mocked(dns.resolve6).mockResolvedValue(["::1"]);
+
+    const result = await isValidPublicHost("localhost.example.com");
+    expect(result).toBe(false);
+  });
+
+  it("should return true when only IPv4 resolves with public IP", async () => {
+    vi.mocked(dns.resolve4).mockResolvedValue(["8.8.8.8"]);
+    vi.mocked(dns.resolve6).mockRejectedValue(new Error("ENODATA"));
+
+    const result = await isValidPublicHost("ipv4-only.example.com");
+    expect(result).toBe(true);
+  });
+});

--- a/apps/backend/src/lib/__tests__/validation.unit.test.ts
+++ b/apps/backend/src/lib/__tests__/validation.unit.test.ts
@@ -28,6 +28,7 @@ import {
   gitlabUrlSchema,
   validateData,
   safeValidateData,
+  sessionDataSchema,
   updateLabelDialogueBodySchema,
   updateLabelSchema,
   createWorldElementSchema,
@@ -344,15 +345,15 @@ describe("GitLab URL Schema (SSRF Protection)", () => {
       }
     });
 
-    it("should accept valid HTTPS *.gitlab.io URLs", () => {
-      const validUrls = [
+    it("should reject *.gitlab.io URLs (user-controlled GitLab Pages)", () => {
+      const invalidUrls = [
         "https://example.gitlab.io",
         "https://my-project.gitlab.io/path",
       ];
 
-      for (const url of validUrls) {
+      for (const url of invalidUrls) {
         const result = gitlabUrlSchema.safeParse(url);
-        expect(result.success).toBe(true);
+        expect(result.success).toBe(false);
       }
     });
 
@@ -1483,6 +1484,43 @@ describe("Helper Functions", () => {
       if (!result.success) {
         expect(result.error).toBeDefined();
       }
+    });
+  });
+
+  describe("sessionDataSchema", () => {
+    it("should accept valid session data", () => {
+      const data = {
+        user: { sub: "user-123" },
+        flash: "welcome back",
+      };
+      const result = sessionDataSchema.safeParse(data);
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject string values exceeding 4096 characters", () => {
+      const longString = "a".repeat(4097);
+      const data = {
+        flash: longString,
+      };
+      const result = sessionDataSchema.safeParse(data);
+      expect(result.success).toBe(false);
+    });
+
+    it("should accept nested objects with valid strings", () => {
+      const data = {
+        user: { sub: "user-123" },
+      };
+      const result = sessionDataSchema.safeParse(data);
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject nested object string values exceeding 4096", () => {
+      const longString = "a".repeat(4097);
+      const data = {
+        user: { sub: longString },
+      };
+      const result = sessionDataSchema.safeParse(data);
+      expect(result.success).toBe(false);
     });
   });
 });

--- a/apps/backend/src/lib/ip-validation.ts
+++ b/apps/backend/src/lib/ip-validation.ts
@@ -5,7 +5,11 @@
  * local hostnames, and validating GitLab hostnames against the allowlist.
  */
 
+import { promises as dns } from "node:dns";
 import ipaddr from "ipaddr.js";
+
+// DNS resolution timeout for isValidPublicHost (ms)
+const DNS_RESOLVE_TIMEOUT_MS = 5000;
 
 // Allowed GitLab hostnames (can be extended with environment variable)
 const ALLOWED_GITLAB_HOSTS = new Set([
@@ -36,7 +40,9 @@ export function isPrivateIP(ip: string): boolean {
       range === "linkLocal" ||
       range === "reserved" ||
       range === "broadcast" ||
-      range === "carrierGradeNat"
+      range === "carrierGradeNat" ||
+      range === "uniqueLocal" ||
+      range === "multicast"
     );
   } catch {
     return false;
@@ -75,9 +81,13 @@ export function isPrivateOrLocalHostname(hostname: string): boolean {
  *
  * Allows:
  * - gitlab.com (exact match)
- * - *.gitlab.io subdomains (for GitLab Pages instances)
  * - *.gitlab.com subdomains
  * - Any host added via ALLOWED_GITLAB_HOSTS env var
+ *
+ * NOTE: *.gitlab.io subdomains are NOT unconditionally allowed.
+ * GitLab Pages sites are user-controlled static sites, not API
+ * instances. To allow a specific *.gitlab.io host, add it via
+ * the ALLOWED_GITLAB_HOSTS environment variable.
  */
 export function isAllowedGitlabHost(hostname: string): boolean {
   const lower = hostname.toLowerCase();
@@ -86,9 +96,54 @@ export function isAllowedGitlabHost(hostname: string): boolean {
     return true;
   }
 
-  if (lower.endsWith(".gitlab.io") || lower.endsWith(".gitlab.com")) {
+  if (lower.endsWith(".gitlab.com")) {
     return true;
   }
 
   return false;
+}
+
+/**
+ * Resolve a hostname to IP addresses and check that none are private.
+ *
+ * Uses `dns.resolve4` / `dns.resolve6` (c-ares, non-blocking) rather than
+ * `dns.lookup` to avoid threadpool pressure and `/etc/hosts` bypasses.
+ * Queries both address families in parallel and rejects the host if ANY
+ * resolved address is private, link-local, ULA, or multicast.
+ *
+ * Must be called immediately before making an outbound HTTP request
+ * to prevent DNS rebinding attacks where a hostname's A/AAAA records
+ * are changed between hostname-only validation and the actual fetch.
+ *
+ * @returns true if all resolved addresses are public, false on DNS
+ *   failure, timeout, or if any resolved IP is private.
+ */
+export async function isValidPublicHost(hostname: string): Promise<boolean> {
+  let timeoutId: NodeJS.Timeout | undefined;
+
+  try {
+    const timeout = new Promise<"timeout">((resolve) => {
+      timeoutId = setTimeout(() => resolve("timeout"), DNS_RESOLVE_TIMEOUT_MS);
+    });
+
+    const resolve = (async () => {
+      const [v4, v6] = await Promise.allSettled([
+        dns.resolve4(hostname),
+        dns.resolve6(hostname),
+      ]);
+      const addresses = [
+        ...(v4.status === "fulfilled" ? v4.value : []),
+        ...(v6.status === "fulfilled" ? v6.value : []),
+      ];
+      if (addresses.length === 0) return false;
+      return addresses.every((ip) => !isPrivateIP(ip));
+    })();
+
+    const result = await Promise.race([resolve, timeout]);
+    return result === "timeout" ? false : result;
+  } catch {
+    return false;
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
 }

--- a/apps/backend/src/lib/ip-validation.ts
+++ b/apps/backend/src/lib/ip-validation.ts
@@ -14,9 +14,9 @@ const DNS_RESOLVE_TIMEOUT_MS = 5000;
 // Allowed GitLab hostnames (can be extended with environment variable)
 const ALLOWED_GITLAB_HOSTS = new Set([
   "gitlab.com",
-  ...(process.env.ALLOWED_GITLAB_HOSTS?.split(",").map((h) =>
-    h.trim().toLowerCase()
-  ) || []),
+  ...(process.env.ALLOWED_GITLAB_HOSTS?.split(",")
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean) || []),
 ]);
 
 /**
@@ -42,7 +42,8 @@ export function isPrivateIP(ip: string): boolean {
       range === "broadcast" ||
       range === "carrierGradeNat" ||
       range === "uniqueLocal" ||
-      range === "multicast"
+      range === "multicast" ||
+      range === "unspecified"
     );
   } catch {
     return false;
@@ -119,6 +120,26 @@ export function isAllowedGitlabHost(hostname: string): boolean {
  *   failure, timeout, or if any resolved IP is private.
  */
 export async function isValidPublicHost(hostname: string): Promise<boolean> {
+  const ips = await resolvePublicHost(hostname);
+  return ips !== null && ips.length > 0;
+}
+
+/**
+ * Resolve a hostname to a list of public IP addresses suitable for
+ * connection pinning.
+ *
+ * Performs the same validation as `isValidPublicHost` but returns the
+ * actual resolved addresses so callers can pin the TCP connection
+ * (via `https.request`'s `lookup` option) rather than letting `fetch()`
+ * independently re-resolve the hostname, closing the DNS rebinding
+ * TOCTOU race entirely.
+ *
+ * @returns array of public IP addresses, or null if DNS fails, times
+ *   out, or any resolved address is private.
+ */
+export async function resolvePublicHost(
+  hostname: string
+): Promise<string[] | null> {
   let timeoutId: NodeJS.Timeout | undefined;
 
   try {
@@ -135,14 +156,15 @@ export async function isValidPublicHost(hostname: string): Promise<boolean> {
         ...(v4.status === "fulfilled" ? v4.value : []),
         ...(v6.status === "fulfilled" ? v6.value : []),
       ];
-      if (addresses.length === 0) return false;
-      return addresses.every((ip) => !isPrivateIP(ip));
+      if (addresses.length === 0) return null;
+      if (addresses.some((ip) => isPrivateIP(ip))) return null;
+      return addresses;
     })();
 
     const result = await Promise.race([resolve, timeout]);
-    return result === "timeout" ? false : result;
+    return result === "timeout" ? null : result;
   } catch {
-    return false;
+    return null;
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId);
   }

--- a/apps/backend/src/lib/logger.ts
+++ b/apps/backend/src/lib/logger.ts
@@ -109,6 +109,7 @@ export const LogEventType = {
   // General security events
   SECURITY_PATH_TRAVERSAL: "security.path_traversal",
   SECURITY_INVALID_PATH: "security.invalid_path",
+  SECURITY_SSRF_REFUSAL: "security.ssrf_refusal",
 
   // Service lifecycle events - general operational states
   SERVICE_START: "service.start",

--- a/apps/backend/src/lib/pinned-request.ts
+++ b/apps/backend/src/lib/pinned-request.ts
@@ -9,10 +9,12 @@
  */
 
 import https from "node:https";
+import net from "node:net";
 
 export interface PinnedRequestOptions {
   hostname: string;
   path: string;
+  port?: number;
   method?: string;
   headers?: Record<string, string>;
   body?: string | Buffer;
@@ -30,14 +32,22 @@ export async function pinnedHttpsRequest(
   options: PinnedRequestOptions,
   pinnedIp: string
 ): Promise<Response> {
+  const family = net.isIP(pinnedIp);
+  if (family === 0) {
+    throw new TypeError(
+      `Invalid pinned IP address: ${JSON.stringify(pinnedIp)}`
+    );
+  }
+
   return new Promise<Response>((resolve, reject) => {
     const req = https.request(
       {
         hostname: options.hostname,
         path: options.path,
+        port: options.port,
         method: options.method || "GET",
         headers: options.headers,
-        lookup: (_hostname, _opts, cb) => cb(null, pinnedIp, 4),
+        lookup: (_hostname, _opts, cb) => cb(null, pinnedIp, family),
         signal: options.signal,
         rejectUnauthorized: true,
       },

--- a/apps/backend/src/lib/pinned-request.ts
+++ b/apps/backend/src/lib/pinned-request.ts
@@ -1,0 +1,77 @@
+/**
+ * Connection-pinned HTTPS request helper for SSRF protection.
+ *
+ * Uses `https.request` with a custom `lookup` function to pin the
+ * TCP connection to a pre-resolved IP address, closing the DNS
+ * rebinding TOCTOU window between hostname validation and the
+ * outbound call. The original hostname is preserved for TLS SNI
+ * and the Host header.
+ */
+
+import https from "node:https";
+
+export interface PinnedRequestOptions {
+  hostname: string;
+  path: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string | Buffer;
+  signal?: AbortSignal;
+}
+
+/**
+ * Make an HTTPS request pinned to a specific IP address.
+ *
+ * The TCP connection goes to `pinnedIp`, while the `hostname` is used
+ * for TLS SNI (server name indication) and the HTTP Host header.
+ * Unlike `fetch()`, the hostname is never re-resolved by the transport.
+ */
+export async function pinnedHttpsRequest(
+  options: PinnedRequestOptions,
+  pinnedIp: string
+): Promise<Response> {
+  return new Promise<Response>((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: options.hostname,
+        path: options.path,
+        method: options.method || "GET",
+        headers: options.headers,
+        lookup: (_hostname, _opts, cb) => cb(null, pinnedIp, 4),
+        signal: options.signal,
+        rejectUnauthorized: true,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          const body = chunks.length > 0 ? Buffer.concat(chunks) : null;
+          const responseHeaders = new Headers();
+          for (const [key, value] of Object.entries(res.headers)) {
+            if (value !== undefined && value !== null) {
+              responseHeaders.set(
+                key,
+                Array.isArray(value) ? value.join(", ") : String(value)
+              );
+            }
+          }
+          resolve(
+            new Response(body, {
+              status: res.statusCode,
+              statusText: res.statusMessage,
+              headers: responseHeaders,
+            })
+          );
+        });
+        res.on("error", reject);
+      }
+    );
+
+    req.on("error", reject);
+
+    if (options.body) {
+      req.write(options.body);
+    }
+    req.end();
+  });
+}

--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -1555,7 +1555,7 @@ export const ALLOWED_SESSION_KEYS = [
  * Allowed primitive value types for session data
  */
 const allowedPrimitiveSchema = z.union([
-  z.string(),
+  z.string().max(4096, "Session value string too long"),
   z.number(),
   z.boolean(),
   z.null(),

--- a/apps/backend/src/services/__tests__/encryption.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/encryption.service.unit.test.ts
@@ -15,7 +15,13 @@ vi.mock("../../lib/ip-validation.js", () => ({
   isPrivateIP: vi.fn(() => false),
   isPrivateOrLocalHostname: vi.fn(() => false),
   isAllowedGitlabHost: vi.fn(() => true),
-  isValidPublicHost: vi.fn(() => Promise.resolve(true)),
+  resolvePublicHost: vi.fn(() => Promise.resolve(["8.8.8.8"])),
+}));
+
+// Mock pinnedHttpsRequest so the test controls the response without
+// real network calls or DNS resolution.
+vi.mock("../../lib/pinned-request.js", () => ({
+  pinnedHttpsRequest: vi.fn(),
 }));
 
 import {
@@ -24,6 +30,7 @@ import {
   isValidPATFormat,
   validateAndGetUsername,
 } from "../encryption.service.js";
+import * as pinnedRequest from "../../lib/pinned-request.js";
 
 describe("EncryptionService", () => {
   const testToken = "glpat-123456789abcdefghijklmn";
@@ -169,38 +176,35 @@ describe("EncryptionService", () => {
     const expectedUsername = "testuser";
 
     beforeEach(() => {
-      // Mock fetch globally
-      global.fetch = vi.fn();
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
+      vi.clearAllMocks();
     });
 
     it("should validate token and return username for valid GitLab PAT", async () => {
       // Mock successful GitLab API response
-      vi.mocked(global.fetch).mockResolvedValueOnce({
+      vi.mocked(pinnedRequest.pinnedHttpsRequest).mockResolvedValueOnce({
         ok: true,
         json: async () => ({ username: expectedUsername }),
       } as Response);
 
       const result = await validateAndGetUsername(validPat, testGitlabUrl);
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        `${testGitlabUrl}/api/v4/user`,
+      expect(pinnedRequest.pinnedHttpsRequest).toHaveBeenCalledWith(
         expect.objectContaining({
+          hostname: "gitlab.com",
+          path: "/api/v4/user",
           method: "GET",
           headers: {
             "PRIVATE-TOKEN": validPat,
           },
-        })
+        }),
+        "8.8.8.8"
       );
       expect(result).toBe(expectedUsername);
     });
 
     it("should return null for invalid PAT (401 unauthorized)", async () => {
       // Mock unauthorized GitLab API response
-      vi.mocked(global.fetch).mockResolvedValueOnce({
+      vi.mocked(pinnedRequest.pinnedHttpsRequest).mockResolvedValueOnce({
         ok: false,
         status: 401,
       } as Response);
@@ -217,21 +221,21 @@ describe("EncryptionService", () => {
       );
 
       expect(result).toBeNull();
-      // Fetch should not be called for invalid format
-      expect(global.fetch).not.toHaveBeenCalled();
+      // Request should not be made for invalid format
+      expect(pinnedRequest.pinnedHttpsRequest).not.toHaveBeenCalled();
     });
 
     it("should return null for empty token", async () => {
       const result = await validateAndGetUsername("", testGitlabUrl);
 
       expect(result).toBeNull();
-      // Fetch should not be called for empty token
-      expect(global.fetch).not.toHaveBeenCalled();
+      // Request should not be made for empty token
+      expect(pinnedRequest.pinnedHttpsRequest).not.toHaveBeenCalled();
     });
 
     it("should return null when API response lacks username", async () => {
       // Mock successful response but without username field
-      vi.mocked(global.fetch).mockResolvedValueOnce({
+      vi.mocked(pinnedRequest.pinnedHttpsRequest).mockResolvedValueOnce({
         ok: true,
         json: async () => ({ id: 123, name: "Test User" }),
       } as Response);
@@ -243,7 +247,9 @@ describe("EncryptionService", () => {
 
     it("should return null on network error", async () => {
       // Mock network error
-      vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"));
+      vi.mocked(pinnedRequest.pinnedHttpsRequest).mockRejectedValueOnce(
+        new Error("Network error")
+      );
 
       const result = await validateAndGetUsername(validPat, testGitlabUrl);
 
@@ -254,7 +260,9 @@ describe("EncryptionService", () => {
       // Mock AbortError for timeout
       const abortError = new Error("Request timeout");
       abortError.name = "AbortError";
-      vi.mocked(global.fetch).mockRejectedValueOnce(abortError);
+      vi.mocked(pinnedRequest.pinnedHttpsRequest).mockRejectedValueOnce(
+        abortError
+      );
 
       const result = await validateAndGetUsername(validPat, testGitlabUrl);
 

--- a/apps/backend/src/services/__tests__/encryption.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/encryption.service.unit.test.ts
@@ -31,6 +31,7 @@ import {
   validateAndGetUsername,
 } from "../encryption.service.js";
 import * as pinnedRequest from "../../lib/pinned-request.js";
+import * as ipValidation from "../../lib/ip-validation.js";
 
 describe("EncryptionService", () => {
   const testToken = "glpat-123456789abcdefghijklmn";
@@ -267,6 +268,15 @@ describe("EncryptionService", () => {
       const result = await validateAndGetUsername(validPat, testGitlabUrl);
 
       expect(result).toBeNull();
+    });
+
+    it("should return null when resolver refuses the host", async () => {
+      vi.mocked(ipValidation.resolvePublicHost).mockResolvedValueOnce(null);
+
+      const result = await validateAndGetUsername(validPat, testGitlabUrl);
+
+      expect(result).toBeNull();
+      expect(pinnedRequest.pinnedHttpsRequest).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/services/__tests__/encryption.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/encryption.service.unit.test.ts
@@ -6,6 +6,18 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Mock DNS-based SSRF guard so tests don't require real DNS resolution.
+// The hostname-level guards (isPrivateOrLocalHostname, isAllowedGitlabHost)
+// are tested separately in validation.unit.test.ts; this mock only ensures
+// the resolved-IP check doesn't block mocked fetch calls.
+vi.mock("../../lib/ip-validation.js", () => ({
+  isPrivateIP: vi.fn(() => false),
+  isPrivateOrLocalHostname: vi.fn(() => false),
+  isAllowedGitlabHost: vi.fn(() => true),
+  isValidPublicHost: vi.fn(() => Promise.resolve(true)),
+}));
+
 import {
   encryptPAT,
   decryptPAT,

--- a/apps/backend/src/services/__tests__/gitlab.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/gitlab.service.unit.test.ts
@@ -39,7 +39,7 @@ vi.mock("../../lib/ip-validation.js", () => ({
   isPrivateIP: vi.fn(() => false),
   isPrivateOrLocalHostname: vi.fn(() => false),
   isAllowedGitlabHost: vi.fn(() => true),
-  isValidPublicHost: vi.fn(() => Promise.resolve(true)),
+  resolvePublicHost: vi.fn(() => Promise.resolve(["8.8.8.8"])),
 }));
 
 // Wire the mocked allowlist to the imported namespace so per-test overrides
@@ -811,13 +811,13 @@ describe("GitLabService (HTTP Operations)", () => {
       );
     });
 
-    it("should refuse to fetch when isValidPublicHost returns false (DNS rebind guard)", async () => {
+    it("should refuse to fetch when resolvePublicHost returns null (DNS rebind guard)", async () => {
       // All hostname-level checks pass, but the resolved-IP check fails.
       // This simulates a DNS rebinding attack where a previously-valid
       // hostname now resolves to a private IP.
       vi.mocked(ipValidation.isAllowedGitlabHost).mockReturnValue(true);
       vi.mocked(ipValidation.isPrivateOrLocalHostname).mockReturnValue(false);
-      vi.mocked(ipValidation.isValidPublicHost).mockResolvedValue(false);
+      vi.mocked(ipValidation.resolvePublicHost).mockResolvedValue(null);
 
       mockLimit.mockResolvedValueOnce([
         {

--- a/apps/backend/src/services/__tests__/gitlab.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/gitlab.service.unit.test.ts
@@ -39,6 +39,7 @@ vi.mock("../../lib/ip-validation.js", () => ({
   isPrivateIP: vi.fn(() => false),
   isPrivateOrLocalHostname: vi.fn(() => false),
   isAllowedGitlabHost: vi.fn(() => true),
+  isValidPublicHost: vi.fn(() => Promise.resolve(true)),
 }));
 
 // Wire the mocked allowlist to the imported namespace so per-test overrides
@@ -807,6 +808,31 @@ describe("GitLabService (HTTP Operations)", () => {
 
       await expect(listGitlabRepositories(testUserId)).rejects.toThrow(
         /non-allowlisted or internal host/
+      );
+    });
+
+    it("should refuse to fetch when isValidPublicHost returns false (DNS rebind guard)", async () => {
+      // All hostname-level checks pass, but the resolved-IP check fails.
+      // This simulates a DNS rebinding attack where a previously-valid
+      // hostname now resolves to a private IP.
+      vi.mocked(ipValidation.isAllowedGitlabHost).mockReturnValue(true);
+      vi.mocked(ipValidation.isPrivateOrLocalHostname).mockReturnValue(false);
+      vi.mocked(ipValidation.isValidPublicHost).mockResolvedValue(false);
+
+      mockLimit.mockResolvedValueOnce([
+        {
+          id: "integration-123",
+          userId: testUserId,
+          encryptedToken: "encrypted_token",
+          gitlabUrl: "https://gitlab.test",
+          username: "testuser",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      await expect(listGitlabRepositories(testUserId)).rejects.toThrow(
+        /non-public IP/
       );
     });
   });

--- a/apps/backend/src/services/encryption.service.ts
+++ b/apps/backend/src/services/encryption.service.ts
@@ -15,8 +15,9 @@ import crypto from "node:crypto";
 import {
   isPrivateOrLocalHostname,
   isAllowedGitlabHost,
-  isValidPublicHost,
+  resolvePublicHost,
 } from "../lib/ip-validation.js";
+import { pinnedHttpsRequest } from "../lib/pinned-request.js";
 import { logWarn, LogEventType } from "../lib/logger.js";
 
 // GitLab PAT format: glpat- followed by alphanumeric characters, hyphens, underscores, and dots
@@ -189,29 +190,29 @@ export async function validateAndGetUsername(
   try {
     const url = new URL("/api/v4/user", validatedUrl);
 
-    // Validate the resolved IP immediately before making the outbound
-    // request, closing a DNS rebinding window between hostname validation
-    // (validateGitLabUrl) and the actual fetch call.
-    if (!(await isValidPublicHost(url.hostname))) {
+    // Resolve DNS to a known-public IP and pin the TCP connection
+    // via https.request's `lookup` option, closing the DNS rebinding
+    // TOCTOU window between hostname validation (validateGitLabUrl)
+    // and the outbound call.
+    const pinnedIps = await resolvePublicHost(url.hostname);
+    if (!pinnedIps) {
       logWarn(LogEventType.SECURITY_SSRF_REFUSAL, {
         hostname: url.hostname,
       });
       return null;
     }
+    const pinnedIp = pinnedIps[0];
 
-    const response = await fetch(url.toString(), {
-      method: "GET",
-      headers: {
-        "PRIVATE-TOKEN": token,
+    const response = await pinnedHttpsRequest(
+      {
+        hostname: url.hostname,
+        path: url.pathname + url.search,
+        method: "GET",
+        headers: { "PRIVATE-TOKEN": token },
+        signal: controller.signal,
       },
-      // Never follow redirects automatically: a 3xx could point to an
-      // internal host or cloud-metadata endpoint and would carry the
-      // PAT header. A redirect on /api/v4/user is treated as a
-      // validation failure (response.ok is false for 3xx) rather than
-      // risking token leakage off the allowlisted host.
-      redirect: "manual",
-      signal: controller.signal,
-    });
+      pinnedIp
+    );
 
     if (!response.ok) {
       return null;

--- a/apps/backend/src/services/encryption.service.ts
+++ b/apps/backend/src/services/encryption.service.ts
@@ -207,6 +207,7 @@ export async function validateAndGetUsername(
       {
         hostname: url.hostname,
         path: url.pathname + url.search,
+        port: url.port ? parseInt(url.port, 10) : undefined,
         method: "GET",
         headers: { "PRIVATE-TOKEN": token },
         signal: controller.signal,

--- a/apps/backend/src/services/encryption.service.ts
+++ b/apps/backend/src/services/encryption.service.ts
@@ -15,7 +15,9 @@ import crypto from "node:crypto";
 import {
   isPrivateOrLocalHostname,
   isAllowedGitlabHost,
+  isValidPublicHost,
 } from "../lib/ip-validation.js";
+import { logWarn, LogEventType } from "../lib/logger.js";
 
 // GitLab PAT format: glpat- followed by alphanumeric characters, hyphens, underscores, and dots
 const GITLAB_PAT_REGEX = /^glpat-[a-zA-Z0-9_.-]+$/;
@@ -186,6 +188,16 @@ export async function validateAndGetUsername(
 
   try {
     const url = new URL("/api/v4/user", validatedUrl);
+
+    // Validate the resolved IP immediately before making the outbound
+    // request, closing a DNS rebinding window between hostname validation
+    // (validateGitLabUrl) and the actual fetch call.
+    if (!(await isValidPublicHost(url.hostname))) {
+      logWarn(LogEventType.SECURITY_SSRF_REFUSAL, {
+        hostname: url.hostname,
+      });
+      return null;
+    }
 
     const response = await fetch(url.toString(), {
       method: "GET",

--- a/apps/backend/src/services/gitlab.service.ts
+++ b/apps/backend/src/services/gitlab.service.ts
@@ -155,6 +155,7 @@ async function fetchWithTimeout(
         {
           hostname: parsedUrl.hostname,
           path: parsedUrl.pathname + parsedUrl.search,
+          port: parsedUrl.port ? parseInt(parsedUrl.port, 10) : undefined,
           method: (options.method as string) || "GET",
           headers: requestHeaders,
           body: options.body as string | undefined,

--- a/apps/backend/src/services/gitlab.service.ts
+++ b/apps/backend/src/services/gitlab.service.ts
@@ -6,6 +6,7 @@
  */
 
 import { getDb } from "../db/index.js";
+import { pinnedHttpsRequest } from "../lib/pinned-request.js";
 import {
   gitlabIntegrations,
   gitlabRepositories,
@@ -29,7 +30,7 @@ import { isPostgresError } from "../lib/db.js";
 import {
   isPrivateOrLocalHostname,
   isAllowedGitlabHost,
-  isValidPublicHost,
+  resolvePublicHost,
 } from "../lib/ip-validation.js";
 import { createProject, deleteProject } from "./projects.service.js";
 import { importFromGitlab } from "./gitlab-sync.service.js";
@@ -127,22 +128,40 @@ async function fetchWithTimeout(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      // Validate the resolved IP immediately before making the outbound
-      // request. This closes a DNS rebinding window where a hostname's
-      // A/AAAA records are changed between hostname-only validation
-      // (approveGitlabUrl) and the actual fetch call.
+      // Resolve DNS to a known-public IP and pin the TCP connection
+      // to that exact IP via https.request's `lookup` option, closing
+      // the DNS rebinding TOCTOU window: the hostname is never
+      // re-resolved by the outbound transport.
       const parsedHost = new URL(currentUrl).hostname;
-      if (!(await isValidPublicHost(parsedHost))) {
+      const pinnedIps = await resolvePublicHost(parsedHost);
+      if (!pinnedIps) {
         logSecurityEvent(LogEventType.SECURITY_SSRF_REFUSAL, {
           hostname: parsedHost,
         });
         throw new Error("Refused GitLab fetch to non-public IP");
       }
-      const response = await fetch(currentUrl, {
-        ...options,
-        redirect: "manual",
-        signal: controller.signal,
-      });
+      const pinnedIp = pinnedIps[0];
+
+      const parsedUrl = new URL(currentUrl);
+      const requestHeaders: Record<string, string> = {};
+      if (options.headers) {
+        const h = options.headers as Record<string, string>;
+        for (const [k, v] of Object.entries(h)) {
+          requestHeaders[k] = v;
+        }
+      }
+
+      const response = await pinnedHttpsRequest(
+        {
+          hostname: parsedUrl.hostname,
+          path: parsedUrl.pathname + parsedUrl.search,
+          method: (options.method as string) || "GET",
+          headers: requestHeaders,
+          body: options.body as string | undefined,
+          signal: controller.signal,
+        },
+        pinnedIp
+      );
 
       // Only follow real redirects (300-399 excluding 304 Not Modified
       // and 305 Use Proxy). If there is no Location header, surface the

--- a/apps/backend/src/services/gitlab.service.ts
+++ b/apps/backend/src/services/gitlab.service.ts
@@ -29,13 +29,19 @@ import { isPostgresError } from "../lib/db.js";
 import {
   isPrivateOrLocalHostname,
   isAllowedGitlabHost,
+  isValidPublicHost,
 } from "../lib/ip-validation.js";
 import { createProject, deleteProject } from "./projects.service.js";
 import { importFromGitlab } from "./gitlab-sync.service.js";
 import { requireProjectOwnership } from "./authz.service.js";
 import { syncLabelsFromGitLabFile } from "./labels.service.js";
 import { calculateContentHash } from "../lib/hash.js";
-import { logError, logWarn, LogEventType } from "../lib/logger.js";
+import {
+  logError,
+  logWarn,
+  logSecurityEvent,
+  LogEventType,
+} from "../lib/logger.js";
 import type {
   ConflictResolution,
   SyncOperation,
@@ -121,6 +127,17 @@ async function fetchWithTimeout(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
     try {
+      // Validate the resolved IP immediately before making the outbound
+      // request. This closes a DNS rebinding window where a hostname's
+      // A/AAAA records are changed between hostname-only validation
+      // (approveGitlabUrl) and the actual fetch call.
+      const parsedHost = new URL(currentUrl).hostname;
+      if (!(await isValidPublicHost(parsedHost))) {
+        logSecurityEvent(LogEventType.SECURITY_SSRF_REFUSAL, {
+          hostname: parsedHost,
+        });
+        throw new Error("Refused GitLab fetch to non-public IP");
+      }
       const response = await fetch(currentUrl, {
         ...options,
         redirect: "manual",


### PR DESCRIPTION
Closes #313

## Summary
Fixes three MEDIUM security findings from the backend audit (#279) in validation.ts and SSRF guards.

### Changes
1. **SSRF — DNS rebinding fix**: Added `isValidPublicHost()` in `ip-validation.ts` that resolves hostnames via `dns.resolve4`/`resolve6` and checks all resolved IPs are public. Called in `fetchWithTimeout` (before every `fetch()` call) and `validateAndGetUsername` (before PAT validation). Also added `uniqueLocal` and `multicast` ranges to `isPrivateIP`.

2. **Session — string length limit**: Added `.max(4096)` to `z.string()` in `allowedPrimitiveSchema` to prevent session store bloat.

3. **`*.gitlab.io` removal**: Removed unconditional allowlisting of `*.gitlab.io` subdomains (user-controlled GitLab Pages) from `isAllowedGitlabHost`. Explicit entries still supported via `ALLOWED_GITLAB_HOSTS`.

### Additional
- Added `SECURITY_SSRF_REFUSAL` log event and logging in both SSRF refusal paths
- New `ip-validation.unit.test.ts` with 19 tests covering IP ranges, DNS resolution, and hostname checks
- Added session string length regression tests
- Added DNS guard regression test in `gitlab.service.unit.test.ts`

### Verification
- CodeQL `request-forgery`: clean (no alerts)
- TypeScript: clean
- ESLint: clean
- Unit tests: 46 files / 888 tests — all passing

### @oracle Review
Reviewed and approved after addressing all findings:
- Must-fix: added `uniqueLocal`/`multicast` to `isPrivateIP` ranges, added unit tests
- Should-fix: switched to `dns.resolve4`/`resolve6` with timeout, added security logging, added DNS guard regression test

### Backward Compatibility Note
Any integration previously relying on `*.gitlab.io` will stop working. Use `ALLOWED_GITLAB_HOSTS` env var to explicitly allow specific Pages hosts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened SSRF defenses by classifying more non-public IP ranges (loopback, private, multicast, unique-local) and rejecting non-public DNS resolution results.
  * Added DNS public-host validation with a resolution timeout and connection pinning for outbound HTTPS requests to reduce DNS rebinding/TOCTOU risk.
  * Tightened GitLab host allowlisting by removing unconditional `*.gitlab.io` acceptance.
  * Added security event logging when requests are blocked.
* **Validation**
  * Limited session string values to 4,096 characters (including nested fields).
* **Tests**
  * Expanded unit coverage for IP/host validation, session validation, and SSRF defenses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->