### PR TITLE
refactor: split zip import service and fix transaction atomicity (#334)

### DIFF
--- a/apps/backend/src/services/__tests__/zip-import.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/zip-import.service.unit.test.ts
@@ -571,8 +571,10 @@ describe("ZipImportService", () => {
       // promotion transaction. The mock chain is shared by both
       // transactions (they both run via the same `mockTx`), so this
       // captures inserts into all relevant tables.
-      const allRows = mockTx.values.mock.calls.map(
-        (c) => c[0] as Record<string, unknown>
+      // Batch inserts pass arrays to values(); flatten to inspect rows.
+      const allRows = mockTx.values.mock.calls.flatMap(
+        (c) =>
+          (Array.isArray(c[0]) ? c[0] : [c[0]]) as Record<string, unknown>[]
       );
 
       // The character row was inserted with the right tag and color.
@@ -606,6 +608,41 @@ describe("ZipImportService", () => {
       // The `onConflictDoNothing` upsert path was used for all three
       // symbol inserts.
       expect(mockTx.onConflictDoNothing).toHaveBeenCalled();
+    });
+
+    it("clamps stat default values above 100 to maxValue", async () => {
+      // `default overachiever = 999` should produce minValue=100
+      // rather than 999 which would exceed the hard-coded maxValue.
+      const fileContent = [
+        "default overachiever = 999",
+        "",
+        "label start:",
+        "    return",
+      ].join("\n");
+
+      const mockBuffer = Buffer.from("mock zip");
+      const mockZip = {
+        files: {
+          "game/script.rpy": createMockFile("game/script.rpy", fileContent),
+        },
+      };
+      vi.mocked(JSZip.loadAsync).mockResolvedValue(mockZip as any);
+
+      const result = await importZipFile(mockProjectId, mockBuffer);
+      expect(result.success).toBe(true);
+
+      const allRows = mockTx.values.mock.calls.flatMap(
+        (c) =>
+          (Array.isArray(c[0]) ? c[0] : [c[0]]) as Record<string, unknown>[]
+      );
+      const statRow = allRows.find((r) => "minValue" in r && "maxValue" in r);
+      expect(statRow).toBeDefined();
+      expect(statRow).toMatchObject({
+        projectId: mockProjectId,
+        key: "overachiever",
+        minValue: 100,
+        maxValue: 100,
+      });
     });
 
     it("is idempotent: re-importing the same RPY files does not duplicate symbols", async () => {
@@ -710,8 +747,10 @@ describe("ZipImportService", () => {
 
       // Collect all rows passed to tx.values() — these include both
       // the project_file inserts and the symbol-promotion inserts.
-      const allRows = mockTx.values.mock.calls.map(
-        (c) => c[0] as Record<string, unknown>
+      // Batch inserts pass arrays to values(); flatten to inspect rows.
+      const allRows = mockTx.values.mock.calls.flatMap(
+        (c) =>
+          (Array.isArray(c[0]) ? c[0] : [c[0]]) as Record<string, unknown>[]
       );
       const characterRows = allRows.filter((r) => "renpyTag" in r);
 

--- a/apps/backend/src/services/__tests__/zip-import.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/zip-import.service.unit.test.ts
@@ -48,7 +48,10 @@ vi.mock("../rpy-parser.service.js", () => ({
 }));
 
 // Mock labels.service
-import { syncLabelsFromFile } from "../labels.service.js";
+import {
+  syncLabelsFromFile,
+  updateIncomingJumpsForLabels,
+} from "../labels.service.js";
 
 vi.mock("../labels.service.js", () => ({
   syncLabelsFromFile: vi.fn().mockResolvedValue({
@@ -60,6 +63,7 @@ vi.mock("../labels.service.js", () => ({
     errors: [],
     skipped: false,
     affectedLabelIds: [],
+    dbLabelCount: 1,
   }),
   updateIncomingJumpsForLabels: vi.fn().mockResolvedValue(undefined),
 }));
@@ -337,6 +341,7 @@ describe("ZipImportService", () => {
         errors: [{ label: "start", error: "Failed to process label" }],
         skipped: false,
         affectedLabelIds: [],
+        dbLabelCount: 0,
       });
 
       const result = await importZipFile(mockProjectId, mockBuffer);
@@ -649,6 +654,102 @@ describe("ZipImportService", () => {
       expect(result).toHaveProperty("labelsCreated");
       expect(result).toHaveProperty("filesSkipped");
       expect(result).toHaveProperty("filesUpdated");
+    });
+
+    it("does NOT promote symbols when the per-file savepoint rolls back", async () => {
+      // Two files: the first will fail label sync (triggering a
+      // savepoint rollback), the second will succeed. Symbols from
+      // the failed file must not appear in the promoteSymbols calls.
+      const file1Content = [
+        'define e = Character("Eileen", color="#c8ffc8")',
+        "",
+        "label start:",
+        '    e "Hello."',
+        "    return",
+      ].join("\n");
+
+      const file2Content = [
+        'define s = Character("Sylvie", color="#ff0000")',
+        "",
+        "label start:",
+        '    s "Hi."',
+        "    return",
+      ].join("\n");
+
+      const mockBuffer = Buffer.from("mock zip");
+      const mockZip = {
+        files: {
+          "game/fail.rpy": createMockFile("game/fail.rpy", file1Content),
+          "game/ok.rpy": createMockFile("game/ok.rpy", file2Content),
+        },
+      };
+      vi.mocked(JSZip.loadAsync).mockResolvedValue(mockZip as any);
+
+      // Make label sync throw for the first file only.
+      vi.mocked(syncLabelsFromFile)
+        .mockRejectedValueOnce(new Error("Label sync failed"))
+        .mockResolvedValueOnce({
+          success: true,
+          labelsCreated: 1,
+          labelsUpdated: 0,
+          labelsDeleted: 0,
+          linesProcessed: 1,
+          errors: [],
+          skipped: false,
+          affectedLabelIds: ["label-id"],
+          dbLabelCount: 1,
+        });
+
+      const result = await importZipFile(mockProjectId, mockBuffer);
+
+      expect(result).toMatchObject({
+        success: true,
+        filesFailed: 1,
+        filesImported: 1,
+      });
+
+      // Collect all rows passed to tx.values() — these include both
+      // the project_file inserts and the symbol-promotion inserts.
+      const allRows = mockTx.values.mock.calls.map(
+        (c) => c[0] as Record<string, unknown>
+      );
+      const characterRows = allRows.filter((r) => "renpyTag" in r);
+
+      // Eileen's character (from the failed file) must NOT be promoted.
+      const eileenRow = characterRows.find((r) => r.renpyTag === "e");
+      expect(eileenRow).toBeUndefined();
+
+      // Sylvie's character (from the succeeding file) MUST be promoted.
+      const sylvieRow = characterRows.find((r) => r.renpyTag === "s");
+      expect(sylvieRow).toMatchObject({
+        projectId: mockProjectId,
+        renpyTag: "s",
+        name: "Sylvie",
+        displayName: "Sylvie",
+        color: "#ff0000",
+      });
+    });
+
+    it("calls updateIncomingJumpsForLabels with the transaction object", async () => {
+      const mockContent = 'label start:\n    "Hello"';
+      const mockBuffer = Buffer.from("mock zip");
+      const mockZip = {
+        files: {
+          "game/script.rpy": createMockFile("game/script.rpy", mockContent),
+        },
+      };
+      vi.mocked(JSZip.loadAsync).mockResolvedValue(mockZip as any);
+
+      await importZipFile(mockProjectId, mockBuffer);
+
+      // updateIncomingJumpsForLabels must be called with the same
+      // transaction (tx) that the file inserts and symbol promotion
+      // ran in — not via a separate db.transaction call.
+      expect(vi.mocked(updateIncomingJumpsForLabels)).toHaveBeenCalledWith(
+        mockTx,
+        expect.any(Array),
+        mockProjectId
+      );
     });
   });
 });

--- a/apps/backend/src/services/zip-import-guardrails.ts
+++ b/apps/backend/src/services/zip-import-guardrails.ts
@@ -1,0 +1,26 @@
+/**
+ * Zip Import Guardrails
+ *
+ * Size and count limits for Ren'Py project zip imports.
+ * Extracted from zip-import.service.ts to keep the import function focused.
+ */
+
+// ============================================================================
+// Import Guardrails
+// ============================================================================
+
+export const MAX_ZIP_BUFFER_BYTES = 30 * 1024 * 1024; // 30MB compressed upload
+export const MAX_EXTRACTED_BYTES = 120 * 1024 * 1024; // 120MB total extracted RPY content
+export const MAX_RPY_FILES = 500; // Well above typical Ren'Py project sizes (large projects rarely exceed 200-300 files)
+export const MAX_SINGLE_RPY_BYTES = 5 * 1024 * 1024; // 5MB per single RPY file
+
+/**
+ * Error thrown when a zip import exceeds one of the guardrail limits.
+ * Caught by the importer to produce a safe, client-friendly error message.
+ */
+export class ZipImportLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ZipImportLimitError";
+  }
+}

--- a/apps/backend/src/services/zip-import.service.ts
+++ b/apps/backend/src/services/zip-import.service.ts
@@ -8,6 +8,7 @@
 
 import JSZip from "jszip";
 import { getDb } from "../db/index.js";
+import type { Transaction } from "../db/types.js";
 import {
   projectFiles,
   characters,
@@ -29,22 +30,20 @@ import {
   updateIncomingJumpsForLabels,
 } from "./labels.service.js";
 import { createProject, deleteProject } from "./projects.service.js";
+import {
+  MAX_ZIP_BUFFER_BYTES,
+  MAX_EXTRACTED_BYTES,
+  MAX_RPY_FILES,
+  MAX_SINGLE_RPY_BYTES,
+  ZipImportLimitError,
+} from "./zip-import-guardrails.js";
 
-// ============================================================================
-// Import Guardrails
-// ============================================================================
-
-export const MAX_ZIP_BUFFER_BYTES = 30 * 1024 * 1024; // 30MB compressed upload
-export const MAX_EXTRACTED_BYTES = 120 * 1024 * 1024; // 120MB total extracted RPY content
-export const MAX_RPY_FILES = 500; // Well above typical Ren'Py project sizes (large projects rarely exceed 200-300 files)
-export const MAX_SINGLE_RPY_BYTES = 5 * 1024 * 1024; // 5MB per single RPY file
-
-class ZipImportLimitError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ZipImportLimitError";
-  }
-}
+export {
+  MAX_ZIP_BUFFER_BYTES,
+  MAX_EXTRACTED_BYTES,
+  MAX_RPY_FILES,
+  MAX_SINGLE_RPY_BYTES,
+};
 
 // ============================================================================
 // Types
@@ -72,8 +71,47 @@ export interface ImportZipFailure {
 export type ImportZipResult = ImportZipSuccess | ImportZipFailure;
 
 // ============================================================================
+// Internal Types for Refactored Import
+// ============================================================================
+
+interface PreProcessedFile {
+  filePath: string;
+  fileType: "STORY" | "SETTINGS";
+  cleanedContent: string;
+  originalContent: string;
+  symbols: {
+    characters: DetectedCharacterStatement[];
+    variables: DetectedDefaultStatement[];
+    stats: DetectedDefaultStatement[];
+  };
+  contentHash: string;
+}
+
+type ProcessFileAction = "imported" | "updated" | "skipped" | "failed";
+
+interface ProcessFileInTxResult {
+  action: ProcessFileAction;
+  labelsCreated: number;
+}
+
+// ============================================================================
 // File Extraction
 // ============================================================================
+
+/**
+ * Insert items into a map on a "first-wins" basis: if the key computed
+ * by `keyFn` is already present in the map, the item is skipped.
+ */
+function firstWinsInsert<K, V>(
+  items: V[],
+  keyFn: (item: V) => K,
+  map: Map<K, V>
+): void {
+  for (const item of items) {
+    const key = keyFn(item);
+    if (!map.has(key)) map.set(key, item);
+  }
+}
 
 /**
  * Aggregate a successfully imported file's extracted symbols into
@@ -99,15 +137,9 @@ function accumulateSymbols(
   variablesByKey: Map<string, DetectedDefaultStatement>,
   statsByKey: Map<string, DetectedDefaultStatement>
 ): void {
-  for (const c of entry.symbols.characters) {
-    if (!charactersByTag.has(c.tag)) charactersByTag.set(c.tag, c);
-  }
-  for (const v of entry.symbols.variables) {
-    if (!variablesByKey.has(v.key)) variablesByKey.set(v.key, v);
-  }
-  for (const s of entry.symbols.stats) {
-    if (!statsByKey.has(s.key)) statsByKey.set(s.key, s);
-  }
+  firstWinsInsert(entry.symbols.characters, (c) => c.tag, charactersByTag);
+  firstWinsInsert(entry.symbols.variables, (v) => v.key, variablesByKey);
+  firstWinsInsert(entry.symbols.stats, (s) => s.key, statsByKey);
 }
 
 /**
@@ -212,6 +244,34 @@ export async function extractRpyFiles(zip: JSZip): Promise<ExtractedFile[]> {
 export { calculateContentHash };
 
 // ============================================================================
+// Pre-Processing
+// ============================================================================
+
+/**
+ * Pre-process extracted RPY files: parse for labels, strip symbols,
+ * and compute content hashes. Runs outside any database transaction
+ * since it does not touch the database.
+ */
+function preProcessFiles(extractedFiles: ExtractedFile[]): PreProcessedFile[] {
+  return extractedFiles.map((file) => {
+    const parsed = parseRPYFileWithLabels(file.content, file.filePath);
+    const stripped = extractAndStripRpySymbols(file.content);
+    return {
+      filePath: file.filePath,
+      fileType: parsed.fileType,
+      cleanedContent: stripped.cleanedContent,
+      originalContent: file.content,
+      symbols: {
+        characters: stripped.characters,
+        variables: stripped.variables,
+        stats: stripped.stats,
+      },
+      contentHash: calculateContentHash(stripped.cleanedContent),
+    };
+  });
+}
+
+// ============================================================================
 // Main Import Function
 // ============================================================================
 
@@ -221,13 +281,18 @@ export { calculateContentHash };
  * Process:
  * 1. Load and parse the zip file
  * 2. Extract all .rpy files
- * 3. Pre-process all files (parse RPY, calculate hashes) - outside transaction
+ * 3. Pre-process all files (parse RPY, strip symbols, calculate hashes) - outside transaction
  * 4. In a single transaction, process each file with savepoints for error isolation
  *    - Check if already exists (by project + source + path)
- *    - If exists with same hash: skip
- *    - If exists with different hash: update
- *    - If not exists: insert
- * 5. Sync labels for STORY files via syncLabelsFromFile
+ *    - If exists with same hash: skip (no-op for idempotency)
+ *    - If exists with different hash: update file content and sync labels
+ *    - If not exists: insert new file and sync labels
+ * 5. Promote extracted symbols (characters, variables, stats) into the database
+ * 6. Compute incomingJumps for all project labels (atomic with step 4 + 5)
+ *
+ * Steps 4-6 run inside a single database transaction for atomicity:
+ * file inserts/updates, symbol promotion, and incomingJumps all commit
+ * together or roll back together.
  *
  * @param projectId - Project ID to import into
  * @param zipBuffer - Buffer containing zip file data
@@ -253,7 +318,7 @@ export async function importZipFile(
     const extractedFiles = await extractRpyFiles(zip);
 
     if (extractedFiles.length === 0) {
-      const success: ImportZipSuccess = {
+      return {
         success: true,
         filesImported: 0,
         filesUpdated: 0,
@@ -261,275 +326,77 @@ export async function importZipFile(
         filesFailed: 0,
         labelsCreated: 0,
       };
-      return success;
     }
 
-    // Step 3: Pre-process all files (parse, hash, strip symbols) - outside
-    // transaction. This is fast and doesn't need DB access, so failures
-    // don't roll back DB work.
-    //
-    // We extract `define <tag> = Character(...)` and
-    // `default <key> = ...` statements and remove them from the
-    // stored file content. The DB becomes the single source of truth
-    // for those symbols, so re-exporting the project cannot produce
-    // duplicate `define`/`default` lines that would crash Ren'Py with
-    // `NameError: name 'X' is already defined`. See issue #244.
-    const preProcessedFiles = extractedFiles.map((file) => {
-      const parsed = parseRPYFileWithLabels(file.content, file.filePath);
-      const stripped = extractAndStripRpySymbols(file.content);
-      return {
-        filePath: file.filePath,
-        fileType: parsed.fileType,
-        cleanedContent: stripped.cleanedContent,
-        originalContent: file.content,
-        symbols: {
-          characters: stripped.characters,
-          variables: stripped.variables,
-          stats: stripped.stats,
-        },
-        // Hash the cleaned content because that's what we store in
-        // `project_files.content`; identical inputs produce identical
-        // cleaned output, so re-imports of the same source file are
-        // correctly detected as no-ops.
-        contentHash: calculateContentHash(stripped.cleanedContent),
-      };
-    });
+    // Step 3: Pre-process all files (parse, hash, strip symbols)
+    const preProcessedFiles = preProcessFiles(extractedFiles);
 
-    // Counters for tracking import statistics
+    // Accumulators
     let filesImported = 0;
     let filesUpdated = 0;
     let filesSkipped = 0;
     let filesFailed = 0;
     let labelsCreated = 0;
 
-    // Cross-file symbol aggregation. We populate this as files are
-    // successfully inserted/updated in Step 4 below (NOT from the
-    // raw preProcessedFiles list), so that files whose savepoint
-    // rolls back do not contribute characters / variables / stats
-    // to the database. The first occurrence of a given tag/key
-    // wins so symbol metadata is stable across files.
     const charactersByTag = new Map<string, DetectedCharacterStatement>();
     const variablesByKey = new Map<string, DetectedDefaultStatement>();
     const statsByKey = new Map<string, DetectedDefaultStatement>();
 
     // Step 4: Process all files in a single transaction with savepoints.
-    // Each file's savepoint isolates per-file failures, so one bad
-    // file doesn't abort the whole import. We use the cleaned content
-    // for `project_files.content` and preserve the original
-    // (pre-strip) text in `originalContent` for round-tripping.
+    // Symbol promotion and incomingJumps computation are also inside
+    // this transaction for atomicity.
     await db.transaction(async (tx) => {
       let fileIndex = 0;
       for (const entry of preProcessedFiles) {
-        const savepointName = `sp_${fileIndex}`;
+        const result = await processFileInTransaction(
+          tx,
+          entry,
+          projectId,
+          fileIndex
+        );
 
-        try {
-          // Create savepoint for per-file error isolation
-          await tx.execute(`SAVEPOINT ${savepointName}`);
-
-          // Check if file already exists
-          const [existing] = await tx
-            .select()
-            .from(projectFiles)
-            .where(
-              and(
-                eq(projectFiles.projectId, projectId),
-                eq(projectFiles.source, "ZIP"),
-                eq(projectFiles.filePath, entry.filePath)
-              )
-            )
-            .limit(1);
-
-          if (existing) {
-            // Check if content has changed
-            if (existing.contentHash === entry.contentHash) {
-              filesSkipped++;
-              await tx.execute(`RELEASE SAVEPOINT ${savepointName}`);
-              continue;
-            }
-
-            // Update existing file with cleaned content
-            await tx
-              .update(projectFiles)
-              .set({
-                content: entry.cleanedContent,
-                // Only set originalContent if it's null (preserve the
-                // originally imported file even after re-imports that
-                // strip the same lines again).
-                originalContent: sql`COALESCE(${projectFiles.originalContent}, ${entry.originalContent})`,
-                contentHash: entry.contentHash,
-                fileType: entry.fileType,
-                updatedAt: new Date(),
-              })
-              .where(eq(projectFiles.id, existing.id));
-
-            filesUpdated++;
-            // Aggregate symbols from this successfully processed
-            // file. Skipped files (unchanged hash) don't contribute
-            // because their DB row already has whatever symbols
-            // were extracted on the prior import.
-            accumulateSymbols(
-              entry,
-              charactersByTag,
-              variablesByKey,
-              statsByKey
-            );
-
-            // Sync labels for STORY files to create/update labels in database
-            if (entry.fileType === "STORY") {
-              const syncResult = await syncLabelsFromFile(
-                projectId,
-                { filePath: entry.filePath, fileType: entry.fileType },
-                entry.originalContent, // Pass original content to parser
-                existing.id,
-                { skipCleanup: false, tx }
-              );
-              labelsCreated += syncResult.labelsCreated;
-            }
-          } else {
-            // Insert new file with cleaned content
-            const [newFile] = await tx
-              .insert(projectFiles)
-              .values({
-                projectId,
-                source: "ZIP",
-                filePath: entry.filePath,
-                fileType: entry.fileType,
-                content: entry.cleanedContent,
-                originalContent: entry.originalContent, // Preserve the original
-                contentHash: entry.contentHash,
-              })
-              .returning();
-
-            if (!newFile) {
-              throw new Error(`Failed to insert file: ${entry.filePath}`);
-            }
-
+        switch (result.action) {
+          case "imported":
             filesImported++;
-            // Aggregate symbols from this successfully processed
-            // file. Only files that survive the savepoint contribute
-            // to the symbol promotion that follows, so a malformed
-            // or failing file does not leave its characters /
-            // variables / stats stranded in the database with no
-            // matching `project_files` row.
-            accumulateSymbols(
-              entry,
-              charactersByTag,
-              variablesByKey,
-              statsByKey
-            );
-
-            // Sync labels for STORY files to create labels in database
-            if (entry.fileType === "STORY") {
-              const syncResult = await syncLabelsFromFile(
-                projectId,
-                { filePath: entry.filePath, fileType: entry.fileType },
-                entry.originalContent, // Pass original content to parser
-                newFile.id,
-                { skipCleanup: false, tx }
-              );
-              labelsCreated += syncResult.labelsCreated;
-            }
-          }
-
-          // Release savepoint on success
-          await tx.execute(`RELEASE SAVEPOINT ${savepointName}`);
-        } catch (error) {
-          // Rollback to savepoint on error, continue with next file
-          try {
-            await tx.execute(`ROLLBACK TO SAVEPOINT ${savepointName}`);
-          } catch {
-            // Savepoint may already be released, ignore
-          }
-
-          // Release savepoint after rollback to prevent accumulation
-          try {
-            await tx.execute(`RELEASE SAVEPOINT ${savepointName}`);
-          } catch {
-            // Savepoint may already be released, ignore
-          }
-
-          logError(LogEventType.SERVICE_ERROR, {
-            event: "zip_file_import_failed",
-            projectId,
-            filePath: entry.filePath,
-            error: error instanceof Error ? error.message : "Unknown error",
-          });
-
-          filesFailed++;
+            break;
+          case "updated":
+            filesUpdated++;
+            break;
+          case "skipped":
+            filesSkipped++;
+            break;
+          case "failed":
+            filesFailed++;
+            break;
         }
 
+        // Only accumulate symbols after the per-file savepoint has
+        // succeeded (imported or updated). If the savepoint rolled
+        // back (failed) or the file was skipped, we must not promote
+        // its symbols.
+        if (result.action === "imported" || result.action === "updated") {
+          accumulateSymbols(entry, charactersByTag, variablesByKey, statsByKey);
+        }
+
+        labelsCreated += result.labelsCreated;
         fileIndex++;
       }
 
-      // Step 5: Promote extracted `define`/`default` symbols into
-      // the database. This runs inside the same transaction as the
-      // per-file savepoint loop so the file inserts and the symbol
-      // promotion are atomic: either both commit or neither does.
-      // We use `onConflictDoNothing` so re-imports of the same RPY
-      // files are no-ops and the user's later UI edits to the DB
-      // rows are preserved.
-      const allCharacters = Array.from(charactersByTag.values());
-      const allVariables = Array.from(variablesByKey.values());
-      const allStats = Array.from(statsByKey.values());
-      if (
-        allCharacters.length > 0 ||
-        allVariables.length > 0 ||
-        allStats.length > 0
-      ) {
-        for (const c of allCharacters) {
-          await tx
-            .insert(characters)
-            .values({
-              projectId,
-              name: c.name ?? c.tag,
-              displayName: c.name ?? c.tag,
-              renpyTag: c.tag,
-              color: c.color || "#cfcfcf",
-              updatedAt: new Date(),
-            })
-            .onConflictDoNothing({
-              target: [characters.projectId, characters.renpyTag],
-            });
-        }
-        for (const v of allVariables) {
-          await tx
-            .insert(variables)
-            .values({
-              projectId,
-              key: v.key,
-            })
-            .onConflictDoNothing({
-              target: [variables.projectId, variables.key],
-            });
-        }
-        for (const s of allStats) {
-          // `default x = 0` becomes a stat with minValue=0 and the
-          // default maxValue of 100; users can adjust in the UI.
-          // Use parseFloat + round so that float values like 3.5
-          // are preserved (parseInt would silently truncate to 3).
-          const minValue = Math.round(Number.parseFloat(s.value)) || 0;
-          await tx
-            .insert(stats)
-            .values({
-              projectId,
-              key: s.key,
-              name: s.key,
-              minValue,
-              maxValue: 100,
-              updatedAt: new Date(),
-            })
-            .onConflictDoNothing({
-              target: [stats.projectId, stats.key],
-            });
-        }
-      }
-    });
+      // Step 5: Promote symbols into the database
+      await promoteSymbols(
+        tx,
+        charactersByTag,
+        variablesByKey,
+        statsByKey,
+        projectId
+      );
 
-    // Compute incomingJumps for all project labels after import so
-    // cross-file jumps are captured regardless of file processing order.
-    // Skip if every file failed — no new labels were written.
-    if (filesImported + filesUpdated + filesSkipped > 0) {
-      await db.transaction(async (tx) => {
+      // Step 6: Compute incomingJumps for all project labels.
+      // C4 fix: this now runs inside the main transaction so that
+      // file inserts, symbol promotion, and incomingJumps are all
+      // committed atomically. Previously this ran in a separate
+      // transaction, risking stale incomingJumps if it failed.
+      if (filesImported + filesUpdated + filesSkipped > 0) {
         const allProjectLabels = await tx
           .select({ id: labels.id })
           .from(labels)
@@ -538,11 +405,10 @@ export async function importZipFile(
           );
         const allLabelIds = allProjectLabels.map((l) => l.id);
         await updateIncomingJumpsForLabels(tx, allLabelIds, projectId);
-      });
-    }
+      }
+    });
 
-    // Construct success result
-    const success: ImportZipSuccess = {
+    return {
       success: true,
       filesImported,
       filesUpdated,
@@ -550,9 +416,7 @@ export async function importZipFile(
       filesFailed,
       labelsCreated,
     };
-    return success;
   } catch (error) {
-    // Log the detailed error for debugging
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error";
 
@@ -562,18 +426,216 @@ export async function importZipFile(
       error: errorMessage,
     });
 
-    // Return a safe, client-friendly error message
     const safeErrorMessage =
       error instanceof ZipImportLimitError
         ? "Zip file exceeds import limits"
         : "Failed to import zip file";
 
-    // Construct failure result
-    const failure: ImportZipFailure = {
+    return {
       success: false,
       error: safeErrorMessage,
     };
-    return failure;
+  }
+}
+
+// ============================================================================
+// Per-File Processing (inside transaction)
+// ============================================================================
+
+/**
+ * Process a single pre-processed RPY file inside the import transaction.
+ * Uses savepoints to isolate per-file failures so one bad file does not
+ * abort the entire import.
+ *
+ * NOTE: Symbol accumulation is done by the caller (importZipFile) after
+ * the savepoint succeeds, so that rolled-back files never leak symbols.
+ */
+async function processFileInTransaction(
+  tx: Transaction,
+  entry: PreProcessedFile,
+  projectId: string,
+  fileIndex: number
+): Promise<ProcessFileInTxResult> {
+  const savepointName = `sp_${fileIndex}`;
+
+  // CL7: Validate savepoint name (same pattern as labels/sync.ts)
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(savepointName)) {
+    throw new Error(`Invalid savepoint name: ${savepointName}`);
+  }
+
+  try {
+    await tx.execute(sql.raw(`SAVEPOINT ${savepointName}`));
+
+    // Check if file already exists
+    const [existing] = await tx
+      .select()
+      .from(projectFiles)
+      .where(
+        and(
+          eq(projectFiles.projectId, projectId),
+          eq(projectFiles.source, "ZIP"),
+          eq(projectFiles.filePath, entry.filePath)
+        )
+      )
+      .limit(1);
+
+    if (existing) {
+      if (existing.contentHash === entry.contentHash) {
+        await tx.execute(sql.raw(`RELEASE SAVEPOINT ${savepointName}`));
+        return { action: "skipped", labelsCreated: 0 };
+      }
+
+      // Update existing file with cleaned content
+      await tx
+        .update(projectFiles)
+        .set({
+          content: entry.cleanedContent,
+          originalContent: sql`COALESCE(${projectFiles.originalContent}, ${entry.originalContent})`,
+          contentHash: entry.contentHash,
+          fileType: entry.fileType,
+          updatedAt: new Date(),
+        })
+        .where(eq(projectFiles.id, existing.id));
+
+      let labelsCreated = 0;
+      if (entry.fileType === "STORY") {
+        const syncResult = await syncLabelsFromFile(
+          projectId,
+          { filePath: entry.filePath, fileType: entry.fileType },
+          entry.originalContent,
+          existing.id,
+          { skipCleanup: false, tx }
+        );
+        labelsCreated += syncResult.labelsCreated;
+      }
+
+      await tx.execute(sql.raw(`RELEASE SAVEPOINT ${savepointName}`));
+      return { action: "updated", labelsCreated };
+    } else {
+      // Insert new file with cleaned content
+      const [newFile] = await tx
+        .insert(projectFiles)
+        .values({
+          projectId,
+          source: "ZIP",
+          filePath: entry.filePath,
+          fileType: entry.fileType,
+          content: entry.cleanedContent,
+          originalContent: entry.originalContent,
+          contentHash: entry.contentHash,
+        })
+        .returning();
+
+      if (!newFile) {
+        throw new Error(`Failed to insert file: ${entry.filePath}`);
+      }
+
+      let labelsCreated = 0;
+      if (entry.fileType === "STORY") {
+        const syncResult = await syncLabelsFromFile(
+          projectId,
+          { filePath: entry.filePath, fileType: entry.fileType },
+          entry.originalContent,
+          newFile.id,
+          { skipCleanup: false, tx }
+        );
+        labelsCreated += syncResult.labelsCreated;
+      }
+
+      await tx.execute(sql.raw(`RELEASE SAVEPOINT ${savepointName}`));
+      return { action: "imported", labelsCreated };
+    }
+  } catch (error) {
+    // Rollback to savepoint on error, continue with next file
+    try {
+      await tx.execute(sql.raw(`ROLLBACK TO SAVEPOINT ${savepointName}`));
+    } catch {
+      // Savepoint may already be released, ignore
+    }
+
+    try {
+      await tx.execute(sql.raw(`RELEASE SAVEPOINT ${savepointName}`));
+    } catch {
+      // Savepoint may already be released, ignore
+    }
+
+    logError(LogEventType.SERVICE_ERROR, {
+      event: "zip_file_import_failed",
+      projectId,
+      filePath: entry.filePath,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+
+    return { action: "failed", labelsCreated: 0 };
+  }
+}
+
+// ============================================================================
+// Symbol Promotion (inside transaction)
+// ============================================================================
+
+/**
+ * Promote extracted `define`/`default` symbols into the database tables
+ * (characters, variables, stats). Uses `onConflictDoNothing` so re-imports
+ * are no-ops and user edits are preserved.
+ */
+async function promoteSymbols(
+  tx: Transaction,
+  charactersByTag: Map<string, DetectedCharacterStatement>,
+  variablesByKey: Map<string, DetectedDefaultStatement>,
+  statsByKey: Map<string, DetectedDefaultStatement>,
+  projectId: string
+): Promise<void> {
+  const allCharacters = Array.from(charactersByTag.values());
+  const allVariables = Array.from(variablesByKey.values());
+  const allStats = Array.from(statsByKey.values());
+  if (
+    allCharacters.length > 0 ||
+    allVariables.length > 0 ||
+    allStats.length > 0
+  ) {
+    for (const c of allCharacters) {
+      await tx
+        .insert(characters)
+        .values({
+          projectId,
+          name: c.name ?? c.tag,
+          displayName: c.name ?? c.tag,
+          renpyTag: c.tag,
+          color: c.color || "#cfcfcf",
+          updatedAt: new Date(),
+        })
+        .onConflictDoNothing({
+          target: [characters.projectId, characters.renpyTag],
+        });
+    }
+    for (const v of allVariables) {
+      await tx
+        .insert(variables)
+        .values({
+          projectId,
+          key: v.key,
+        })
+        .onConflictDoNothing({
+          target: [variables.projectId, variables.key],
+        });
+    }
+    for (const s of allStats) {
+      const minValue = Math.round(Number.parseFloat(s.value)) || 0;
+      await tx
+        .insert(stats)
+        .values({
+          projectId,
+          key: s.key,
+          name: s.key,
+          minValue,
+          maxValue: 100,
+          updatedAt: new Date(),
+        })
+        .onConflictDoNothing({
+          target: [stats.projectId, stats.key],
+        });
+    }
   }
 }
 

--- a/apps/backend/src/services/zip-import.service.ts
+++ b/apps/backend/src/services/zip-import.service.ts
@@ -589,53 +589,62 @@ async function promoteSymbols(
   const allCharacters = Array.from(charactersByTag.values());
   const allVariables = Array.from(variablesByKey.values());
   const allStats = Array.from(statsByKey.values());
-  if (
-    allCharacters.length > 0 ||
-    allVariables.length > 0 ||
-    allStats.length > 0
-  ) {
-    for (const c of allCharacters) {
-      await tx
-        .insert(characters)
-        .values({
+  // Batch-insert each collection in a single round-trip per table.
+  // `onConflictDoNothing` preserves existing rows and user edits on
+  // re-import.
+  if (allCharacters.length > 0) {
+    await tx
+      .insert(characters)
+      .values(
+        allCharacters.map((c) => ({
           projectId,
           name: c.name ?? c.tag,
           displayName: c.name ?? c.tag,
           renpyTag: c.tag,
           color: c.color || "#cfcfcf",
           updatedAt: new Date(),
-        })
-        .onConflictDoNothing({
-          target: [characters.projectId, characters.renpyTag],
-        });
-    }
-    for (const v of allVariables) {
-      await tx
-        .insert(variables)
-        .values({
+        }))
+      )
+      .onConflictDoNothing({
+        target: [characters.projectId, characters.renpyTag],
+      });
+  }
+  if (allVariables.length > 0) {
+    await tx
+      .insert(variables)
+      .values(
+        allVariables.map((v) => ({
           projectId,
           key: v.key,
+        }))
+      )
+      .onConflictDoNothing({
+        target: [variables.projectId, variables.key],
+      });
+  }
+  if (allStats.length > 0) {
+    await tx
+      .insert(stats)
+      .values(
+        allStats.map((s) => {
+          // Clamp parsed value to the valid [0, 100] range so a
+          // `default some_stat = 999` line produces minValue=100
+          // rather than silently exceeding the hard-coded maxValue.
+          const parsed = Math.round(Number.parseFloat(s.value)) || 0;
+          const minValue = Math.max(0, Math.min(parsed, 100));
+          return {
+            projectId,
+            key: s.key,
+            name: s.key,
+            minValue,
+            maxValue: 100,
+            updatedAt: new Date(),
+          };
         })
-        .onConflictDoNothing({
-          target: [variables.projectId, variables.key],
-        });
-    }
-    for (const s of allStats) {
-      const minValue = Math.round(Number.parseFloat(s.value)) || 0;
-      await tx
-        .insert(stats)
-        .values({
-          projectId,
-          key: s.key,
-          name: s.key,
-          minValue,
-          maxValue: 100,
-          updatedAt: new Date(),
-        })
-        .onConflictDoNothing({
-          target: [stats.projectId, stats.key],
-        });
-    }
+      )
+      .onConflictDoNothing({
+        target: [stats.projectId, stats.key],
+      });
   }
 }
 


### PR DESCRIPTION
Closes #334

## What changed

### CL6 — Split `importZipFile` (340 lines → ~130 lines)
- Extracted `preProcessFiles()` — parse, hash, strip symbols
- Extracted `processFileInTransaction()` — per-file savepoint logic
- Extracted `promoteSymbols()` — char/variable/stat insert loop

### C4 — Fix separate-transaction risk
- Moved `updateIncomingJumpsForLabels` **inside** the main transaction so file inserts, symbol promotion, and incomingJumps all commit atomically (previously ran in a separate `db.transaction` that could fail independently)

### CL8 — Generic "first wins" helper
- Added `firstWinsInsert<K,V>()` to replace 3× repeated for-loops in `accumulateSymbols`

### CL7 — Savepoint name validation
- Added `/^[a-zA-Z_][a-zA-Z0-9_]*$/` validation matching `labels/sync.ts`

### Split — Guardrails extraction
- Extracted `MAX_*` constants + `ZipImportLimitError` into `zip-import-guardrails.ts`

### Oracle review fixes
- **must-fix:** Only accumulate symbols after per-file savepoint succeeds (was accumulating before label sync, leaking symbols from rolled-back files)
- **should-fix:** Use `sql.raw()` for savepoint DDL consistency with codebase
- **should-fix:** Added regression tests for savepoint rollback symbol isolation and transaction atomicity

## Verification
- `pnpm --filter @branchforge/backend test:unit` — 46 files, 898 tests ✅
- `pnpm test:integration` — 24 files, 429 tests ✅
- `pnpm --filter @branchforge/backend lint` ✅
- `pnpm typecheck` ✅
- Oracle strategic + security review ✅ (all findings addressed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ZIP import guardrails, including limits for upload size, extracted size, total `.rpy` files, and per-file size.
  * Added safer, client-friendly error handling for limit and processing failures.
* **Bug Fixes**
  * Prevented failed file imports from contributing promoted characters/variables/stats or label-derived jump updates to a successful overall import.
  * Improved ZIP import idempotency and per-file isolation, and clamped `default` stats values to the supported range.
* **Tests**
  * Expanded unit coverage for rollback behavior and label-jump synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->