### PR TITLE
fix: Tier C audit fixes for conflict-detection, character-linker, flow services (#343)

### DIFF
--- a/apps/backend/src/services/__tests__/resolve-jump-targets.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/resolve-jump-targets.service.unit.test.ts
@@ -39,11 +39,13 @@ describe("resolveJumpTargets", () => {
       label: "Choice 1",
       targetLabelId: "label-2",
       targetLabelName: "luna_scene_2",
+      targetType: "id",
     });
     expect(result[0].menuOptions[1]).toEqual({
       label: "Choice 2",
       targetLabelId: "label-1",
       targetLabelName: "start",
+      targetType: "id",
     });
     expect(result[0].menuOptions[2]).toEqual({
       label: "Choice 3",

--- a/apps/backend/src/services/__tests__/resolve-jump-targets.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/resolve-jump-targets.service.unit.test.ts
@@ -106,4 +106,60 @@ describe("resolveJumpTargets", () => {
 
     expect(result[0].menuOptions[0].targetLabelId).toBe("label-1");
   });
+
+  it("respects targetType name even when value is UUID-shaped", () => {
+    const allLabels = [
+      { id: "label-1", labelName: "550e8400-e29b-41d4-a716-446655440000" },
+    ];
+
+    const lines = [
+      {
+        id: "line-1",
+        menuOptions: [
+          {
+            label: "Named like UUID",
+            targetLabelId: "550e8400-e29b-41d4-a716-446655440000",
+            targetLabelName: "uuid-named-label",
+            targetType: "name" as const,
+          },
+        ],
+      },
+    ];
+
+    const result = resolveJumpTargets(lines, allLabels);
+
+    expect(result[0].menuOptions[0]).toEqual({
+      label: "Named like UUID",
+      targetLabelId: "label-1",
+      targetLabelName: "uuid-named-label",
+      targetType: "id",
+    });
+  });
+
+  it("preserves already-resolved target with targetType id", () => {
+    const allLabels = [{ id: "label-1", labelName: "some-label" }];
+
+    const lines = [
+      {
+        id: "line-1",
+        menuOptions: [
+          {
+            label: "Already ID",
+            targetLabelId: "550e8400-e29b-41d4-a716-446655440000",
+            targetLabelName: "some-label",
+            targetType: "id" as const,
+          },
+        ],
+      },
+    ];
+
+    const result = resolveJumpTargets(lines, allLabels);
+
+    expect(result[0].menuOptions[0]).toEqual({
+      label: "Already ID",
+      targetLabelId: "550e8400-e29b-41d4-a716-446655440000",
+      targetLabelName: "some-label",
+      targetType: "id",
+    });
+  });
 });

--- a/apps/backend/src/services/character-linker.service.ts
+++ b/apps/backend/src/services/character-linker.service.ts
@@ -9,6 +9,7 @@
  */
 
 import { getDb } from "../db/index.js";
+import type { Db } from "../db/index.js";
 import type { Transaction } from "../db/types.js";
 import {
   labelLines,
@@ -21,6 +22,9 @@ import {
   parseRPYFileWithLabels,
   convertToBranchForgeFormatFromLabels,
 } from "./rpy-parser.service.js";
+
+/** Union type for database connection (regular or transactional) */
+type DatabaseConnection = Db | Transaction;
 
 /**
  * Conflict information for speaker linking
@@ -63,40 +67,20 @@ class CharacterLinkerService {
   }
 
   /**
-   * Link speakers to lines for labels in a project
-   *
-   * This method parses the original RPY files to extract speaker information,
-   * then links speakers to label_lines by matching character tags.
-   *
-   * Process:
-   * 1. Get all labels and their project_files
-   * 2. Parse RPY files to extract dialogue entries with speakers
-   * 3. Match speakers to characters by renpyTag
-   * 4. Update label_lines.speakerId for each dialogue line
-   *
-   * @param tx - Optional transaction. When provided, all DB operations use
-   *   this transaction instead of starting a new connection, allowing the
-   *   caller to wrap speaker linking in an atomic unit of work.
+   * Build character lookup maps from project characters
    */
-  async linkSpeakersToLines(
+  private async buildCharacterMaps(
     projectId: string,
-    labelIds: string[],
-    excludedTags: Set<string> = new Set(),
-    tx?: Transaction
-  ): Promise<SpeakerLinkResult> {
-    const db = tx ?? getDb();
-
-    if (labelIds.length === 0) {
-      return { linked: 0, unmatched: [], conflicts: [] };
-    }
-
-    // Get all characters for this project
+    db: DatabaseConnection
+  ): Promise<{
+    characterByTag: Map<string, string>;
+    characterByTagLower: Map<string, string>;
+  }> {
     const projectCharacters = await db
       .select()
       .from(characters)
       .where(eq(characters.projectId, projectId));
 
-    // Build character map by tag for fast lookups
     const characterByTag = new Map<string, string>();
     const characterByTagLower = new Map<string, string>();
 
@@ -105,7 +89,13 @@ class CharacterLinkerService {
       characterByTagLower.set(char.renpyTag.toLowerCase(), char.id);
     }
 
-    // Get all labels with their project files
+    return { characterByTag, characterByTagLower };
+  }
+
+  /**
+   * Load labels with their project files and group dialogue lines by label
+   */
+  private async loadLabelsAndLines(labelIds: string[], db: DatabaseConnection) {
     const labelsWithFiles = await db
       .select({
         labelId: labels.id,
@@ -140,13 +130,20 @@ class CharacterLinkerService {
       }
     }
 
-    // Track unmatched speaker tags and their occurrence counts
-    const unmatchedTagCounts = new Map<string, number>();
-    let linkedCount = 0;
+    return { labelsWithFiles, linesByLabel };
+  }
 
-    // Build updates in batch
-    const updates: Array<{ lineId: string; speakerId: string | null }> = [];
-
+  /**
+   * Fetch unique project files in a single query and parse each once
+   */
+  private async loadAndParseProjectFiles(
+    labelsWithFiles: Array<{
+      labelId: string;
+      labelName: string | null;
+      projectFileId: string | null;
+    }>,
+    db: DatabaseConnection
+  ) {
     // Collect unique project file IDs to avoid N+1 queries
     const uniqueProjectFileIds = Array.from(
       new Set(
@@ -192,6 +189,46 @@ class CharacterLinkerService {
       parsedFileCache.set(fileId, parsed);
     }
 
+    return { projectFileMap, parsedFileCache };
+  }
+
+  /**
+   * Process each label: match speakers to characters using parsed file data
+   */
+  private async processLabelSpeakers(
+    labelsWithFiles: Array<{
+      labelId: string;
+      labelName: string | null;
+      projectFileId: string | null;
+    }>,
+    projectFileMap: Map<string, { content: string; filePath: string }>,
+    parsedFileCache: Map<string, ReturnType<typeof parseRPYFileWithLabels>>,
+    linesByLabel: Map<
+      string,
+      Array<{
+        id: string;
+        labelId: string;
+        rpyLineNumber: number | null;
+        contentType: string;
+        speakerId: string | null;
+      }>
+    >,
+    characterByTag: Map<string, string>,
+    characterByTagLower: Map<string, string>,
+    excludedTags: Set<string>
+  ) {
+    // Track unmatched speaker tags and their occurrence counts
+    const unmatchedTagCounts = new Map<string, number>();
+    let linkedCount = 0;
+    const updates: Array<{ lineId: string; speakerId: string | null }> = [];
+
+    // Cache conversion results per (fileId, labelName) to avoid redundant
+    // calls to convertToBranchForgeFormatFromLabels on the same parsed data.
+    const conversionCache = new Map<
+      string,
+      ReturnType<typeof convertToBranchForgeFormatFromLabels>
+    >();
+
     // Process each label
     for (const labelInfo of labelsWithFiles) {
       if (!labelInfo.projectFileId || !labelInfo.labelName) continue;
@@ -208,12 +245,17 @@ class CharacterLinkerService {
       );
       if (!parsedLabel) continue;
 
-      // Convert to BranchForge format to get entries
-      const labelData = convertToBranchForgeFormatFromLabels(
-        parsed,
-        labelInfo.labelName,
-        projectFileData.content
-      );
+      // Convert to BranchForge format to get entries (with caching)
+      const cacheKey = `${labelInfo.projectFileId}:${labelInfo.labelName}`;
+      let labelData = conversionCache.get(cacheKey);
+      if (!labelData) {
+        labelData = convertToBranchForgeFormatFromLabels(
+          parsed,
+          labelInfo.labelName,
+          projectFileData.content
+        );
+        conversionCache.set(cacheKey, labelData);
+      }
 
       // Build a map of RPY line number -> speaker for this label
       const speakerByLineNumber = new Map<number, string | null>();
@@ -277,31 +319,44 @@ class CharacterLinkerService {
       }
     }
 
-    // Apply updates in batch - group by speakerId to avoid N+1 queries
-    if (updates.length > 0) {
-      // Group updates by speakerId (including null/unmatched)
-      const updatesBySpeakerId = new Map<string | null, string[]>();
-      for (const update of updates) {
-        const speakerId = update.speakerId;
-        if (!updatesBySpeakerId.has(speakerId)) {
-          updatesBySpeakerId.set(speakerId, []);
-        }
-        updatesBySpeakerId.get(speakerId)!.push(update.lineId);
-      }
+    return { updates, linkedCount, unmatchedTagCounts };
+  }
 
-      // Execute one UPDATE per distinct speakerId in parallel
-      const updatePromises = Array.from(updatesBySpeakerId.entries()).map(
-        ([speakerId, lineIds]) =>
-          db
-            .update(labelLines)
-            .set({ speakerId, updatedAt: new Date() })
-            .where(inArray(labelLines.id, lineIds))
+  /**
+   * Apply batched speakerId updates using a single CASE-based UPDATE
+   */
+  private async applySpeakerUpdates(
+    updates: Array<{ lineId: string; speakerId: string | null }>,
+    db: DatabaseConnection
+  ): Promise<void> {
+    if (updates.length === 0) return;
+
+    // Build CASE expression for single bulk UPDATE
+    const caseClauses = sql.join(
+      updates.map((u) => sql`WHEN ${u.lineId} THEN ${u.speakerId}`),
+      sql` `
+    );
+    await db
+      .update(labelLines)
+      .set({
+        speakerId: sql`CASE ${labelLines.id} ${caseClauses} END`,
+        updatedAt: new Date(),
+      })
+      .where(
+        inArray(
+          labelLines.id,
+          updates.map((u) => u.lineId)
+        )
       );
+  }
 
-      await Promise.all(updatePromises);
-    }
-
-    // Build conflict info for unmatched tags
+  /**
+   * Build the SpeakerLinkResult from unmatched tags and linked count
+   */
+  private buildLinkResult(
+    unmatchedTagCounts: Map<string, number>,
+    linkedCount: number
+  ): SpeakerLinkResult {
     const conflicts: SpeakerLinkConflict[] = Array.from(
       unmatchedTagCounts.keys()
     ).map((speakerTag) => ({
@@ -315,6 +370,56 @@ class CharacterLinkerService {
       unmatched: Array.from(unmatchedTagCounts.keys()),
       conflicts,
     };
+  }
+
+  /**
+   * Link speakers to lines for labels in a project
+   *
+   * This method parses the original RPY files to extract speaker information,
+   * then links speakers to label_lines by matching character tags.
+   *
+   * Process:
+   * 1. Get all labels and their project_files
+   * 2. Parse RPY files to extract dialogue entries with speakers
+   * 3. Match speakers to characters by renpyTag
+   * 4. Update label_lines.speakerId for each dialogue line
+   *
+   * @param tx - Optional transaction. When provided, all DB operations use
+   *   this transaction instead of starting a new connection, allowing the
+   *   caller to wrap speaker linking in an atomic unit of work.
+   */
+  async linkSpeakersToLines(
+    projectId: string,
+    labelIds: string[],
+    excludedTags: Set<string> = new Set(),
+    tx?: Transaction
+  ): Promise<SpeakerLinkResult> {
+    const db = tx ?? getDb();
+
+    if (labelIds.length === 0) {
+      return { linked: 0, unmatched: [], conflicts: [] };
+    }
+
+    const { characterByTag, characterByTagLower } =
+      await this.buildCharacterMaps(projectId, db);
+    const { labelsWithFiles, linesByLabel } = await this.loadLabelsAndLines(
+      labelIds,
+      db
+    );
+    const { projectFileMap, parsedFileCache } =
+      await this.loadAndParseProjectFiles(labelsWithFiles, db);
+    const { updates, linkedCount, unmatchedTagCounts } =
+      await this.processLabelSpeakers(
+        labelsWithFiles,
+        projectFileMap,
+        parsedFileCache,
+        linesByLabel,
+        characterByTag,
+        characterByTagLower,
+        excludedTags
+      );
+    await this.applySpeakerUpdates(updates, db);
+    return this.buildLinkResult(unmatchedTagCounts, linkedCount);
   }
 
   /**

--- a/apps/backend/src/services/character-linker.service.ts
+++ b/apps/backend/src/services/character-linker.service.ts
@@ -331,23 +331,27 @@ class CharacterLinkerService {
   ): Promise<void> {
     if (updates.length === 0) return;
 
-    // Build CASE expression for single bulk UPDATE
-    const caseClauses = sql.join(
-      updates.map((u) => sql`WHEN ${u.lineId} THEN ${u.speakerId}`),
-      sql` `
-    );
-    await db
-      .update(labelLines)
-      .set({
-        speakerId: sql`CASE ${labelLines.id} ${caseClauses} END`,
-        updatedAt: new Date(),
-      })
-      .where(
-        inArray(
-          labelLines.id,
-          updates.map((u) => u.lineId)
-        )
+    // Chunk to stay under PostgreSQL parameter limit (~65535)
+    const CHUNK_SIZE = 2000;
+    for (let i = 0; i < updates.length; i += CHUNK_SIZE) {
+      const chunk = updates.slice(i, i + CHUNK_SIZE);
+      const caseClauses = sql.join(
+        chunk.map((u) => sql`WHEN ${u.lineId} THEN ${u.speakerId}`),
+        sql` `
       );
+      await db
+        .update(labelLines)
+        .set({
+          speakerId: sql`CASE ${labelLines.id} ${caseClauses} END`,
+          updatedAt: new Date(),
+        })
+        .where(
+          inArray(
+            labelLines.id,
+            chunk.map((u) => u.lineId)
+          )
+        );
+    }
   }
 
   /**
@@ -400,12 +404,13 @@ class CharacterLinkerService {
       return { linked: 0, unmatched: [], conflicts: [] };
     }
 
-    const { characterByTag, characterByTagLower } =
-      await this.buildCharacterMaps(projectId, db);
-    const { labelsWithFiles, linesByLabel } = await this.loadLabelsAndLines(
-      labelIds,
-      db
-    );
+    const [
+      { characterByTag, characterByTagLower },
+      { labelsWithFiles, linesByLabel },
+    ] = await Promise.all([
+      this.buildCharacterMaps(projectId, db),
+      this.loadLabelsAndLines(labelIds, db),
+    ]);
     const { projectFileMap, parsedFileCache } =
       await this.loadAndParseProjectFiles(labelsWithFiles, db);
     const { updates, linkedCount, unmatchedTagCounts } =

--- a/apps/backend/src/services/conflict-detection.service.ts
+++ b/apps/backend/src/services/conflict-detection.service.ts
@@ -17,12 +17,7 @@ import { eq, and, inArray, asc, isNull } from "drizzle-orm";
 import { getFileContent } from "./gitlab/gitlab-repository.service.js";
 import { parseRPYFileWithLabels } from "./rpy-parser.service.js";
 import { ConcurrencyLimiter } from "./concurrency-limiter.js";
-
-// ============================================================================
-// Shared Concurrency Limiter
-// ============================================================================
-
-const sharedLimiter = new ConcurrencyLimiter(5);
+import { HttpError } from "../middleware/error-handler.middleware.js";
 
 // ============================================================================
 // Types
@@ -139,7 +134,7 @@ export async function detectConflicts(
       );
 
     // Fetch file contents in parallel with concurrency limit
-    const limiter = sharedLimiter;
+    const limiter = new ConcurrencyLimiter(5);
     const fileFetchResults = await Promise.allSettled(
       files.map((projectFile) =>
         limiter.run(async () => {
@@ -157,6 +152,15 @@ export async function detectConflicts(
     // Track if any file fetch succeeded and capture first error
     let anySuccess = false;
     let firstError: Error | null = null;
+
+    // Build a Map for O(1) local scene lookup by (projectFileId, labelName).
+    // Built once before the per-file loop — keyed by (fileId, labelName).
+    const localSceneMap = new Map<string, (typeof localScenes)[number]>();
+    for (const s of localScenes) {
+      if (s.projectFileId && s.labelName) {
+        localSceneMap.set(`${s.projectFileId}:${s.labelName}`, s);
+      }
+    }
 
     // Process fetched results, handling errors per-file
     for (const result of fileFetchResults) {
@@ -193,9 +197,8 @@ export async function detectConflicts(
           });
         } else {
           // Compare local and remote content
-          const localScene = localScenes.find(
-            (s) =>
-              s.projectFileId === projectFile.id && s.labelName === label.label
+          const localScene = localSceneMap.get(
+            `${projectFile.id}:${label.label}`
           );
           if (localScene) {
             // Use pre-fetched scene lines from map to avoid N+1 queries
@@ -260,6 +263,17 @@ export async function detectConflicts(
       conflicts,
     };
   } catch (error) {
+    // Re-throw HTTP errors so the error-handler middleware can produce
+    // proper status codes. Also re-throw programming errors (TypeError,
+    // ReferenceError) that should never be silently swallowed.
+    if (
+      error instanceof HttpError ||
+      error instanceof TypeError ||
+      error instanceof ReferenceError
+    ) {
+      throw error;
+    }
+    // Catch only true operational errors (DB failures, API errors, etc.)
     return {
       hasConflicts: false,
       conflicts: [],

--- a/apps/backend/src/services/conflict-detection.service.ts
+++ b/apps/backend/src/services/conflict-detection.service.ts
@@ -165,12 +165,23 @@ export async function detectConflicts(
     // Process fetched results, handling errors per-file
     for (const result of fileFetchResults) {
       if (result.status === "rejected") {
-        // Capture the first error for reporting
+        // Re-throw HTTP errors so the error-handler middleware can produce
+        // proper status codes. Also re-throw programming errors (TypeError,
+        // ReferenceError) that should never be silently swallowed.
+        const reason =
+          result.reason instanceof Error
+            ? result.reason
+            : new Error(String(result.reason));
+        if (
+          reason instanceof HttpError ||
+          reason instanceof TypeError ||
+          reason instanceof ReferenceError
+        ) {
+          throw reason;
+        }
+        // Capture the first operational error for reporting
         if (!firstError) {
-          firstError =
-            result.reason instanceof Error
-              ? result.reason
-              : new Error(String(result.reason));
+          firstError = reason;
         }
         continue;
       }

--- a/apps/backend/src/services/flow.service.ts
+++ b/apps/backend/src/services/flow.service.ts
@@ -27,6 +27,9 @@ import { requireProjectAccess } from "./authz.service.js";
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/** Type discriminator for resolving targetLabelId as UUID or label name. */
+type TargetType = "id" | "name";
+
 /**
  * Regex for matching jump statements in label line content
  */
@@ -114,6 +117,7 @@ export async function getFlowGraph(
       label: string;
       targetLabelId: string;
       targetLabelName: string;
+      targetType?: "id" | "name";
       conditionFlags?: string[];
       effects?: {
         stats?: Record<string, number>;
@@ -149,12 +153,22 @@ export async function getFlowGraph(
     `${source}|${target}`;
 
   // Resolve target label ID (UUID or name)
-  const resolveTargetId = (targetLabelId: string): string | null => {
-    if (UUID_REGEX.test(targetLabelId)) {
-      // It's already a UUID - check if it's in our project labels
+  const resolveTargetId = (
+    targetLabelId: string,
+    targetType?: TargetType
+  ): string | null => {
+    // Use explicit type discriminator when available
+    if (targetType === "id") {
       return labelIdSet.has(targetLabelId) ? targetLabelId : null;
     }
-    // It's a label name - resolve via map
+    if (targetType === "name") {
+      return labelNameToId.get(targetLabelId.toLowerCase()) ?? null;
+    }
+    // Fallback: guess using UUID regex for backward compatibility
+    // with existing menuOptions that lack the targetType field.
+    if (UUID_REGEX.test(targetLabelId)) {
+      return labelIdSet.has(targetLabelId) ? targetLabelId : null;
+    }
     return labelNameToId.get(targetLabelId.toLowerCase()) ?? null;
   };
 
@@ -162,7 +176,10 @@ export async function getFlowGraph(
   for (const line of linesRows) {
     if (line.contentType === "MENU" && line.menuOptions) {
       for (const option of line.menuOptions) {
-        const targetId = resolveTargetId(option.targetLabelId);
+        const targetId = resolveTargetId(
+          option.targetLabelId,
+          option.targetType
+        );
         if (targetId) {
           const key = edgeKey(line.labelId, targetId);
           if (!existingEdgeKeys.has(key)) {
@@ -259,9 +276,8 @@ export async function getFlowGraph(
       }
       set.add(line.speakerId);
     }
-    // Count words from text-bearing line types. The `word_count` column
-    // on label_lines has no database trigger to populate it, so we compute
-    // from the `content` field at query time.
+    // Count words from text-bearing line types. Word counts are computed
+    // from the `content` field at query time — there is no persisted column.
     if (line.contentType === "DIALOGUE" || line.contentType === "NARRATION") {
       const trimmed = line.content?.trim();
       const words = trimmed ? trimmed.split(/\s+/).length : 0;

--- a/apps/backend/src/services/labels/jump-targets.ts
+++ b/apps/backend/src/services/labels/jump-targets.ts
@@ -24,6 +24,7 @@ export function resolveJumpTargets<
       label: string;
       targetLabelId: string;
       targetLabelName: string;
+      targetType?: "id" | "name";
       conditionFlags?: string[];
       effects?: {
         stats?: Record<string, number>;
@@ -67,13 +68,15 @@ export function resolveJumpTargets<
         if (!choice.targetLabelId || choice.targetLabelId === "") {
           return { ...choice, targetLabelId: "" };
         }
-        // Already a UUID, preserve it
+        // Already a UUID, mark as resolved ID
         if (UUID_REGEX.test(choice.targetLabelId)) {
-          return choice;
+          return { ...choice, targetType: "id" };
         }
+        const resolvedId = resolvedMap[choice.targetLabelId] ?? "";
         return {
           ...choice,
-          targetLabelId: resolvedMap[choice.targetLabelId] ?? "",
+          targetLabelId: resolvedId,
+          ...(resolvedId ? ({ targetType: "id" } as const) : {}),
         };
       }),
     };

--- a/apps/backend/src/services/labels/jump-targets.ts
+++ b/apps/backend/src/services/labels/jump-targets.ts
@@ -45,7 +45,8 @@ export function resolveJumpTargets<
         if (
           choice.targetLabelId &&
           choice.targetLabelId !== "" &&
-          !UUID_REGEX.test(choice.targetLabelId)
+          (choice.targetType === "name" ||
+            !UUID_REGEX.test(choice.targetLabelId))
         ) {
           targetNames.push(choice.targetLabelId);
         }
@@ -68,7 +69,30 @@ export function resolveJumpTargets<
         if (!choice.targetLabelId || choice.targetLabelId === "") {
           return { ...choice, targetLabelId: "" };
         }
-        // Already a UUID, mark as resolved ID
+        // Explicit discriminator: targetType tells us how to interpret the value
+        if (choice.targetType === "name") {
+          // Treat as a label name regardless of UUID shape
+          const resolvedId = resolvedMap[choice.targetLabelId] ?? "";
+          return {
+            ...choice,
+            targetLabelId: resolvedId,
+            ...(resolvedId ? ({ targetType: "id" } as const) : {}),
+          };
+        }
+        if (choice.targetType === "id") {
+          // Treat as an ID — validate it's a UUID
+          if (UUID_REGEX.test(choice.targetLabelId)) {
+            return { ...choice };
+          }
+          // Non-UUID "id" — try resolving as name as fallback
+          const resolvedId = resolvedMap[choice.targetLabelId] ?? "";
+          return {
+            ...choice,
+            targetLabelId: resolvedId,
+            ...(resolvedId ? ({ targetType: "id" } as const) : {}),
+          };
+        }
+        // No explicit targetType — use UUID shape heuristic
         if (UUID_REGEX.test(choice.targetLabelId)) {
           return { ...choice, targetType: "id" };
         }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -503,6 +503,8 @@ export interface LabelLine {
     label: string;
     targetLabelId: string;
     targetLabelName: string;
+    /** Discriminator for UUID vs label-name resolution. Set to "id" after resolution. */
+    targetType?: "id" | "name";
     conditionFlags?: string[];
     effects?: {
       stats?: Record<string, number>;


### PR DESCRIPTION
Closes #343

## What changed

Targeted bug-fix/improvement pass on three services flagged in a Tier C audit.

### conflict-detection.service.ts (3 fixes)
- **Per-call concurrency limiter** — moved from module-level (shared across all calls) to per-call instantiation, so User A's conflict check no longer throttles User B's
- **O(1) Map lookup** — replaced O(n²) `.find()` with `Map.get()` keyed by `(fileId, labelName)`, built once before the per-file loop
- **Narrowed error catch** — re-throws `HttpError` (so middleware produces proper status codes), `TypeError`, and `ReferenceError` (programming bugs); only catches true operational errors

### character-linker.service.ts (3 improvements)
- **Conversion cache** — caches `convertToBranchForgeFormatFromLabels` results per `(fileId, labelName)` to avoid redundant full-parse conversions
- **Extracted helpers** — split `linkSpeakersToLines` (~230 lines) into 6 focused private methods: `buildCharacterMaps`, `loadLabelsAndLines`, `loadAndParseProjectFiles`, `processLabelSpeakers`, `applySpeakerUpdates`, `buildLinkResult`
- **Single bulk UPDATE** — replaced N per-speakerId UPDATEs with one `CASE WHEN ... THEN ... END` query

### flow.service.ts (2 fixes)
- **Type discriminator** — added `TargetType` (`"id" | "name"`) to `resolveTargetId`; uses explicit discriminator when available, falls back to UUID regex for backward compatibility
- **Fixed misleading comment** — removed reference to non-existent `word_count` column

### Supporting changes
- Added optional `targetType?: "id" | "name"` to `menuOption` type in shared types
- `resolveJumpTargets` now sets `targetType: "id"` on resolved menu options (only when resolution succeeds)
- Updated `resolve-jump-targets.service.unit.test.ts` expectations

## Verification
- Unit tests: **899/899** passing (46 files)
- Integration tests: **429/429** passing (24 files)
- Lint: clean
- Typecheck: clean (all 4 packages)

## @oracle review
Delegated per AGENTS.md (security-sensitive code, >200 line diff, touches error-handling layer). All must-fix and should-fix findings addressed:
- **Must-fix**: catch block now also re-throws `TypeError`/`ReferenceError` (programming bugs) beyond just `HttpError`
- **Should-fix**: `localSceneMap` moved outside the per-file loop (was being rebuilt redundantly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menu choice targets can now be resolved explicitly as either label IDs or label names via a new `targetType` discriminator.
  * Flow graph menu target handling now supports ID-vs-name resolution.

* **Bug Fixes**
  * Jump target resolution now preserves/sets `targetType` correctly and clears unresolved targets consistently.
  * Conflict detection performance and error handling were improved for faster, correct per-invocation behavior.
  * Speaker linking was optimized and updated using bulk updates for improved accuracy.

* **Tests**
  * Expanded unit coverage for `targetType`-dependent jump target resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->