### PR TITLE
refactor: apply P2+P3 polish to gitlab trio (F11-F24)

### DIFF
--- a/apps/backend/src/services/__tests__/gitlab-sync.service.integration.test.ts
+++ b/apps/backend/src/services/__tests__/gitlab-sync.service.integration.test.ts
@@ -916,6 +916,97 @@ describe("GitLabSyncService (Integration)", () => {
         new Date("2024-01-01").getTime()
       );
     });
+
+    it("should skip labels with null contentHash (regression: F11)", async () => {
+      // Insert a label with non-null contentHash (control)
+      const initialContentHash = "control-content-hash";
+      await db.insert(labelsTable).values({
+        ...testScene,
+        contentHash: initialContentHash,
+        lastSyncedHash: "old-baseline",
+        syncStatus: "MODIFIED_LOCAL",
+      });
+
+      // Insert a second label with null contentHash
+      const nullHashLabelId = testUuid("26000000", 2);
+      await db.insert(labelsTable).values({
+        id: nullHashLabelId,
+        projectId: testProjectId,
+        title: "null_hash_label",
+        labelName: "null_hash_label",
+        labelPosition: 1,
+        labelNumber: 2,
+        sequenceOrder: 1,
+        status: "DRAFT" as const,
+        conditions: {},
+        effects: {},
+        projectFileId: testGitlabFileId,
+        contentHash: null,
+        lastSyncedHash: null,
+        syncStatus: "MODIFIED_LOCAL",
+        route: "COMMON" as const,
+      });
+
+      // Insert a label line for the null-hash label
+      await db.insert(labelLines).values({
+        id: testUuid("46000000", 9),
+        labelId: nullHashLabelId,
+        sequence: 1,
+        contentType: "NARRATION" as const,
+        content: "Null hash line content",
+        contentHash: "null-hash-line-ch",
+        lastSyncedHash: null,
+        isDirty: true,
+        visualType: "GENERATED" as const,
+      });
+
+      // Mock the GitLab service
+      vi.spyOn(gitlabFileService, "batchCommitFiles").mockResolvedValue(
+        undefined
+      );
+
+      const result = await exportToGitlab(
+        testProjectId,
+        testUserId,
+        testBranch,
+        "Test export"
+      );
+
+      expect(result.status).toBe("COMPLETED");
+
+      // Verify: null-hash label was NOT synced
+      const [nullHashLabel] = await db
+        .select()
+        .from(labelsTable)
+        .where(eq(labelsTable.id, nullHashLabelId));
+      expect(nullHashLabel).toBeDefined();
+      expect(nullHashLabel?.lastSyncedHash).toBeNull();
+      expect(nullHashLabel?.syncStatus).toBe("MODIFIED_LOCAL");
+
+      // Verify: null-hash label's line baseline was NOT cleared
+      const [nullHashLine] = await db
+        .select()
+        .from(labelLines)
+        .where(eq(labelLines.labelId, nullHashLabelId));
+      expect(nullHashLine).toBeDefined();
+      expect(nullHashLine?.lastSyncedHash).toBeNull();
+      expect(nullHashLine?.isDirty).toBe(true);
+
+      // Verify: control label with non-null contentHash WAS synced
+      const [controlLabel] = await db
+        .select()
+        .from(labelsTable)
+        .where(eq(labelsTable.id, testScene.id));
+      expect(controlLabel).toBeDefined();
+      expect(controlLabel?.lastSyncedHash).toBe(initialContentHash);
+      expect(controlLabel?.syncStatus).toBe("SYNCED");
+
+      // Cleanup the additional data
+      await db
+        .delete(labelLines)
+        .where(eq(labelLines.labelId, nullHashLabelId));
+      await db.delete(labelsTable).where(eq(labelsTable.id, nullHashLabelId));
+    });
   });
 
   describe("importFromGitlab", () => {

--- a/apps/backend/src/services/__tests__/gitlab-sync.service.integration.test.ts
+++ b/apps/backend/src/services/__tests__/gitlab-sync.service.integration.test.ts
@@ -972,40 +972,42 @@ describe("GitLabSyncService (Integration)", () => {
         "Test export"
       );
 
-      expect(result.status).toBe("COMPLETED");
+      try {
+        expect(result.status).toBe("COMPLETED");
 
-      // Verify: null-hash label was NOT synced
-      const [nullHashLabel] = await db
-        .select()
-        .from(labelsTable)
-        .where(eq(labelsTable.id, nullHashLabelId));
-      expect(nullHashLabel).toBeDefined();
-      expect(nullHashLabel?.lastSyncedHash).toBeNull();
-      expect(nullHashLabel?.syncStatus).toBe("MODIFIED_LOCAL");
+        // Verify: null-hash label was NOT synced
+        const [nullHashLabel] = await db
+          .select()
+          .from(labelsTable)
+          .where(eq(labelsTable.id, nullHashLabelId));
+        expect(nullHashLabel).toBeDefined();
+        expect(nullHashLabel?.lastSyncedHash).toBeNull();
+        expect(nullHashLabel?.syncStatus).toBe("MODIFIED_LOCAL");
 
-      // Verify: null-hash label's line baseline was NOT cleared
-      const [nullHashLine] = await db
-        .select()
-        .from(labelLines)
-        .where(eq(labelLines.labelId, nullHashLabelId));
-      expect(nullHashLine).toBeDefined();
-      expect(nullHashLine?.lastSyncedHash).toBeNull();
-      expect(nullHashLine?.isDirty).toBe(true);
+        // Verify: null-hash label's line baseline was NOT cleared
+        const [nullHashLine] = await db
+          .select()
+          .from(labelLines)
+          .where(eq(labelLines.labelId, nullHashLabelId));
+        expect(nullHashLine).toBeDefined();
+        expect(nullHashLine?.lastSyncedHash).toBeNull();
+        expect(nullHashLine?.isDirty).toBe(true);
 
-      // Verify: control label with non-null contentHash WAS synced
-      const [controlLabel] = await db
-        .select()
-        .from(labelsTable)
-        .where(eq(labelsTable.id, testScene.id));
-      expect(controlLabel).toBeDefined();
-      expect(controlLabel?.lastSyncedHash).toBe(initialContentHash);
-      expect(controlLabel?.syncStatus).toBe("SYNCED");
-
-      // Cleanup the additional data
-      await db
-        .delete(labelLines)
-        .where(eq(labelLines.labelId, nullHashLabelId));
-      await db.delete(labelsTable).where(eq(labelsTable.id, nullHashLabelId));
+        // Verify: control label with non-null contentHash WAS synced
+        const [controlLabel] = await db
+          .select()
+          .from(labelsTable)
+          .where(eq(labelsTable.id, testScene.id));
+        expect(controlLabel).toBeDefined();
+        expect(controlLabel?.lastSyncedHash).toBe(initialContentHash);
+        expect(controlLabel?.syncStatus).toBe("SYNCED");
+      } finally {
+        // Cleanup the additional data — always runs, even on assertion failures
+        await db
+          .delete(labelLines)
+          .where(eq(labelLines.labelId, nullHashLabelId));
+        await db.delete(labelsTable).where(eq(labelsTable.id, nullHashLabelId));
+      }
     });
   });
 

