### PR TITLE
fix: resolve react-doctor findings for cascading-setState, index keys, and toSorted

### DIFF
--- a/apps/frontend/src/components/write-mode/FormattedCondition.tsx
+++ b/apps/frontend/src/components/write-mode/FormattedCondition.tsx
@@ -11,11 +11,11 @@ export function FormattedCondition({
 }: FormattedConditionProps) {
   return (
     <>
-      {parts.map((part, i) =>
+      {parts.map((part) =>
         part.type === "keyword" ? (
-          <span key={i}>{part.text}</span>
+          <span key={part.id}>{part.text}</span>
         ) : (
-          <span key={i} className={valueClassName ?? "font-mono"}>
+          <span key={part.id} className={valueClassName ?? "font-mono"}>
             {part.text}
           </span>
         )

--- a/apps/frontend/src/components/write-mode/ProseEditor/useProseEditorState.ts
+++ b/apps/frontend/src/components/write-mode/ProseEditor/useProseEditorState.ts
@@ -118,9 +118,17 @@ export function useProseEditorState({
 
   // Hover state for focus mode dimming
   const [isBottomBarHovered, setIsBottomBarHovered] = useState(false);
-  const [entries, setEntries] = useState<DialogueEntry[]>(() =>
-    convertLabelLinesToEntries(activeLabel)
-  );
+
+  // entries + initialWordCount share one state object so the label-switch
+  // effect can update both in a single setState (avoids cascading renders).
+  const [content, setContent] = useState<{
+    entries: DialogueEntry[];
+    initialWordCount: number;
+  }>(() => ({
+    entries: convertLabelLinesToEntries(activeLabel),
+    initialWordCount: 0,
+  }));
+  const { entries, initialWordCount } = content;
   const [internalLayoutMode, setInternalLayoutMode] =
     useLocalStorage<LineLayoutMode>(LINE_LAYOUT_STORAGE_KEY, "inline", {
       serializer: (value) => value,
@@ -155,9 +163,6 @@ export function useProseEditorState({
   const prevEntriesRef = useRef<DialogueEntry[]>([]);
   const isInitialMountRef = useRef(true);
 
-  // Track initial word count for the current label to calculate real-time progress
-  const [initialWordCount, setInitialWordCount] = useState<number>(0);
-
   useEffect(() => {
     entriesRef.current = entries;
   }, [entries]);
@@ -169,7 +174,7 @@ export function useProseEditorState({
   const handleInMemoryHistoryChange = useCallback(
     (nextEntries: DialogueEntry[]) => {
       isExternalUpdateRef.current = true;
-      setEntries(nextEntries);
+      setContent((prev) => ({ ...prev, entries: nextEntries }));
       // Propagate undo/redo to parent so autosave picks up the change
       onChangeRef.current(nextEntries);
     },
@@ -296,7 +301,7 @@ export function useProseEditorState({
       },
     ];
     recordImmediateHistorySnapshot(newEntries);
-    setEntries(newEntries);
+    setContent((prev) => ({ ...prev, entries: newEntries }));
   }, [characters, recordImmediateHistorySnapshot]);
 
   // Process pending immediate snapshots after entries have been updated
@@ -361,17 +366,9 @@ export function useProseEditorState({
     }
 
     const newEntries = convertLabelLinesToEntries(activeLabel);
-
-    // Calculate initial word count for this label (only on first load, not on subsequent updates)
-    if (hasSwitchedLabel) {
-      setInitialWordCount(countWordsFromEntries(newEntries));
-    } else {
-      const newWordCount = countWordsFromEntries(newEntries);
-
-      // Update baseline to latest persisted content from server.
-      // Any unsaved local edits remain represented by (wordCount - initialWordCount).
-      setInitialWordCount(newWordCount);
-    }
+    // Update baseline to latest persisted content from server.
+    // Any unsaved local edits remain represented by (wordCount - initialWordCount).
+    const newWordCount = countWordsFromEntries(newEntries);
 
     flushPendingTextHistory();
 
@@ -379,22 +376,29 @@ export function useProseEditorState({
       // Always reset undo history when switching labels, even if content is identical
       // This prevents undo history of one label bleeding into another
       isExternalUpdateRef.current = true;
-      setEntries(newEntries);
+      setContent({ entries: newEntries, initialWordCount: newWordCount });
       inMemoryUndo.clear(cloneEntries(newEntries));
     } else {
-      // Only update state if content actually changed (handles external updates)
-      if (areDialogueEntriesEqual(entriesRef.current, newEntries)) {
-        return;
-      }
+      // Only update entries if content actually changed (handles external updates).
+      // Still refresh initialWordCount so the session delta stays accurate.
+      const entriesUnchanged = areDialogueEntriesEqual(
+        entriesRef.current,
+        newEntries
+      );
 
       // Ignore server echo updates while a textarea is focused to avoid remount-driven blur.
       // Local editor state remains the source of truth during active typing.
-      if (isEditorTextareaFocused()) {
+      if (entriesUnchanged || isEditorTextareaFocused()) {
+        setContent((prev) =>
+          prev.initialWordCount === newWordCount
+            ? prev
+            : { ...prev, initialWordCount: newWordCount }
+        );
         return;
       }
 
       isExternalUpdateRef.current = true;
-      setEntries(newEntries);
+      setContent({ entries: newEntries, initialWordCount: newWordCount });
       inMemoryUndo.updatePresent(cloneEntries(newEntries));
     }
 
@@ -439,10 +443,10 @@ export function useProseEditorState({
 
   const handleEntryChange = useCallback(
     (index: number, updatedEntry: DialogueEntry) => {
-      setEntries((prev) => {
-        const newEntries = [...prev];
+      setContent((prev) => {
+        const newEntries = [...prev.entries];
         newEntries[index] = updatedEntry;
-        return newEntries;
+        return { ...prev, entries: newEntries };
       });
     },
     []
@@ -450,13 +454,14 @@ export function useProseEditorState({
 
   const handleAddLine = useCallback(
     (index: number) => {
-      setEntries((prev) => {
-        const newEntries = [...prev];
-        const currentEntry = prev[index];
+      setContent((prev) => {
+        const entries = prev.entries;
+        const newEntries = [...entries];
+        const currentEntry = entries[index];
         // Always insert dialogue/narration. Never create CHOICE rows here —
         // Script Mode owns menu structure, and empty choice labels fail API
         // validation. Enter on a menu prompt or choice jumps past the block.
-        const insertAt = findDialogueInsertIndex(prev, index);
+        const insertAt = findDialogueInsertIndex(entries, index);
         const speakerId =
           currentEntry?.contentType === "CHOICE"
             ? null
@@ -474,7 +479,7 @@ export function useProseEditorState({
         // Queue focus operation
         pendingFocusRef.current = { index: insertAt, scrollIntoView: true };
 
-        return newEntries;
+        return { ...prev, entries: newEntries };
       });
     },
     [recordImmediateHistorySnapshot]
@@ -482,8 +487,8 @@ export function useProseEditorState({
 
   const handleDeleteLine = useCallback(
     (index: number) => {
-      setEntries((prev) => {
-        const newEntries = prev.filter((_, i) => i !== index);
+      setContent((prev) => {
+        const newEntries = prev.entries.filter((_, i) => i !== index);
         const focusIndex = index > 0 ? index - 1 : 0;
 
         // Record history snapshot
@@ -495,7 +500,7 @@ export function useProseEditorState({
           scrollIntoView: false,
         };
 
-        return newEntries;
+        return { ...prev, entries: newEntries };
       });
     },
     [recordImmediateHistorySnapshot]
@@ -504,14 +509,14 @@ export function useProseEditorState({
   const handleMoveUp = useCallback(
     (index: number) => {
       if (index === 0) return;
-      setEntries((prev) => {
-        const newEntries = [...prev];
+      setContent((prev) => {
+        const newEntries = [...prev.entries];
         [newEntries[index - 1], newEntries[index]] = [
           newEntries[index],
           newEntries[index - 1],
         ];
         recordImmediateHistorySnapshot(newEntries);
-        return newEntries;
+        return { ...prev, entries: newEntries };
       });
     },
     [recordImmediateHistorySnapshot]
@@ -519,15 +524,15 @@ export function useProseEditorState({
 
   const handleMoveDown = useCallback(
     (index: number) => {
-      setEntries((prev) => {
-        if (index >= prev.length - 1) return prev;
-        const newEntries = [...prev];
+      setContent((prev) => {
+        if (index >= prev.entries.length - 1) return prev;
+        const newEntries = [...prev.entries];
         [newEntries[index], newEntries[index + 1]] = [
           newEntries[index + 1],
           newEntries[index],
         ];
         recordImmediateHistorySnapshot(newEntries);
-        return newEntries;
+        return { ...prev, entries: newEntries };
       });
     },
     [recordImmediateHistorySnapshot]

--- a/apps/frontend/src/components/write-mode/ProseEditor/useProseEditorState.ts
+++ b/apps/frontend/src/components/write-mode/ProseEditor/useProseEditorState.ts
@@ -454,54 +454,46 @@ export function useProseEditorState({
 
   const handleAddLine = useCallback(
     (index: number) => {
-      setContent((prev) => {
-        const entries = prev.entries;
-        const newEntries = [...entries];
-        const currentEntry = entries[index];
-        // Always insert dialogue/narration. Never create CHOICE rows here —
-        // Script Mode owns menu structure, and empty choice labels fail API
-        // validation. Enter on a menu prompt or choice jumps past the block.
-        const insertAt = findDialogueInsertIndex(entries, index);
-        const speakerId =
-          currentEntry?.contentType === "CHOICE"
-            ? null
-            : (currentEntry?.speakerId ?? null);
-        const newEntry: DialogueEntry = {
-          id: crypto.randomUUID(),
-          speakerId,
-          text: "",
-        };
-        newEntries.splice(insertAt, 0, newEntry);
+      // Compute next entries outside the updater so history/focus side
+      // effects stay pure (react-doctor/no-impure-state-updater).
+      const currentEntries = entriesRef.current;
+      const newEntries = [...currentEntries];
+      const currentEntry = currentEntries[index];
+      // Always insert dialogue/narration. Never create CHOICE rows here —
+      // Script Mode owns menu structure, and empty choice labels fail API
+      // validation. Enter on a menu prompt or choice jumps past the block.
+      const insertAt = findDialogueInsertIndex(currentEntries, index);
+      const speakerId =
+        currentEntry?.contentType === "CHOICE"
+          ? null
+          : (currentEntry?.speakerId ?? null);
+      const newEntry: DialogueEntry = {
+        id: crypto.randomUUID(),
+        speakerId,
+        text: "",
+      };
+      newEntries.splice(insertAt, 0, newEntry);
 
-        // Record history snapshot
-        recordImmediateHistorySnapshot(newEntries);
-
-        // Queue focus operation
-        pendingFocusRef.current = { index: insertAt, scrollIntoView: true };
-
-        return { ...prev, entries: newEntries };
-      });
+      recordImmediateHistorySnapshot(newEntries);
+      pendingFocusRef.current = { index: insertAt, scrollIntoView: true };
+      entriesRef.current = newEntries;
+      setContent((prev) => ({ ...prev, entries: newEntries }));
     },
     [recordImmediateHistorySnapshot]
   );
 
   const handleDeleteLine = useCallback(
     (index: number) => {
-      setContent((prev) => {
-        const newEntries = prev.entries.filter((_, i) => i !== index);
-        const focusIndex = index > 0 ? index - 1 : 0;
+      const newEntries = entriesRef.current.filter((_, i) => i !== index);
+      const focusIndex = index > 0 ? index - 1 : 0;
 
-        // Record history snapshot
-        recordImmediateHistorySnapshot(newEntries);
-
-        // Queue focus operation
-        pendingFocusRef.current = {
-          index: focusIndex,
-          scrollIntoView: false,
-        };
-
-        return { ...prev, entries: newEntries };
-      });
+      recordImmediateHistorySnapshot(newEntries);
+      pendingFocusRef.current = {
+        index: focusIndex,
+        scrollIntoView: false,
+      };
+      entriesRef.current = newEntries;
+      setContent((prev) => ({ ...prev, entries: newEntries }));
     },
     [recordImmediateHistorySnapshot]
   );
@@ -509,31 +501,30 @@ export function useProseEditorState({
   const handleMoveUp = useCallback(
     (index: number) => {
       if (index === 0) return;
-      setContent((prev) => {
-        const newEntries = [...prev.entries];
-        [newEntries[index - 1], newEntries[index]] = [
-          newEntries[index],
-          newEntries[index - 1],
-        ];
-        recordImmediateHistorySnapshot(newEntries);
-        return { ...prev, entries: newEntries };
-      });
+      const newEntries = [...entriesRef.current];
+      [newEntries[index - 1], newEntries[index]] = [
+        newEntries[index],
+        newEntries[index - 1],
+      ];
+      recordImmediateHistorySnapshot(newEntries);
+      entriesRef.current = newEntries;
+      setContent((prev) => ({ ...prev, entries: newEntries }));
     },
     [recordImmediateHistorySnapshot]
   );
 
   const handleMoveDown = useCallback(
     (index: number) => {
-      setContent((prev) => {
-        if (index >= prev.entries.length - 1) return prev;
-        const newEntries = [...prev.entries];
-        [newEntries[index], newEntries[index + 1]] = [
-          newEntries[index + 1],
-          newEntries[index],
-        ];
-        recordImmediateHistorySnapshot(newEntries);
-        return { ...prev, entries: newEntries };
-      });
+      const currentEntries = entriesRef.current;
+      if (index >= currentEntries.length - 1) return;
+      const newEntries = [...currentEntries];
+      [newEntries[index], newEntries[index + 1]] = [
+        newEntries[index + 1],
+        newEntries[index],
+      ];
+      recordImmediateHistorySnapshot(newEntries);
+      entriesRef.current = newEntries;
+      setContent((prev) => ({ ...prev, entries: newEntries }));
     },
     [recordImmediateHistorySnapshot]
   );

--- a/apps/frontend/src/hooks/useFlowLayoutPositions.ts
+++ b/apps/frontend/src/hooks/useFlowLayoutPositions.ts
@@ -21,7 +21,7 @@
  * caller should show a loading indicator instead of rendering ReactFlow.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useReducer, useRef } from "react";
 import type { FlowLayoutMode, FlowNode, FlowEdge } from "@branchforge/shared";
 import { computeAutoLayout } from "@/components/flow/flow-graph-utils";
 import { FLOW_VIRTUALIZATION_THRESHOLD } from "@/lib/constants";
@@ -132,6 +132,42 @@ function mapToRecord(map: PositionMap): PositionRecord {
   return obj;
 }
 
+// ── Worker layout state ───────────────────────────────────────────────
+// Combined into one reducer so the async worker message handler (which
+// runs outside React's automatic batching) only triggers a single render.
+
+type WorkerLayoutState = {
+  positions: PositionMap;
+  isComputing: boolean;
+};
+
+type WorkerLayoutAction =
+  | { type: "cache_hit"; positions: PositionMap }
+  | { type: "start" }
+  | { type: "done"; positions: PositionMap }
+  | { type: "idle" };
+
+function workerLayoutReducer(
+  state: WorkerLayoutState,
+  action: WorkerLayoutAction
+): WorkerLayoutState {
+  switch (action.type) {
+    case "cache_hit":
+      return { positions: action.positions, isComputing: false };
+    case "start":
+      return state.isComputing ? state : { ...state, isComputing: true };
+    case "done":
+      return { positions: action.positions, isComputing: false };
+    case "idle":
+      return state.isComputing ? { ...state, isComputing: false } : state;
+    default: {
+      const _exhaustive: never = action;
+      void _exhaustive;
+      return state;
+    }
+  }
+}
+
 // ── Hook ──────────────────────────────────────────────────────────────
 
 export function useFlowLayoutPositions(
@@ -164,15 +200,18 @@ export function useFlowLayoutPositions(
   }, [useWorker, cacheKey, mode, nodes, edges]);
 
   // Async path — Web Worker for large graphs.
-  const [workerPositions, setWorkerPositions] = useState<PositionMap>(() => {
-    // Initialize from cache so the first render after mount is instant.
-    const cached = getCached(cacheKey);
-    return cached ? recordToMap(cached) : new Map();
-  });
-  const [isComputing, setIsComputing] = useState(() => {
-    if (!useWorker) return false;
-    return getCached(cacheKey) === null;
-  });
+  const [workerLayout, dispatchWorkerLayout] = useReducer(
+    workerLayoutReducer,
+    undefined,
+    (): WorkerLayoutState => {
+      // Initialize from cache so the first render after mount is instant.
+      const cached = getCached(cacheKey);
+      return {
+        positions: cached ? recordToMap(cached) : new Map(),
+        isComputing: useWorker && cached === null,
+      };
+    }
+  );
   const workerRef = useRef<Worker | null>(null);
   // Monotonically-increasing job id. The worker is shared, processes
   // messages in order, and we can't cancel a queued message — so each
@@ -184,19 +223,21 @@ export function useFlowLayoutPositions(
 
   useEffect(() => {
     if (!useWorker) {
-      setIsComputing(false);
+      dispatchWorkerLayout({ type: "idle" });
       return;
     }
 
     // Cache hit — skip the worker entirely.
     const cached = getCached(cacheKey);
     if (cached) {
-      setWorkerPositions(recordToMap(cached));
-      setIsComputing(false);
+      dispatchWorkerLayout({
+        type: "cache_hit",
+        positions: recordToMap(cached),
+      });
       return;
     }
 
-    setIsComputing(true);
+    dispatchWorkerLayout({ type: "start" });
 
     // Lazily create the worker (reused across re-computations).
     if (!workerRef.current) {
@@ -216,8 +257,10 @@ export function useFlowLayoutPositions(
       };
       if (responseJobId !== jobIdRef.current) return; // superseded — discard
       setCached(cacheKey, positions);
-      setWorkerPositions(recordToMap(positions));
-      setIsComputing(false);
+      dispatchWorkerLayout({
+        type: "done",
+        positions: recordToMap(positions),
+      });
     };
     worker.addEventListener("message", handler);
     worker.postMessage({ jobId, mode, nodes, edges });
@@ -240,7 +283,7 @@ export function useFlowLayoutPositions(
   }, []);
 
   return {
-    positions: useWorker ? workerPositions : syncPositions,
-    isComputing: useWorker ? isComputing : false,
+    positions: useWorker ? workerLayout.positions : syncPositions,
+    isComputing: useWorker ? workerLayout.isComputing : false,
   };
 }

--- a/apps/frontend/src/lib/format-conditions.ts
+++ b/apps/frontend/src/lib/format-conditions.ts
@@ -4,8 +4,11 @@ import type {
   VariableCondition,
 } from "@branchforge/shared";
 
+// `id` is a stable role key within one condition (left/op/right/name),
+// scoped to FormattedCondition's sibling list — not a global unique id.
 export type FormattedConditionPart =
-  { type: "keyword"; text: string } | { type: "value"; text: string };
+  | { type: "keyword"; text: string; id: string }
+  | { type: "value"; text: string; id: string };
 
 export function formatVariableCondition(
   varName: string,
@@ -13,14 +16,14 @@ export function formatVariableCondition(
 ): FormattedConditionPart[] {
   if (condition.operator === "truthy") {
     return [
-      { type: "keyword", text: "is" },
-      { type: "value", text: varName },
+      { type: "keyword", text: "is", id: "op" },
+      { type: "value", text: varName, id: "name" },
     ];
   }
   if (condition.operator === "falsy") {
     return [
-      { type: "keyword", text: "not" },
-      { type: "value", text: varName },
+      { type: "keyword", text: "not", id: "op" },
+      { type: "value", text: varName, id: "name" },
     ];
   }
   const val =
@@ -29,16 +32,16 @@ export function formatVariableCondition(
       : String(condition.value);
   if (condition.operator === "==") {
     return [
-      { type: "value", text: varName },
-      { type: "keyword", text: "is" },
-      { type: "value", text: val },
+      { type: "value", text: varName, id: "left" },
+      { type: "keyword", text: "is", id: "op" },
+      { type: "value", text: val, id: "right" },
     ];
   }
   // operator === "!="
   return [
-    { type: "value", text: varName },
-    { type: "keyword", text: "is not" },
-    { type: "value", text: val },
+    { type: "value", text: varName, id: "left" },
+    { type: "keyword", text: "is not", id: "op" },
+    { type: "value", text: val, id: "right" },
   ];
 }
 
@@ -56,8 +59,12 @@ export function formatStatCondition(
   condition: StatCondition
 ): FormattedConditionPart[] {
   return [
-    { type: "value", text: statName },
-    { type: "keyword", text: STAT_OPERATOR_WORDS[condition.operator] },
-    { type: "value", text: String(condition.value) },
+    { type: "value", text: statName, id: "left" },
+    {
+      type: "keyword",
+      text: STAT_OPERATOR_WORDS[condition.operator],
+      id: "op",
+    },
+    { type: "value", text: String(condition.value), id: "right" },
   ];
 }

--- a/apps/frontend/src/workers/flow-layout.worker.ts
+++ b/apps/frontend/src/workers/flow-layout.worker.ts
@@ -67,7 +67,7 @@ function isNullishKey(key: string | null | undefined): boolean {
 }
 
 function sortRowsNullishFirst(keys: string[]): string[] {
-  return [...keys].sort((a, b) => {
+  return keys.toSorted((a, b) => {
     const aNull = isNullishKey(a);
     const bNull = isNullishKey(b);
     if (aNull && !bNull) return -1;


### PR DESCRIPTION
## Description

Batch fix for three react-doctor findings that remained after recent component splits.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes, just code improvement)

## Related Issue

Fixes #217
Fixes #218
Fixes #220

## Changes Made

- **#217 cascading-setState**
  - `useFlowLayoutPositions`: merged `workerPositions` + `isComputing` into one `useReducer` so the async worker callback updates once
  - `useProseEditorState`: merged `entries` + `initialWordCount` into one `content` state object so the label-switch effect updates once
- **#218 array-index-as-key**
  - Added stable role `id`s (`left` / `op` / `right` / `name`) on `FormattedConditionPart`
  - `FormattedCondition` now keys on `part.id`
- **#220 toSorted**
  - `flow-layout.worker.ts`: replaced `[...keys].sort()` with `keys.toSorted()`
  - await-in-loop finding was previously confirmed FP (intentional sequential autosave)

## Testing

- [x] All tests pass locally: `pnpm --filter @branchforge/frontend test:unit` (992 tests)
- [x] Typecheck clean: `pnpm typecheck`
- [x] Prettier + eslint clean via pre-commit hook
- [x] Cleared react-doctor cache and re-ran doctor; targeted findings for #217/#218/#220 no longer reported (remaining cascading-setState is unrelated `EditorTabBar`)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (`pnpm typecheck`)
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**@oracle verdict:** READY to open PR. Overall risk Low. No must-fix findings. Behavior preserved for word-count baseline, worker cache/job supersession, and FormattedCondition rendering. One actionable should-fix addressed (local-key comment on `FormattedConditionPart.id`). Remaining should-fix items were explicitly non-blocking / no-change-required.

User requested a single PR covering all three issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved write-mode editing behavior when labels or server content change, helping preserve active edits and maintain accurate word-count baselines.
  - Improved flow layout updates when cached or background-calculated positioning data is available.
  - Enhanced condition formatting stability for more consistent rendering.

- **Refactor**
  - Streamlined editor state and layout processing without changing existing user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->