### PR TITLE
refactor: extract gitlab.types.ts and fix import shadowing (#319)

### DIFF
--- a/apps/backend/src/services/__tests__/gitlab-sync.service.integration.test.ts
+++ b/apps/backend/src/services/__tests__/gitlab-sync.service.integration.test.ts
@@ -36,8 +36,8 @@ import {
   detectConflicts,
   exportToGitlab,
   importFromGitlab,
-  type ConflictResolution,
 } from "../gitlab-sync.service.js";
+import type { ConflictResolution } from "../gitlab.types.js";
 import { testEmail, testUuid } from "../../utils/test-ids.js";
 
 describe("GitLabSyncService (Integration)", () => {

--- a/apps/backend/src/services/gitlab-sync.service.ts
+++ b/apps/backend/src/services/gitlab-sync.service.ts
@@ -5,7 +5,7 @@
  * Handles conflict detection and resolution for bidirectional sync.
  */
 
-import { getDb, type Db } from "../db/index.js";
+import { getDb } from "../db/index.js";
 import { requireProjectOwnership } from "./authz.service.js";
 import {
   gitlabSyncOperations,
@@ -37,6 +37,11 @@ import {
 } from "./rpy-generator.service.js";
 import { calculateLinesHash, calculateContentHash } from "../lib/hash.js";
 import { type DetectedCharacter } from "./character-parser.service.js";
+import type {
+  ConflictResolution,
+  SyncOperation,
+  Transaction,
+} from "./gitlab.types.js";
 import {
   computeCommonDirectoryPrefix,
   extractAndStripRpySymbols,
@@ -53,32 +58,6 @@ import { ConcurrencyLimiter } from "./concurrency-limiter.js";
 // IN_PROGRESS for longer than this without completing, it is considered
 // stale. Same value as SYNC_LEASE_TIMEOUT_MS in labels/sync-state.ts.
 const SYNC_OPERATION_STALE_MS = 5 * 60 * 1000; // 5 minutes
-
-// Type definitions
-export type ConflictResolution =
-  "branchforge_wins" | "gitlab_wins" | "manual_review";
-
-export interface SyncOperation {
-  id: string;
-  projectId: string;
-  operation: "EXPORT" | "IMPORT";
-  status: "PENDING" | "IN_PROGRESS" | "COMPLETED" | "FAILED";
-  branch: string | null;
-  conflictCount: number;
-  errorMessage: string | null;
-  startedAt: Date;
-  completedAt: Date | null;
-  detectedCharacters?: DetectedCharacter[];
-}
-
-// Type for Drizzle transaction - flexible interface to accept both typed and generic transactions
-// This avoids schema type inference issues while maintaining type safety for query methods
-interface Transaction {
-  select: Db["select"];
-  insert: Db["insert"];
-  update: Db["update"];
-  delete: Db["delete"];
-}
 
 /**
  * Helper function to fetch characters and build a Map of renpyTag -> id

--- a/apps/backend/src/services/gitlab.service.ts
+++ b/apps/backend/src/services/gitlab.service.ts
@@ -46,8 +46,13 @@ import {
 } from "../lib/logger.js";
 import type {
   ConflictResolution,
+  GitlabBranch,
+  GitlabFile,
+  GitlabRepository,
+  GitlabRepositoryFull,
+  GitlabTreeItem,
   SyncOperation,
-} from "./gitlab-sync.service.js";
+} from "./gitlab.types.js";
 
 const DEFAULT_TIMEOUT_MS = 30000;
 
@@ -198,52 +203,6 @@ async function fetchWithTimeout(
   throw new Error("Too many GitLab redirects");
 }
 
-// GitLab API response types
-export interface GitlabUser {
-  id: number;
-  username: string;
-  name: string;
-  email: string;
-}
-
-// Full GitLab repository data (from API)
-export interface GitlabRepositoryFull {
-  id: number;
-  name: string;
-  path_with_namespace: string;
-  default_branch: string;
-  http_url_to_repo?: string;
-}
-
-// Lightweight repository data for repository selection UI
-export interface GitlabRepository {
-  id: number;
-  name: string;
-  path_with_namespace: string;
-}
-
-export interface GitlabBranch {
-  name: string;
-  commit: {
-    id: string;
-  };
-}
-
-export interface GitlabFile {
-  file_name: string;
-  file_path: string;
-  size: number;
-  encoding: string;
-  content: string;
-  ref: string;
-}
-
-export interface GitlabTreeItem {
-  name: string;
-  path: string;
-  type: "blob" | "tree";
-}
-
 /**
  * Validate a GitLab Personal Access Token by calling GitLab API
  * @param token - The PAT to validate
@@ -359,7 +318,7 @@ export async function listGitlabRepositories(
     gitlabUrl || integration.gitlabUrl || undefined
   );
 
-  const gitlabRepositories: GitlabRepository[] = [];
+  const repos: GitlabRepository[] = [];
   let page = 1;
   const perPage = 100;
 
@@ -381,7 +340,7 @@ export async function listGitlabRepositories(
 
     const pageProjects = (await response.json()) as GitlabRepositoryFull[];
     // Extract only fields needed for repository selection UI
-    gitlabRepositories.push(
+    repos.push(
       ...pageProjects.map((p) => ({
         id: p.id,
         name: p.name,
@@ -398,7 +357,7 @@ export async function listGitlabRepositories(
     }
   } while (true); // eslint-disable-line no-constant-condition -- Valid pagination pattern with break condition inside loop
 
-  return gitlabRepositories;
+  return repos;
 }
 
 /**

--- a/apps/backend/src/services/gitlab.types.ts
+++ b/apps/backend/src/services/gitlab.types.ts
@@ -1,0 +1,76 @@
+import type { Db } from "../db/index.js";
+import type { DetectedCharacter } from "./character-parser.service.js";
+
+// GitLab API response types
+
+export interface GitlabUser {
+  id: number;
+  username: string;
+  name: string;
+  email: string;
+}
+
+// Full GitLab repository data (from API)
+export interface GitlabRepositoryFull {
+  id: number;
+  name: string;
+  path_with_namespace: string;
+  default_branch: string;
+  http_url_to_repo?: string;
+}
+
+// Lightweight repository data for repository selection UI
+export interface GitlabRepository {
+  id: number;
+  name: string;
+  path_with_namespace: string;
+}
+
+export interface GitlabBranch {
+  name: string;
+  commit: {
+    id: string;
+  };
+}
+
+export interface GitlabFile {
+  file_name: string;
+  file_path: string;
+  size: number;
+  encoding: string;
+  content: string;
+  ref: string;
+}
+
+export interface GitlabTreeItem {
+  name: string;
+  path: string;
+  type: "blob" | "tree";
+}
+
+// Sync operation types
+
+export type ConflictResolution =
+  "branchforge_wins" | "gitlab_wins" | "manual_review";
+
+export interface SyncOperation {
+  id: string;
+  projectId: string;
+  operation: "EXPORT" | "IMPORT";
+  status: "PENDING" | "IN_PROGRESS" | "COMPLETED" | "FAILED";
+  branch: string | null;
+  conflictCount: number;
+  errorMessage: string | null;
+  startedAt: Date;
+  completedAt: Date | null;
+  detectedCharacters?: DetectedCharacter[];
+}
+
+// Type for Drizzle transaction - flexible interface to accept both typed and generic transactions
+// This avoids schema type inference issues while maintaining type safety for query methods
+export interface Transaction {
+  select: Db["select"];
+  insert: Db["insert"];
+  update: Db["update"];
+  delete: Db["delete"];
+}


### PR DESCRIPTION
Closes #319

## What changed

Extracted all shared TypeScript types from `gitlab.service.ts` and `gitlab-sync.service.ts` into a dedicated `gitlab.types.ts` module:

- **`GitlabUser`, `GitlabRepositoryFull`, `GitlabRepository`, `GitlabBranch`, `GitlabFile`, `GitlabTreeItem`** — moved from `gitlab.service.ts`
- **`ConflictResolution`, `SyncOperation`, `Transaction`** — moved from `gitlab-sync.service.ts`
- Fixed variable shadowing (F22): local `gitlabRepositories` → `repos` in `listGitlabRepositories`
- Updated imports in both service files and the integration test that imported `ConflictResolution`

## Verification

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test:unit` (892 tests) ✅
- `pnpm test:integration` (428 tests) ✅
- Pre-push typecheck hook ✅

## @oracle review

Not required — pure refactor, no auth/schema/API/security changes, diff <200 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized GitLab API and synchronization type definitions for improved consistency across services.
  * Preserved existing GitLab repository listing and synchronization behavior.
  * Simplified internal type usage without changing end-user functionality.

* **Tests**
  * Updated integration test type references to match the centralized definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->