--- a/apps/backend/src/services/__tests__/gitlab-sync.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/gitlab-sync.service.unit.test.ts
@@ -7,10 +7,10 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
-  computeCommonDirectoryPrefix,
   getSyncOperation,
   listSyncOperations,
 } from "../gitlab-sync.service.js";
+import { computeCommonDirectoryPrefix } from "../rpy-statements.service.js";
 
 // Mock the database at module level
 vi.mock("../../db/index.js", () => ({

--- a/apps/backend/src/services/gitlab-sync.service.ts
+++ b/apps/backend/src/services/gitlab-sync.service.ts
@@ -7,7 +7,6 @@ export {
   listSyncOperations,
   cleanupStaleSyncOperations,
   detectConflicts,
-  computeCommonDirectoryPrefix,
 } from "./gitlab/index.js";
 
 export type { ConflictInfo, ConflictDetectionResult } from "./gitlab/index.js";

--- a/apps/backend/src/services/gitlab.types.ts
+++ b/apps/backend/src/services/gitlab.types.ts
@@ -1,4 +1,3 @@
-import type { Db } from "../db/index.js";
 import type { DetectedCharacter } from "./character-parser.service.js";
 
 // GitLab API response types
@@ -66,11 +65,4 @@ export interface SyncOperation {
   detectedCharacters?: DetectedCharacter[];
 }
 
-// Type for Drizzle transaction - flexible interface to accept both typed and generic transactions
-// This avoids schema type inference issues while maintaining type safety for query methods
-export interface Transaction {
-  select: Db["select"];
-  insert: Db["insert"];
-  update: Db["update"];
-  delete: Db["delete"];
-}
+export type { Transaction } from "../db/types.js";

--- a/apps/backend/src/services/gitlab/gitlab-export.service.ts
+++ b/apps/backend/src/services/gitlab/gitlab-export.service.ts
@@ -212,8 +212,12 @@ export async function exportToGitlab(
         )
       );
 
-    if (exportedLabels.length > 0) {
-      const exportedLabelIds = exportedLabels.map((l) => l.id);
+    const labelsWithContentHash = exportedLabels.filter(
+      (l) => l.contentHash !== null
+    );
+
+    if (labelsWithContentHash.length > 0) {
+      const exportedLabelIds = labelsWithContentHash.map((l) => l.id);
 
       // Update labels: advance lastSyncedHash to current contentHash, establishing new baseline
       await db

--- a/apps/backend/src/services/gitlab/gitlab-file.service.ts
+++ b/apps/backend/src/services/gitlab/gitlab-file.service.ts
@@ -22,7 +22,7 @@ import { getDecryptedToken } from "./gitlab-integration.service.js";
 import {
   getRepositoryLink,
   getBranchCommitSha,
-  listRpyFiles,
+  _listFilesWithAuth,
 } from "./gitlab-repository.service.js";
 import { fetchWithTimeout } from "./gitlab-api.client.js";
 
@@ -210,12 +210,11 @@ export async function batchCommitFiles(
   }
 
   if (branchExists) {
-    const existingFiles = await listRpyFiles(
-      projectId,
+    const existingFiles = await _listFilesWithAuth(
+      token,
+      url,
+      String(repoLink.gitlabProjectId),
       branch,
-      userId,
-      gitlabUrl,
-      { token, url, gitlabProjectId: String(repoLink.gitlabProjectId) },
       (_item: { name: string; path: string }) => true
     );
     existingFilePaths = new Set(existingFiles.map((f) => f.path));

--- a/apps/backend/src/services/gitlab/gitlab-import.service.ts
+++ b/apps/backend/src/services/gitlab/gitlab-import.service.ts
@@ -5,7 +5,7 @@
  * Handles file fetching, parsing, label creation, and project creation.
  */
 
-import { getDb } from "../../db/index.js";
+import { getDb, type Db } from "../../db/index.js";
 import { requireProjectOwnership } from "../authz.service.js";
 import {
   projectFiles,
@@ -32,6 +32,7 @@ import type {
 } from "../gitlab.types.js";
 import {
   extractAndStripRpySymbols,
+  DEFAULT_EXCLUDED_RENPY_TAGS,
   type DetectedCharacterStatement,
   type DetectedDefaultStatement,
 } from "../rpy-statements.service.js";
@@ -63,7 +64,7 @@ import { NotFoundError } from "../../middleware/error-handler.middleware.js";
  * Accepts a transaction context to ensure transactional consistency
  */
 async function fetchCharactersByTag(
-  tx: Transaction,
+  tx: Db | Transaction,
   projectId: string
 ): Promise<Map<string, string>> {
   const projectCharacters = await tx
@@ -208,8 +209,17 @@ export async function importFromGitlab(
   const operation = await createSyncOperation(projectId, "IMPORT", branch);
 
   try {
-    // Get the commit SHA for this branch at import time
-    const importCommitSha = await getBranchCommitSha(projectId, userId, branch);
+    // Get the commit SHA for this branch at import time (non-fatal — metadata only)
+    let importCommitSha: string | null = null;
+    try {
+      importCommitSha = await getBranchCommitSha(projectId, userId, branch);
+    } catch (shaError) {
+      logWarn("gitlab_sync.branch_sha_fetch_failed", {
+        projectId,
+        branch,
+        error: shaError instanceof Error ? shaError.message : String(shaError),
+      });
+    }
 
     // List RPY files in the repository, excluding BranchForge-generated files
     // (branchforge_variables.rpy, branchforge_stats.rpy,
@@ -249,7 +259,7 @@ export async function importFromGitlab(
       .limit(1);
 
     const excludedTags = new Set(
-      settings?.excludedCharacterTags || ["n", "u", "narrator", "extend"]
+      settings?.excludedCharacterTags || DEFAULT_EXCLUDED_RENPY_TAGS
     );
 
     // Fetch file contents in parallel with concurrency limit

--- a/apps/backend/src/services/gitlab/gitlab-import.service.ts
+++ b/apps/backend/src/services/gitlab/gitlab-import.service.ts
@@ -5,7 +5,8 @@
  * Handles file fetching, parsing, label creation, and project creation.
  */
 
-import { getDb, type Db } from "../../db/index.js";
+import { getDb } from "../../db/index.js";
+import type { Db } from "../../db/index.js";
 import { requireProjectOwnership } from "../authz.service.js";
 import {
   projectFiles,

--- a/apps/backend/src/services/gitlab/gitlab-repository.service.ts
+++ b/apps/backend/src/services/gitlab/gitlab-repository.service.ts
@@ -372,56 +372,27 @@ export async function getBranchCommitSha(
 }
 
 /**
- * List files in a GitLab repository (recursive), filtered by the
- * provided `fileFilter` callback.
+ * Internal helper: list files in a GitLab repository (recursive) using
+ * pre-resolved auth credentials. Used internally by `listRpyFiles` and
+ * by `batchCommitFiles` to avoid repeating API calls.
  *
- * When `preResolved` is provided the function skips the ownership check
- * and repository-link lookup, using the pre-resolved token/URL/project-id
- * directly.  This is used internally by `batchCommitFiles` so it can
- * determine create vs. update actions without repeating API calls.
- *
- * @param projectId - The BranchForge project ID
+ * @param token - GitLab personal access token
+ * @param url - GitLab instance URL
+ * @param gitlabProjectId - GitLab project ID
  * @param branch - The branch to search
- * @param userId - The user ID making the request (for authorization)
- * @param gitlabUrl - Optional GitLab URL override
- * @param preResolved - Pre-resolved auth/URL values for internal callers
  * @param fileFilter - Optional filter predicate (default: name ends with ".rpy")
  * @returns Array of file info
- * @throws NotFoundError if project not found or repository not linked
- * @throws ForbiddenError if user lacks permission
  */
-export async function listRpyFiles(
-  projectId: string,
+export async function _listFilesWithAuth(
+  token: string,
+  url: string,
+  gitlabProjectId: string,
   branch: string,
-  userId: string,
-  gitlabUrl?: string,
-  preResolved?: { token: string; url: string; gitlabProjectId: string },
   fileFilter?: (item: { name: string; path: string }) => boolean
 ): Promise<Array<{ name: string; path: string }>> {
   const effectiveFilter =
     fileFilter ||
     ((item: { name: string; path: string }) => item.name.endsWith(".rpy"));
-
-  let token: string;
-  let url: string;
-  let gitlabProjectId: string;
-
-  if (preResolved) {
-    token = preResolved.token;
-    url = preResolved.url;
-    gitlabProjectId = preResolved.gitlabProjectId;
-  } else {
-    await requireProjectOwnership(projectId, userId);
-
-    const repoLink = await getRepositoryLink(projectId);
-    if (!repoLink) {
-      throw new RepositoryNotLinkedError();
-    }
-
-    token = await getDecryptedToken(userId);
-    url = validateGitLabUrl(gitlabUrl || repoLink.gitlabUrl || undefined);
-    gitlabProjectId = String(repoLink.gitlabProjectId);
-  }
 
   const files: Array<{ name: string; path: string }> = [];
   let page = 1;
@@ -465,6 +436,40 @@ export async function listRpyFiles(
   } while (true); // eslint-disable-line no-constant-condition -- Valid pagination pattern with break condition inside loop
 
   return files;
+}
+
+/**
+ * List files in a GitLab repository (recursive), filtered by the
+ * provided `fileFilter` callback.
+ *
+ * @param projectId - The BranchForge project ID
+ * @param branch - The branch to search
+ * @param userId - The user ID making the request (for authorization)
+ * @param gitlabUrl - Optional GitLab URL override
+ * @param fileFilter - Optional filter predicate (default: name ends with ".rpy")
+ * @returns Array of file info
+ * @throws NotFoundError if project not found or repository not linked
+ * @throws ForbiddenError if user lacks permission
+ */
+export async function listRpyFiles(
+  projectId: string,
+  branch: string,
+  userId: string,
+  gitlabUrl?: string,
+  fileFilter?: (item: { name: string; path: string }) => boolean
+): Promise<Array<{ name: string; path: string }>> {
+  await requireProjectOwnership(projectId, userId);
+
+  const repoLink = await getRepositoryLink(projectId);
+  if (!repoLink) {
+    throw new RepositoryNotLinkedError();
+  }
+
+  const token = await getDecryptedToken(userId);
+  const url = validateGitLabUrl(gitlabUrl || repoLink.gitlabUrl || undefined);
+  const gitlabProjectId = String(repoLink.gitlabProjectId);
+
+  return _listFilesWithAuth(token, url, gitlabProjectId, branch, fileFilter);
 }
 
 /**

--- a/apps/backend/src/services/gitlab/gitlab-sync-ops.service.ts
+++ b/apps/backend/src/services/gitlab/gitlab-sync-ops.service.ts
@@ -152,8 +152,3 @@ export type {
   ConflictInfo,
   ConflictDetectionResult,
 } from "../conflict-detection.service.js";
-
-// Re-export the shared directory-prefix helper so existing tests and
-// downstream importers keep working. The implementation lives in
-// `rpy-statements.service.ts` so the zip exporter can share it.
-export { computeCommonDirectoryPrefix } from "../rpy-statements.service.js";

--- a/apps/backend/src/services/rpy-statements.service.ts
+++ b/apps/backend/src/services/rpy-statements.service.ts
@@ -16,6 +16,9 @@
 
 import { countCharOutsideStrings } from "./rpy-helpers.js";
 
+/** Default Ren'Py special tags excluded from character import. */
+export const DEFAULT_EXCLUDED_RENPY_TAGS = ["n", "u", "narrator", "extend"];
+
 /**
  * A character definition detected in RPY content.
  *


### PR DESCRIPTION
Closes #322

## Summary
P2 and P3 behavioral fixes from the #279 GitLab audit, applied to the new module structure from #320/#321.

## Changes

### P2 fixes
- **F11** — Filter null `contentHash` labels before bulk-updating `lastSyncedHash` in export
- **F12** — Wrap `getBranchCommitSha` in try/catch; import continues on branch SHA fetch failure
- **F13** — Extract hard-coded excluded character tags into shared `DEFAULT_EXCLUDED_RENPY_TAGS` constant
- **F15** — Replace hand-rolled `Transaction` interface with Drizzle's schema-aware `Transaction` type

### P3 fixes
- **F20** — Remove `computeCommonDirectoryPrefix` re-export indirection through gitlab-sync-ops
- **F23** — Extract `_listFilesWithAuth` helper; remove `preResolved` parameter coupling from `listRpyFiles`

### Already addressed (verified)
- **F10** — Variables/stats/characters queries already use `Promise.all`
- **F14** — `importFromGitlab` sub-phases already split (#320)
- **F16/F17** — Route cleanup already done (#321)
- **F21** — Comments already clear after refactor
- **F24** — `encryptPAT` already called once before upsert

## Verification
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test:unit` — 46 files, 892 tests passed
- `pnpm test:integration` — 24 files, 428 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitLab imports no longer fail when branch commit metadata can’t be retrieved.
  * Export synchronization now skips labels/lines with null content hashes to prevent incorrect baseline updates.
  * GitLab repository file scanning more accurately distinguishes updates vs new files across branches.
  * Ren’Py character imports continue to exclude default special tags.
* **Refactor**
  * Improved consistency across GitLab synchronization services and shared database type handling.
  * Conflict detection remains available through the synchronization surface.
* **Tests**
  * Added regression coverage for skipping null-hash label synchronization during export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->