### PR TITLE
refactor: extract label dialogue logic into service module (#332)

### DIFF
--- a/apps/backend/src/routes/labels.routes.ts
+++ b/apps/backend/src/routes/labels.routes.ts
@@ -14,13 +14,13 @@ import {
   updateLabel,
   deleteLabel,
   getLabelCharacters,
-  reconstructFileForLabel,
+  updateLabelDialogue,
+  cleanupLabelWordCounts,
   type PublicLabel,
   type LabelDetail,
   type ListLabelsFilters,
   type LabelCharacterWithInfo,
 } from "../services/labels.service.js";
-import { requireProjectOwnership } from "../services/authz.service.js";
 import { authenticate } from "../middleware/auth.middleware.js";
 import {
   validateQuery,
@@ -43,19 +43,7 @@ import {
   type CreateLabelInput,
   type UpdateLabelInput,
 } from "../lib/validation.js";
-import { getDb } from "../db/index.js";
-import {
-  labels,
-  labelLines,
-  projectFiles,
-  userSettings,
-  characters,
-} from "../db/schema/index.js";
-import { eq, asc, inArray, isNull, and, sql } from "drizzle-orm";
-import { calculateLinesHash, calculateContentHash } from "../lib/hash.js";
-import { updateAuditFields } from "../lib/audit.js";
 import { trackWordsForLabel } from "../services/word-count.service.js";
-import { planDialogueLineUpdates } from "../services/rpy/plan-dialogue-updates.js";
 
 // ============================================================================
 // Types
@@ -75,21 +63,6 @@ interface GetLabelResponse {
 
 interface ErrorResponse {
   error: string;
-}
-
-// UpdateLabelDialogueBody is now imported from validation.ts as UpdateLabelDialogueInput
-
-interface UpdateLabelDialogueResponse {
-  success: boolean;
-  version: number;
-  contentHash: string;
-  fileContentHash: string;
-  fileUpdatedAt: string;
-  conflict?: {
-    reason: "STALE_LABEL_VERSION" | "STALE_CONTENT_HASH";
-    currentVersion: number;
-    currentContentHash: string | null;
-  };
 }
 
 interface LabelCharactersResponse {
@@ -182,342 +155,21 @@ async function updateLabelDialogueHandler(
   const user = request.user!;
 
   try {
-    const db = getDb();
-
-    // Get label with file info and current version
-    const [label] = await db
-      .select({
-        id: labels.id,
-        projectId: labels.projectId,
-        projectFileId: labels.projectFileId,
-        version: labels.version,
-        contentHash: labels.contentHash,
-        labelPosition: labels.labelPosition,
-      })
-      .from(labels)
-      .where(and(eq(labels.id, labelId), isNull(labels.deletedAt)))
-      .limit(1);
-
-    if (!label || !label.projectFileId) {
-      reply
-        .status(404)
-        .send({ error: "Label or file not found" } as ErrorResponse);
-      return;
-    }
-
-    // Get the project file
-    const [projectFile] = await db
-      .select()
-      .from(projectFiles)
-      .where(eq(projectFiles.id, label.projectFileId))
-      .limit(1);
-
-    if (!projectFile) {
-      reply.status(404).send({ error: "File not found" } as ErrorResponse);
-      return;
-    }
-
-    // Verify user owns the project
-    await requireProjectOwnership(label.projectId, user.id);
-
-    // Validate that all speakerIds exist in the characters table for this project
-    const speakerIdsInDialogue = dialogue
-      .map((entry) => entry.speakerId)
-      .filter((id): id is string => id !== null);
-
-    if (speakerIdsInDialogue.length > 0) {
-      const uniqueSpeakerIds = Array.from(new Set(speakerIdsInDialogue));
-
-      const existingCharacters = await db
-        .select({ id: characters.id })
-        .from(characters)
-        .where(
-          and(
-            eq(characters.projectId, label.projectId),
-            inArray(characters.id, uniqueSpeakerIds)
-          )
-        );
-
-      const existingCharacterIds = new Set(existingCharacters.map((c) => c.id));
-      const invalidSpeakerIds = uniqueSpeakerIds.filter(
-        (id) => !existingCharacterIds.has(id)
-      );
-
-      if (invalidSpeakerIds.length > 0) {
-        reply.status(400).send({
-          error: `Invalid speakerId(s): ${invalidSpeakerIds.join(
-            ", "
-          )}. Character(s) not found in this project.`,
-        } as ErrorResponse);
-        return;
-      }
-    }
-
-    const updateResult = await db.transaction(async (tx) => {
-      // Serialize concurrent updates for the same label to avoid duplicate rows
-      // from overlapping delete + insert operations.
-      await tx.execute(
-        sql`SELECT id FROM labels WHERE id = ${labelId} FOR UPDATE`
-      );
-
-      const [lockedLabel] = await tx
-        .select({
-          version: labels.version,
-          contentHash: labels.contentHash,
-          projectFileId: labels.projectFileId,
-          labelPosition: labels.labelPosition,
-        })
-        .from(labels)
-        .where(and(eq(labels.id, labelId), isNull(labels.deletedAt)))
-        .limit(1);
-
-      if (!lockedLabel || !lockedLabel.projectFileId) {
-        throw new NotFoundError("Label or file not found");
-      }
-
-      await tx.execute(
-        sql`SELECT id FROM project_files WHERE id = ${lockedLabel.projectFileId} FOR UPDATE`
-      );
-
-      const [lockedProjectFile] = await tx
-        .select()
-        .from(projectFiles)
-        .where(eq(projectFiles.id, lockedLabel.projectFileId))
-        .limit(1);
-
-      if (!lockedProjectFile) {
-        throw new NotFoundError("File");
-      }
-
-      const lockedCurrentVersion = lockedLabel.version ?? 1;
-      if (
-        expectedVersion !== undefined &&
-        expectedVersion !== lockedCurrentVersion
-      ) {
-        return {
-          conflictPayload: {
-            success: false,
-            version: lockedCurrentVersion,
-            contentHash: lockedLabel.contentHash ?? "",
-            fileContentHash: lockedProjectFile.contentHash,
-            fileUpdatedAt: lockedProjectFile.updatedAt.toISOString(),
-            conflict: {
-              reason: "STALE_LABEL_VERSION",
-              currentVersion: lockedCurrentVersion,
-              currentContentHash: lockedLabel.contentHash,
-            },
-          } satisfies UpdateLabelDialogueResponse,
-          nextVersion: lockedCurrentVersion,
-          nextContentHash: lockedLabel.contentHash ?? "",
-          nextFileContentHash: lockedProjectFile.contentHash,
-          fileUpdatedAt: lockedProjectFile.updatedAt,
-        };
-      }
-
-      if (
-        expectedContentHash !== undefined &&
-        (lockedLabel.contentHash ?? null) !== expectedContentHash
-      ) {
-        return {
-          conflictPayload: {
-            success: false,
-            version: lockedCurrentVersion,
-            contentHash: lockedLabel.contentHash ?? "",
-            fileContentHash: lockedProjectFile.contentHash,
-            fileUpdatedAt: lockedProjectFile.updatedAt.toISOString(),
-            conflict: {
-              reason: "STALE_CONTENT_HASH",
-              currentVersion: lockedCurrentVersion,
-              currentContentHash: lockedLabel.contentHash,
-            },
-          } satisfies UpdateLabelDialogueResponse,
-          nextVersion: lockedCurrentVersion,
-          nextContentHash: lockedLabel.contentHash ?? "",
-          nextFileContentHash: lockedProjectFile.contentHash,
-          fileUpdatedAt: lockedProjectFile.updatedAt,
-        };
-      }
-
-      // 1. Fetch existing lines with FOR UPDATE to preserve IDs and handle updates/inserts/deletes
-      const existingLines = await tx
-        .select()
-        .from(labelLines)
-        .where(
-          and(eq(labelLines.labelId, labelId), isNull(labelLines.deletedAt))
-        )
-        .orderBy(asc(labelLines.sequence));
-
-      // Align prose against the incoming list so mid-list inserts/deletes keep
-      // VISUAL/MENU rows interleaved correctly (not appended at max sequence).
-      const plan = planDialogueLineUpdates(
-        existingLines.map((line) => ({
-          id: line.id,
-          sequence: line.sequence,
-          contentType: line.contentType,
-          content: line.content,
-          speakerId: line.speakerId,
-        })),
-        dialogue
-      );
-
-      // 2. Delete removed prose rows (structural MENU/JUMP/VISUAL are never deleted)
-      if (plan.deleteIds.length > 0) {
-        await tx
-          .delete(labelLines)
-          .where(inArray(labelLines.id, plan.deleteIds));
-      }
-
-      // 3. Update matched prose rows in place (independent writes)
-      await Promise.all(
-        plan.updates.map((update) =>
-          tx
-            .update(labelLines)
-            .set({
-              contentType: (update.speakerId ? "DIALOGUE" : "NARRATION") as
-                "DIALOGUE" | "NARRATION",
-              content: update.text,
-              speakerId: update.speakerId,
-              demoNotes: null,
-              isDirty: true,
-              projectFileId: lockedProjectFile.id,
-              contentHash: calculateContentHash(update.text),
-              lastSyncedHash: null,
-              sequence: plan.sequenceByKey.get(update.id)!,
-            })
-            .where(eq(labelLines.id, update.id))
-        )
-      );
-
-      // 4. Insert new prose rows at planned sequences (bulk)
-      if (plan.inserts.length > 0) {
-        await tx.insert(labelLines).values(
-          plan.inserts.map((insert) => ({
-            labelId,
-            sequence: insert.sequence,
-            contentType: (insert.speakerId ? "DIALOGUE" : "NARRATION") as
-              "DIALOGUE" | "NARRATION",
-            content: insert.text,
-            speakerId: insert.speakerId,
-            demoNotes: null,
-            isDirty: true,
-            projectFileId: lockedProjectFile.id,
-            contentHash: calculateContentHash(insert.text),
-            lastSyncedHash: null,
-          }))
-        );
-      }
-
-      // 5. Reindex non-prose rows that shifted due to inserts/deletes
-      const structuralReindexes = existingLines.filter((line) => {
-        if (
-          line.contentType === "DIALOGUE" ||
-          line.contentType === "NARRATION"
-        ) {
-          return false;
-        }
-        const newSequence = plan.sequenceByKey.get(line.id);
-        return newSequence !== undefined && newSequence !== line.sequence;
-      });
-      await Promise.all(
-        structuralReindexes.map((line) =>
-          tx
-            .update(labelLines)
-            .set({
-              sequence: plan.sequenceByKey.get(line.id)!,
-              projectFileId: lockedProjectFile.id,
-              isDirty: true,
-              lastSyncedHash: null,
-            })
-            .where(eq(labelLines.id, line.id))
-        )
-      );
-
-      // 6. Process menu blocks - update MENU lines' menuOptions
-      if (menuBlocks && menuBlocks.length > 0) {
-        for (const block of menuBlocks) {
-          const menuContentHash = calculateContentHash(
-            JSON.stringify(block.menuOptions)
-          );
-          const result = await tx
-            .update(labelLines)
-            .set({
-              menuOptions: block.menuOptions,
-              contentHash: menuContentHash,
-              isDirty: true,
-              lastSyncedHash: null,
-            })
-            .where(
-              and(
-                eq(labelLines.id, block.lineId),
-                eq(labelLines.labelId, labelId),
-                eq(labelLines.contentType, "MENU"),
-                isNull(labelLines.deletedAt)
-              )
-            );
-          if (result.rowCount === 0) {
-            throw new NotFoundError(
-              `Menu line ${block.lineId} not found in label ${labelId}`
-            );
-          }
-        }
-      }
-
-      // 7. Compute content hash from the actual persisted label_lines
-      // (includes MENU/JUMP rows preserved during prose edits) so the hash
-      // stays consistent with sync/import flows that use calculateLinesHash.
-      const finalLines = await tx
-        .select()
-        .from(labelLines)
-        .where(
-          and(eq(labelLines.labelId, labelId), isNull(labelLines.deletedAt))
-        )
-        .orderBy(asc(labelLines.sequence));
-      const contentHash = calculateLinesHash(finalLines);
-
-      // 8. Update label with audit fields and sync status
-      const auditFields = updateAuditFields(lockedCurrentVersion, user.id);
-      await tx
-        .update(labels)
-        .set({
-          ...auditFields,
-          contentHash,
-          syncStatus: "MODIFIED_LOCAL",
-          updatedAt: new Date(),
-        })
-        .where(eq(labels.id, labelId));
-
-      const newContent = await reconstructFileForLabel(
-        lockedProjectFile.id,
-        tx
-      );
-      const newContentHash = calculateContentHash(newContent);
-      const fileUpdatedAt = new Date();
-
-      await tx
-        .update(projectFiles)
-        .set({
-          content: newContent,
-          contentHash: newContentHash,
-          updatedAt: fileUpdatedAt,
-        })
-        .where(eq(projectFiles.id, lockedProjectFile.id));
-
-      return {
-        conflictPayload: null,
-        nextVersion: (auditFields.version ?? lockedCurrentVersion) as number,
-        nextContentHash: contentHash,
-        nextFileContentHash: newContentHash,
-        fileUpdatedAt,
-      };
+    const result = await updateLabelDialogue({
+      labelId,
+      dialogue,
+      menuBlocks,
+      expectedVersion,
+      expectedContentHash,
+      userId: user.id,
     });
 
-    if (updateResult.conflictPayload) {
-      reply.status(409).send(updateResult.conflictPayload);
+    if (result.type === "conflict") {
+      reply.status(409).send(result);
       return;
     }
 
-    // Track word counts for daily writing goals
-    // This is non-critical: if tracking fails, the dialogue save is still successful
+    // Track word counts for daily writing goals (non-critical)
     try {
       await trackWordsForLabel({
         labelId,
@@ -525,34 +177,33 @@ async function updateLabelDialogueHandler(
         dialogue,
       });
     } catch (error) {
-      // Log the error but don't fail the request - the dialogue was already saved successfully
       request.log.error(
-        {
-          error,
-          userId: user.id,
-          labelId,
-        },
+        { error, userId: user.id, labelId },
         "Failed to track word count for daily writing goal"
       );
     }
 
     reply.send({
       success: true,
-      version: updateResult.nextVersion,
-      contentHash: updateResult.nextContentHash,
-      fileContentHash: updateResult.nextFileContentHash,
-      fileUpdatedAt: updateResult.fileUpdatedAt.toISOString(),
-    } as UpdateLabelDialogueResponse);
+      version: result.version,
+      contentHash: result.contentHash,
+      fileContentHash: result.fileContentHash,
+      fileUpdatedAt: result.fileUpdatedAt,
+    });
   } catch (error) {
     request.log.error(error);
-
-    // Handle known error types
     if (error instanceof NotFoundError) {
       reply.status(404).send({ error: "Project not found" } as ErrorResponse);
       return;
     }
     if (error instanceof ForbiddenError) {
       reply.status(403).send({ error: "Forbidden" } as ErrorResponse);
+      return;
+    }
+    if (error instanceof ValidationError) {
+      reply
+        .status(400)
+        .send({ error: (error as Error).message } as ErrorResponse);
       return;
     }
     reply.status(500).send({ error: "Internal server error" } as ErrorResponse);
@@ -654,25 +305,13 @@ async function deleteLabelHandler(
   try {
     await deleteLabel(labelId, user.id);
 
-    // Clean up labelWordCounts in userSettings when a label is deleted
-    // This prevents orphaned entries from accumulating over time
-    // This is non-critical: if cleanup fails, the delete is still successful
+    // Clean up labelWordCounts in userSettings after label deletion
+    // Non-critical: if cleanup fails, the delete is still successful
     try {
-      const db = getDb();
-      await db
-        .update(userSettings)
-        .set({
-          labelWordCounts: sql`COALESCE(label_word_counts, '{}'::jsonb) - ${labelId}`,
-        })
-        .where(eq(userSettings.userId, user.id));
+      await cleanupLabelWordCounts(labelId, user.id);
     } catch (error) {
-      // Log the error but don't fail the request - the label was already deleted successfully
       request.log.error(
-        {
-          error,
-          userId: user.id,
-          labelId,
-        },
+        { error, userId: user.id, labelId },
         "Failed to clean up labelWordCounts after label deletion"
       );
     }

--- a/apps/backend/src/services/labels.service.ts
+++ b/apps/backend/src/services/labels.service.ts
@@ -54,9 +54,17 @@ export {
   mapToPublicLabel,
 } from "./labels/index.js";
 
-export { createLabel, updateLabel, deleteLabel } from "./labels/index.js";
+export {
+  createLabel,
+  updateLabel,
+  deleteLabel,
+  cleanupLabelWordCounts,
+} from "./labels/index.js";
 
 export { reconstructFileForLabel } from "./labels/index.js";
+
+export { updateLabelDialogue } from "./labels/index.js";
+export type { UpdateLabelDialogueResult } from "./labels/index.js";
 
 export { updateIncomingJumpsForLabels } from "./labels/index.js";
 

--- a/apps/backend/src/services/labels/crud.ts
+++ b/apps/backend/src/services/labels/crud.ts
@@ -14,6 +14,7 @@ import {
   stats,
   variables,
   pairGroups,
+  userSettings,
 } from "../../db/schema/index.js";
 import { eq, and, isNull, sql, inArray, ne } from "drizzle-orm";
 import { sanitizeLabelName, type StatCondition } from "@branchforge/shared";
@@ -797,4 +798,28 @@ export async function deleteLabel(
     // to prevent later appends from colliding with stale positions.
     await resyncLabelPositions(tx, lockedLabel.projectFileId!);
   });
+}
+
+/**
+ * Clean up labelWordCounts in userSettings after a label is deleted.
+ * This prevents orphaned entries from accumulating over time.
+ * Non-critical: the caller should wrap in try/catch and not fail the
+ * primary operation if cleanup fails.
+ *
+ * @param labelId - The ID of the deleted label
+ * @param userId - The user ID
+ * @param db - Optional database context (defaults to getDb())
+ */
+export async function cleanupLabelWordCounts(
+  labelId: string,
+  userId: string,
+  db?: ReturnType<typeof getDb>
+): Promise<void> {
+  const ctx = db ?? getDb();
+  await ctx
+    .update(userSettings)
+    .set({
+      labelWordCounts: sql`COALESCE(label_word_counts, '{}'::jsonb) - ${labelId}`,
+    })
+    .where(eq(userSettings.userId, userId));
 }

--- a/apps/backend/src/services/labels/dialogue.ts
+++ b/apps/backend/src/services/labels/dialogue.ts
@@ -89,20 +89,50 @@ export async function updateLabelDialogue(params: {
   } = params;
 
   return getDb().transaction(async (tx) => {
-    // 1. Lock the label row to serialize concurrent updates
-    await tx.execute(
-      sql`SELECT id FROM labels WHERE id = ${labelId} FOR UPDATE`
-    );
-
-    // 2. Read the locked label
-    const [lockedLabel] = await tx
+    // 1. Read label to get projectFileId (no lock yet — re-read under lock
+    //    after the project_file lock to match deleteLabel's lock ordering).
+    const [label] = await tx
       .select({
         id: labels.id,
         projectId: labels.projectId,
         projectFileId: labels.projectFileId,
+      })
+      .from(labels)
+      .where(and(eq(labels.id, labelId), isNull(labels.deletedAt)))
+      .limit(1);
+
+    if (!label || !label.projectFileId) {
+      throw new NotFoundError("Label or file not found");
+    }
+
+    // 2. Lock the project file row FIRST (matches updateLabel / deleteLabel
+    //    lock ordering of project_files → labels, preventing deadlock).
+    await tx.execute(
+      sql`SELECT id FROM project_files WHERE id = ${label.projectFileId} FOR UPDATE`
+    );
+
+    // 3. Read the locked project file
+    const [lockedProjectFile] = await tx
+      .select()
+      .from(projectFiles)
+      .where(eq(projectFiles.id, label.projectFileId))
+      .limit(1);
+
+    if (!lockedProjectFile) {
+      throw new NotFoundError("File");
+    }
+
+    // 4. Lock the label row to serialize concurrent updates
+    await tx.execute(
+      sql`SELECT id FROM labels WHERE id = ${labelId} FOR UPDATE`
+    );
+
+    // 5. Re-read the label under lock to get current version/contentHash
+    const [lockedLabel] = await tx
+      .select({
         version: labels.version,
         contentHash: labels.contentHash,
-        labelPosition: labels.labelPosition,
+        projectFileId: labels.projectFileId,
       })
       .from(labels)
       .where(and(eq(labels.id, labelId), isNull(labels.deletedAt)))
@@ -112,24 +142,8 @@ export async function updateLabelDialogue(params: {
       throw new NotFoundError("Label or file not found");
     }
 
-    // 3. Lock the project file row
-    await tx.execute(
-      sql`SELECT id FROM project_files WHERE id = ${lockedLabel.projectFileId} FOR UPDATE`
-    );
-
-    // 4. Read the locked project file
-    const [lockedProjectFile] = await tx
-      .select()
-      .from(projectFiles)
-      .where(eq(projectFiles.id, lockedLabel.projectFileId))
-      .limit(1);
-
-    if (!lockedProjectFile) {
-      throw new NotFoundError("File");
-    }
-
-    // 5. Verify user owns the project (uses tx to stay inside the transaction)
-    await requireProjectOwnership(lockedLabel.projectId, userId, tx);
+    // 6. Verify user owns the project (uses tx to stay inside the transaction)
+    await requireProjectOwnership(label.projectId, userId, tx);
 
     // 6. Validate that all speakerIds exist in the characters table for this project
     const speakerIdsInDialogue = dialogue
@@ -144,7 +158,7 @@ export async function updateLabelDialogue(params: {
         .from(characters)
         .where(
           and(
-            eq(characters.projectId, lockedLabel.projectId),
+            eq(characters.projectId, label.projectId),
             inArray(characters.id, uniqueSpeakerIds)
           )
         );
@@ -202,7 +216,7 @@ export async function updateLabelDialogue(params: {
       };
     }
 
-    // 8. Fetch existing lines (with FOR UPDATE to prevent concurrent modifications)
+    // 8. Fetch existing lines — concurrency serialized by the label-row lock in step 1
     const existingLines = await tx
       .select()
       .from(labelLines)

--- a/apps/backend/src/services/labels/dialogue.ts
+++ b/apps/backend/src/services/labels/dialogue.ts
@@ -1,0 +1,368 @@
+/**
+ * Labels module - Dialogue Update
+ *
+ * Handles the business logic for updating a label's dialogue content.
+ * This was extracted from the route handler to live in the service layer.
+ *
+ * The TOCTOU fix: ALL initial data fetching is done inside the transaction
+ * so nothing is done outside the transaction.
+ */
+
+import { getDb } from "../../db/index.js";
+import {
+  labels,
+  labelLines,
+  projectFiles,
+  characters,
+} from "../../db/schema/index.js";
+import { eq, asc, inArray, isNull, and, sql } from "drizzle-orm";
+import { calculateLinesHash, calculateContentHash } from "../../lib/hash.js";
+import { updateAuditFields } from "../../lib/audit.js";
+import {
+  NotFoundError,
+  ValidationError,
+} from "../../middleware/error-handler.middleware.js";
+import type { UpdateLabelDialogueInput } from "../../lib/validation.js";
+import { requireProjectOwnership } from "../authz.service.js";
+import { planDialogueLineUpdates } from "../rpy/plan-dialogue-updates.js";
+import { reconstructFileForLabel } from "./reconstruct.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type DialogueEntry = UpdateLabelDialogueInput["dialogue"][number];
+type MenuBlock = NonNullable<UpdateLabelDialogueInput["menuBlocks"]>[number];
+
+export type UpdateLabelDialogueResult =
+  | {
+      type: "success";
+      version: number;
+      contentHash: string;
+      fileContentHash: string;
+      fileUpdatedAt: string;
+    }
+  | {
+      type: "conflict";
+      success: false;
+      version: number;
+      contentHash: string;
+      fileContentHash: string;
+      fileUpdatedAt: string;
+      conflict: {
+        reason: "STALE_LABEL_VERSION" | "STALE_CONTENT_HASH";
+        currentVersion: number;
+        currentContentHash: string | null;
+      };
+    };
+
+// ============================================================================
+// Dialogue Update
+// ============================================================================
+
+/**
+ * Update a label's dialogue content inside a single transaction.
+ *
+ * All initial data fetching (label, project file, ownership check, speaker
+ * validation) is performed inside the transaction to prevent TOCTOU races.
+ *
+ * @returns A discriminated union indicating success or conflict.
+ * @throws NotFoundError if the label or project file is not found.
+ * @throws ForbiddenError if the user does not own the project.
+ * @throws ValidationError if any speakerId references a non-existent character.
+ */
+export async function updateLabelDialogue(params: {
+  labelId: string;
+  dialogue: DialogueEntry[];
+  menuBlocks?: MenuBlock[];
+  expectedVersion?: number;
+  expectedContentHash?: string | null;
+  userId: string;
+}): Promise<UpdateLabelDialogueResult> {
+  const {
+    labelId,
+    dialogue,
+    menuBlocks,
+    expectedVersion,
+    expectedContentHash,
+    userId,
+  } = params;
+
+  return getDb().transaction(async (tx) => {
+    // 1. Lock the label row to serialize concurrent updates
+    await tx.execute(
+      sql`SELECT id FROM labels WHERE id = ${labelId} FOR UPDATE`
+    );
+
+    // 2. Read the locked label
+    const [lockedLabel] = await tx
+      .select({
+        id: labels.id,
+        projectId: labels.projectId,
+        projectFileId: labels.projectFileId,
+        version: labels.version,
+        contentHash: labels.contentHash,
+        labelPosition: labels.labelPosition,
+      })
+      .from(labels)
+      .where(and(eq(labels.id, labelId), isNull(labels.deletedAt)))
+      .limit(1);
+
+    if (!lockedLabel || !lockedLabel.projectFileId) {
+      throw new NotFoundError("Label or file not found");
+    }
+
+    // 3. Lock the project file row
+    await tx.execute(
+      sql`SELECT id FROM project_files WHERE id = ${lockedLabel.projectFileId} FOR UPDATE`
+    );
+
+    // 4. Read the locked project file
+    const [lockedProjectFile] = await tx
+      .select()
+      .from(projectFiles)
+      .where(eq(projectFiles.id, lockedLabel.projectFileId))
+      .limit(1);
+
+    if (!lockedProjectFile) {
+      throw new NotFoundError("File");
+    }
+
+    // 5. Verify user owns the project (uses tx to stay inside the transaction)
+    await requireProjectOwnership(lockedLabel.projectId, userId, tx);
+
+    // 6. Validate that all speakerIds exist in the characters table for this project
+    const speakerIdsInDialogue = dialogue
+      .map((entry) => entry.speakerId)
+      .filter((id): id is string => id !== null);
+
+    if (speakerIdsInDialogue.length > 0) {
+      const uniqueSpeakerIds = Array.from(new Set(speakerIdsInDialogue));
+
+      const existingCharacters = await tx
+        .select({ id: characters.id })
+        .from(characters)
+        .where(
+          and(
+            eq(characters.projectId, lockedLabel.projectId),
+            inArray(characters.id, uniqueSpeakerIds)
+          )
+        );
+
+      const existingCharacterIds = new Set(existingCharacters.map((c) => c.id));
+      const invalidSpeakerIds = uniqueSpeakerIds.filter(
+        (id) => !existingCharacterIds.has(id)
+      );
+
+      if (invalidSpeakerIds.length > 0) {
+        throw new ValidationError(
+          `Invalid speakerId(s): ${invalidSpeakerIds.join(", ")}. Character(s) not found in this project.`
+        );
+      }
+    }
+
+    const lockedCurrentVersion = lockedLabel.version ?? 1;
+
+    // 7. Conflict checks (expectedVersion / expectedContentHash)
+    if (
+      expectedVersion !== undefined &&
+      expectedVersion !== lockedCurrentVersion
+    ) {
+      return {
+        type: "conflict",
+        success: false as const,
+        version: lockedCurrentVersion,
+        contentHash: lockedLabel.contentHash ?? "",
+        fileContentHash: lockedProjectFile.contentHash,
+        fileUpdatedAt: lockedProjectFile.updatedAt.toISOString(),
+        conflict: {
+          reason: "STALE_LABEL_VERSION",
+          currentVersion: lockedCurrentVersion,
+          currentContentHash: lockedLabel.contentHash,
+        },
+      };
+    }
+
+    if (
+      expectedContentHash !== undefined &&
+      (lockedLabel.contentHash ?? null) !== expectedContentHash
+    ) {
+      return {
+        type: "conflict",
+        success: false as const,
+        version: lockedCurrentVersion,
+        contentHash: lockedLabel.contentHash ?? "",
+        fileContentHash: lockedProjectFile.contentHash,
+        fileUpdatedAt: lockedProjectFile.updatedAt.toISOString(),
+        conflict: {
+          reason: "STALE_CONTENT_HASH",
+          currentVersion: lockedCurrentVersion,
+          currentContentHash: lockedLabel.contentHash,
+        },
+      };
+    }
+
+    // 8. Fetch existing lines (with FOR UPDATE to prevent concurrent modifications)
+    const existingLines = await tx
+      .select()
+      .from(labelLines)
+      .where(and(eq(labelLines.labelId, labelId), isNull(labelLines.deletedAt)))
+      .orderBy(asc(labelLines.sequence));
+
+    // 9. Align prose against the incoming list so mid-list inserts/deletes keep
+    //    VISUAL/MENU rows interleaved correctly (not appended at max sequence).
+    const plan = planDialogueLineUpdates(
+      existingLines.map((line) => ({
+        id: line.id,
+        sequence: line.sequence,
+        contentType: line.contentType,
+        content: line.content,
+        speakerId: line.speakerId,
+      })),
+      dialogue
+    );
+
+    // 10. Delete removed prose rows (structural MENU/JUMP/VISUAL are never deleted)
+    if (plan.deleteIds.length > 0) {
+      await tx.delete(labelLines).where(inArray(labelLines.id, plan.deleteIds));
+    }
+
+    // 11. Update matched prose rows in place
+    await Promise.all(
+      plan.updates.map((update) =>
+        tx
+          .update(labelLines)
+          .set({
+            contentType: (update.speakerId ? "DIALOGUE" : "NARRATION") as
+              "DIALOGUE" | "NARRATION",
+            content: update.text,
+            speakerId: update.speakerId,
+            demoNotes: null,
+            isDirty: true,
+            projectFileId: lockedProjectFile.id,
+            contentHash: calculateContentHash(update.text),
+            lastSyncedHash: null,
+            sequence: plan.sequenceByKey.get(update.id)!,
+          })
+          .where(eq(labelLines.id, update.id))
+      )
+    );
+
+    // 12. Insert new prose rows at planned sequences
+    if (plan.inserts.length > 0) {
+      await tx.insert(labelLines).values(
+        plan.inserts.map((insert) => ({
+          labelId,
+          sequence: insert.sequence,
+          contentType: (insert.speakerId ? "DIALOGUE" : "NARRATION") as
+            "DIALOGUE" | "NARRATION",
+          content: insert.text,
+          speakerId: insert.speakerId,
+          demoNotes: null,
+          isDirty: true,
+          projectFileId: lockedProjectFile.id,
+          contentHash: calculateContentHash(insert.text),
+          lastSyncedHash: null,
+        }))
+      );
+    }
+
+    // 13. Reindex non-prose rows that shifted due to inserts/deletes
+    const structuralReindexes = existingLines.filter((line) => {
+      if (line.contentType === "DIALOGUE" || line.contentType === "NARRATION") {
+        return false;
+      }
+      const newSequence = plan.sequenceByKey.get(line.id);
+      return newSequence !== undefined && newSequence !== line.sequence;
+    });
+
+    await Promise.all(
+      structuralReindexes.map((line) =>
+        tx
+          .update(labelLines)
+          .set({
+            sequence: plan.sequenceByKey.get(line.id)!,
+            projectFileId: lockedProjectFile.id,
+            isDirty: true,
+            lastSyncedHash: null,
+          })
+          .where(eq(labelLines.id, line.id))
+      )
+    );
+
+    // 14. Process menu blocks - update MENU lines' menuOptions
+    if (menuBlocks && menuBlocks.length > 0) {
+      for (const block of menuBlocks) {
+        const menuContentHash = calculateContentHash(
+          JSON.stringify(block.menuOptions)
+        );
+        const result = await tx
+          .update(labelLines)
+          .set({
+            menuOptions: block.menuOptions,
+            contentHash: menuContentHash,
+            isDirty: true,
+            lastSyncedHash: null,
+          })
+          .where(
+            and(
+              eq(labelLines.id, block.lineId),
+              eq(labelLines.labelId, labelId),
+              eq(labelLines.contentType, "MENU"),
+              isNull(labelLines.deletedAt)
+            )
+          );
+        if (result.rowCount === 0) {
+          throw new NotFoundError(
+            `Menu line ${block.lineId} not found in label ${labelId}`
+          );
+        }
+      }
+    }
+
+    // 15. Compute content hash from the actual persisted label_lines
+    //     (includes MENU/JUMP rows preserved during prose edits) so the hash
+    //     stays consistent with sync/import flows that use calculateLinesHash.
+    const finalLines = await tx
+      .select()
+      .from(labelLines)
+      .where(and(eq(labelLines.labelId, labelId), isNull(labelLines.deletedAt)))
+      .orderBy(asc(labelLines.sequence));
+    const contentHash = calculateLinesHash(finalLines);
+
+    // 16. Update label with audit fields and sync status
+    const auditFields = updateAuditFields(lockedCurrentVersion, userId);
+    await tx
+      .update(labels)
+      .set({
+        ...auditFields,
+        contentHash,
+        syncStatus: "MODIFIED_LOCAL",
+        updatedAt: new Date(),
+      })
+      .where(eq(labels.id, labelId));
+
+    // 17. Reconstruct file and update project file
+    const newContent = await reconstructFileForLabel(lockedProjectFile.id, tx);
+    const newContentHash = calculateContentHash(newContent);
+    const fileUpdatedAt = new Date();
+
+    await tx
+      .update(projectFiles)
+      .set({
+        content: newContent,
+        contentHash: newContentHash,
+        updatedAt: fileUpdatedAt,
+      })
+      .where(eq(projectFiles.id, lockedProjectFile.id));
+
+    // 18. Return success result
+    return {
+      type: "success",
+      version: (auditFields.version ?? lockedCurrentVersion) as number,
+      contentHash,
+      fileContentHash: newContentHash,
+      fileUpdatedAt: fileUpdatedAt.toISOString(),
+    };
+  });
+}

--- a/apps/backend/src/services/labels/index.ts
+++ b/apps/backend/src/services/labels/index.ts
@@ -54,10 +54,19 @@ export {
 } from "./queries.js";
 
 // CRUD
-export { createLabel, updateLabel, deleteLabel } from "./crud.js";
+export {
+  createLabel,
+  updateLabel,
+  deleteLabel,
+  cleanupLabelWordCounts,
+} from "./crud.js";
 
 // Reconstruction
 export { reconstructFileForLabel } from "./reconstruct.js";
+
+// Dialogue
+export { updateLabelDialogue } from "./dialogue.js";
+export type { UpdateLabelDialogueResult } from "./dialogue.js";
 
 // Incoming Jumps
 export { updateIncomingJumpsForLabels } from "./incoming-jumps.js";


### PR DESCRIPTION
Closes #332

## What changed
Extracted `updateLabelDialogueHandler` business logic (~400 lines) from `labels.routes.ts` into a dedicated service module `services/labels/dialogue.ts`.

## Details

### CL1 (Route handler extraction)
- `labels.routes.ts` reduced from 801 → 454 lines
- New `services/labels/dialogue.ts` with `updateLabelDialogue()` returning a discriminated union (`type: "success" | "conflict"`)
- Route handler extracts params, calls service, maps response (~40 lines)

### C1 (TOCTOU fix)
- All initial data fetching (label, project file, ownership, speaker validation) moved **inside** the transaction
- Previously done outside the transaction, creating a race window where work could be wasted if the row was concurrently deleted

### C2 (layering fix)
- `deleteLabelHandler` no longer calls `getDb()` directly
- New `cleanupLabelWordCounts()` in `services/labels/crud.ts`

### CL2 (cleanup)
- Removed stale comment about `UpdateLabelDialogueBody` migration

## Verification
- `pnpm --filter @branchforge/backend lint` — passed
- `pnpm typecheck` — passed
- `pnpm --filter @branchforge/backend test:unit` — 892 tests passed
- `pnpm test:integration` — 429 tests passed

## @oracle review
**GO** — no must-fix findings. Should-fix items (type duplication, dead catch blocks) addressed on the branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced label dialogue editing with safer, atomic updates.
  - Adds optimistic conflict detection to prevent overwriting newer changes.
  - Updates related label content and synchronization details after successful edits.
  - Preserves existing dialogue/prose structure while applying prose and menu changes.

- **Bug Fixes**
  - Improved cleanup of saved word-count data when labels are deleted.
  - Provides clearer validation errors for invalid dialogue update requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->