### PR TITLE
refactor(frontend): split flow-graph-utils into route, edge, layout modules

### DIFF
--- a/apps/frontend/src/components/flow/FlowGraph.tsx
+++ b/apps/frontend/src/components/flow/FlowGraph.tsx
@@ -17,12 +17,9 @@ import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useRouteConfigs } from "@/hooks/useRouteConfigs";
 import { useCharacters } from "@/hooks/useCharacters";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
-import {
-  buildRouteColorMap,
-  buildEdges,
-  buildLayoutNodes,
-  buildRouteOptions,
-} from "./flow-graph-utils";
+import { buildRouteColorMap, buildRouteOptions } from "./flow-graph-routes";
+import { buildEdges } from "./flow-graph-edges";
+import { buildLayoutNodes } from "./flow-graph-layout";
 import { useFlowLayoutPositions } from "@/hooks/useFlowLayoutPositions";
 import { LAYOUT_MODE_STORAGE_KEY, isFlowLayoutMode } from "./flow-layout-mode";
 import type { FlowLayoutMode } from "@branchforge/shared";

--- a/apps/frontend/src/components/flow/__tests__/flow-graph-performance.unit.test.ts
+++ b/apps/frontend/src/components/flow/__tests__/flow-graph-performance.unit.test.ts
@@ -14,11 +14,9 @@
  */
 
 import { describe, it, expect } from "vitest";
-import {
-  buildRouteColorMap,
-  buildEdges,
-  layoutNodes,
-} from "../flow-graph-utils";
+import { buildRouteColorMap } from "../flow-graph-routes";
+import { buildEdges } from "../flow-graph-edges";
+import { layoutNodes } from "../flow-graph-layout";
 import { filterFlowNodes } from "../flow-filters";
 import type { FlowNode, FlowEdge } from "@branchforge/shared";
 

--- a/apps/frontend/src/components/flow/__tests__/flow-graph.unit.test.ts
+++ b/apps/frontend/src/components/flow/__tests__/flow-graph.unit.test.ts
@@ -1,13 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { MarkerType } from "@xyflow/react";
-import {
-  buildRouteColorMap,
-  buildEdges,
-  getEdgeColor,
-  getEdgeWidth,
-  getRouteColor,
-  layoutNodes,
-} from "../flow-graph-utils";
+import { buildRouteColorMap, getRouteColor } from "../flow-graph-routes";
+import { buildEdges, getEdgeColor, getEdgeWidth } from "../flow-graph-edges";
+import { layoutNodes } from "../flow-graph-layout";
 import type { FlowNode, FlowEdge } from "@branchforge/shared";
 
 const mockFlowNodes: FlowNode[] = [

--- a/apps/frontend/src/components/flow/flow-graph-edges.ts
+++ b/apps/frontend/src/components/flow/flow-graph-edges.ts
@@ -1,0 +1,56 @@
+/**
+ * Flow graph edge builders / styling.
+ */
+
+import { MarkerType, type Edge } from "@xyflow/react";
+import type { FlowEdge } from "@branchforge/shared";
+
+export function getEdgeColor(type: string): string {
+  switch (type) {
+    case "JUMP":
+      return "#f59e0b"; // amber
+    case "CHOICE":
+      // The primary branching action — follow the active theme so the
+      // graph's main interaction color matches the rest of the app.
+      return "var(--theme-color)";
+    case "NATURAL":
+      return "#475569"; // slate-600
+    default:
+      return "#64748b";
+  }
+}
+
+export function getEdgeWidth(type: string): number {
+  switch (type) {
+    case "JUMP":
+      return 2;
+    case "CHOICE":
+      return 2;
+    case "NATURAL":
+      return 1;
+    default:
+      return 1;
+  }
+}
+
+export function buildEdges(flowEdges: FlowEdge[]): Edge[] {
+  return flowEdges.map((edge) => {
+    const edgeStyle: Edge = {
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      label: edge.label,
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color: getEdgeColor(edge.type),
+      },
+      style: {
+        stroke: getEdgeColor(edge.type),
+        strokeWidth: getEdgeWidth(edge.type),
+      },
+      labelStyle: { fill: "#94a3b8", fontSize: 11 },
+      animated: false,
+    };
+    return edgeStyle;
+  });
+}

--- a/apps/frontend/src/components/flow/flow-graph-layout.ts
+++ b/apps/frontend/src/components/flow/flow-graph-layout.ts
@@ -1,16 +1,16 @@
 /**
- * Flow graph utility functions extracted from FlowGraph component
+ * Flow graph layout engine (dagre, row layouts, saved-position overlay).
  */
 
 import dagre from "dagre";
-import { MarkerType, type Node, type Edge } from "@xyflow/react";
+import type { Node } from "@xyflow/react";
 import type {
   FlowLayoutMode,
   FlowNode,
   FlowEdge,
   FlowGraphPositions,
-  RouteConfig,
 } from "@branchforge/shared";
+import { getRouteColor } from "./flow-graph-routes";
 
 // Node dimensions used by all layout algorithms. Kept in sync with the
 // `LabelNode` component's intrinsic size.
@@ -26,160 +26,6 @@ const NODE_HEIGHT = 120;
 // left-to-right.
 const NODE_GAP_X = 80; // horizontal gap between nodes within a row
 const ROW_GAP_Y = 160; // vertical gap between rows (node height + padding)
-
-/**
- * Build route options for the filters panel from flow nodes and configs.
- * Always includes an "Unassigned" bucket if any node lacks a routeKey.
- */
-export function buildRouteOptions(
-  flowNodes: readonly FlowNode[],
-  routeConfigs: readonly RouteConfig[]
-): Array<{ key: string | null; label: string }> {
-  const presentKeys = new Set<string>();
-  let hasUnassigned = false;
-  for (const node of flowNodes) {
-    if (node.routeKey) {
-      presentKeys.add(node.routeKey);
-    } else {
-      hasUnassigned = true;
-    }
-  }
-  const fromConfigs: Array<{ key: string; label: string }> = [];
-  for (const c of routeConfigs) {
-    if (presentKeys.has(c.routeKey)) {
-      fromConfigs.push({ key: c.routeKey, label: c.routeName });
-    }
-  }
-  const known = new Set(fromConfigs.map((r) => r.key));
-  for (const k of presentKeys) {
-    if (!known.has(k)) fromConfigs.push({ key: k, label: k });
-  }
-  fromConfigs.sort((a, b) => a.label.localeCompare(b.label));
-  const options: Array<{ key: string | null; label: string }> = [
-    ...fromConfigs,
-  ];
-  if (hasUnassigned) {
-    options.push({ key: null, label: "Unassigned" });
-  }
-  return options;
-}
-
-export function getRouteColor(
-  routeKey: string | null,
-  routeColorMap: Map<string, string>
-): string {
-  if (!routeKey) return "#64748b"; // slate-500 for unassigned
-  const color = routeColorMap.get(routeKey);
-  return color ?? "#64748b";
-}
-
-/**
- * Convert HSL color to hex string.
- * @param h - Hue in degrees (0-360)
- * @param s - Saturation as percentage (0-100)
- * @param l - Lightness as percentage (0-100)
- * @returns 6-digit hex color string (e.g., "#a1b2c3")
- */
-function hslToHex(h: number, s: number, l: number): string {
-  s /= 100;
-  l /= 100;
-  const a = s * Math.min(l, 1 - l);
-  const f = (n: number): number => {
-    const k = (n + h / 30) % 12;
-    return l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-  };
-  const toHex = (n: number): string => {
-    const hex = Math.round(n * 255).toString(16);
-    return hex.length === 1 ? `0${hex}` : hex;
-  };
-  return `#${toHex(f(0))}${toHex(f(8))}${toHex(f(4))}`;
-}
-
-/**
- * djb2 string hash. Stable, fast, and good enough distribution to spread
- * route keys across the 360-bucket hue space without clustering.
- */
-function hashRouteKey(routeKey: string): number {
-  let hash = 5381;
-  for (let i = 0; i < routeKey.length; i++) {
-    hash = ((hash << 5) + hash + routeKey.charCodeAt(i)) | 0;
-  }
-  return hash;
-}
-
-/**
- * Generate a deterministic color for a given hue (0-360) using HSL.
- * @param hue - Hue in degrees (0-360)
- * @returns 6-digit hex color string
- */
-function generateHslColor(hue: number): string {
-  const saturation = 70;
-  const lightness = 55;
-  return hslToHex(hue, saturation, lightness);
-}
-
-export function buildRouteColorMap(nodes: FlowNode[]): Map<string, string> {
-  const routes = new Set<string>();
-  for (const node of nodes) {
-    if (node.routeKey) routes.add(node.routeKey);
-  }
-  const map = new Map<string, string>();
-  for (const route of routes) {
-    const hue = Math.abs(hashRouteKey(route)) % 360;
-    map.set(route, generateHslColor(hue));
-  }
-  return map;
-}
-
-export function getEdgeColor(type: string): string {
-  switch (type) {
-    case "JUMP":
-      return "#f59e0b"; // amber
-    case "CHOICE":
-      // The primary branching action — follow the active theme so the
-      // graph's main interaction color matches the rest of the app.
-      return "var(--theme-color)";
-    case "NATURAL":
-      return "#475569"; // slate-600
-    default:
-      return "#64748b";
-  }
-}
-
-export function getEdgeWidth(type: string): number {
-  switch (type) {
-    case "JUMP":
-      return 2;
-    case "CHOICE":
-      return 2;
-    case "NATURAL":
-      return 1;
-    default:
-      return 1;
-  }
-}
-
-export function buildEdges(flowEdges: FlowEdge[]): Edge[] {
-  return flowEdges.map((edge) => {
-    const edgeStyle: Edge = {
-      id: edge.id,
-      source: edge.source,
-      target: edge.target,
-      label: edge.label,
-      markerEnd: {
-        type: MarkerType.ArrowClosed,
-        color: getEdgeColor(edge.type),
-      },
-      style: {
-        stroke: getEdgeColor(edge.type),
-        strokeWidth: getEdgeWidth(edge.type),
-      },
-      labelStyle: { fill: "#94a3b8", fontSize: 11 },
-      animated: false,
-    };
-    return edgeStyle;
-  });
-}
 
 /**
  * Build the ReactFlow node envelope (data, style) shared by every layout

--- a/apps/frontend/src/components/flow/flow-graph-routes.ts
+++ b/apps/frontend/src/components/flow/flow-graph-routes.ts
@@ -1,0 +1,109 @@
+/**
+ * Flow graph route / color helpers.
+ */
+
+import type { FlowNode, RouteConfig } from "@branchforge/shared";
+
+/**
+ * Build route options for the filters panel from flow nodes and configs.
+ * Always includes an "Unassigned" bucket if any node lacks a routeKey.
+ */
+export function buildRouteOptions(
+  flowNodes: readonly FlowNode[],
+  routeConfigs: readonly RouteConfig[]
+): Array<{ key: string | null; label: string }> {
+  const presentKeys = new Set<string>();
+  let hasUnassigned = false;
+  for (const node of flowNodes) {
+    if (node.routeKey) {
+      presentKeys.add(node.routeKey);
+    } else {
+      hasUnassigned = true;
+    }
+  }
+  const fromConfigs: Array<{ key: string; label: string }> = [];
+  for (const c of routeConfigs) {
+    if (presentKeys.has(c.routeKey)) {
+      fromConfigs.push({ key: c.routeKey, label: c.routeName });
+    }
+  }
+  const known = new Set(fromConfigs.map((r) => r.key));
+  for (const k of presentKeys) {
+    if (!known.has(k)) fromConfigs.push({ key: k, label: k });
+  }
+  fromConfigs.sort((a, b) => a.label.localeCompare(b.label));
+  const options: Array<{ key: string | null; label: string }> = [
+    ...fromConfigs,
+  ];
+  if (hasUnassigned) {
+    options.push({ key: null, label: "Unassigned" });
+  }
+  return options;
+}
+
+export function getRouteColor(
+  routeKey: string | null,
+  routeColorMap: Map<string, string>
+): string {
+  if (!routeKey) return "#64748b"; // slate-500 for unassigned
+  const color = routeColorMap.get(routeKey);
+  return color ?? "#64748b";
+}
+
+/**
+ * Convert HSL color to hex string.
+ * @param h - Hue in degrees (0-360)
+ * @param s - Saturation as percentage (0-100)
+ * @param l - Lightness as percentage (0-100)
+ * @returns 6-digit hex color string (e.g., "#a1b2c3")
+ */
+function hslToHex(h: number, s: number, l: number): string {
+  s /= 100;
+  l /= 100;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number): number => {
+    const k = (n + h / 30) % 12;
+    return l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+  };
+  const toHex = (n: number): string => {
+    const hex = Math.round(n * 255).toString(16);
+    return hex.length === 1 ? `0${hex}` : hex;
+  };
+  return `#${toHex(f(0))}${toHex(f(8))}${toHex(f(4))}`;
+}
+
+/**
+ * djb2 string hash. Stable, fast, and good enough distribution to spread
+ * route keys across the 360-bucket hue space without clustering.
+ */
+function hashRouteKey(routeKey: string): number {
+  let hash = 5381;
+  for (let i = 0; i < routeKey.length; i++) {
+    hash = ((hash << 5) + hash + routeKey.charCodeAt(i)) | 0;
+  }
+  return hash;
+}
+
+/**
+ * Generate a deterministic color for a given hue (0-360) using HSL.
+ * @param hue - Hue in degrees (0-360)
+ * @returns 6-digit hex color string
+ */
+function generateHslColor(hue: number): string {
+  const saturation = 70;
+  const lightness = 55;
+  return hslToHex(hue, saturation, lightness);
+}
+
+export function buildRouteColorMap(nodes: FlowNode[]): Map<string, string> {
+  const routes = new Set<string>();
+  for (const node of nodes) {
+    if (node.routeKey) routes.add(node.routeKey);
+  }
+  const map = new Map<string, string>();
+  for (const route of routes) {
+    const hue = Math.abs(hashRouteKey(route)) % 360;
+    map.set(route, generateHslColor(hue));
+  }
+  return map;
+}

--- a/apps/frontend/src/hooks/useFlowLayoutPositions.ts
+++ b/apps/frontend/src/hooks/useFlowLayoutPositions.ts
@@ -23,7 +23,7 @@
 
 import { useEffect, useMemo, useReducer, useRef } from "react";
 import type { FlowLayoutMode, FlowNode, FlowEdge } from "@branchforge/shared";
-import { computeAutoLayout } from "@/components/flow/flow-graph-utils";
+import { computeAutoLayout } from "@/components/flow/flow-graph-layout";
 import { FLOW_VIRTUALIZATION_THRESHOLD } from "@/lib/constants";
 
 type PositionMap = Map<string, { x: number; y: number }>;

--- a/apps/frontend/src/workers/flow-layout.worker.ts
+++ b/apps/frontend/src/workers/flow-layout.worker.ts
@@ -15,7 +15,7 @@
 import dagre from "dagre";
 import type { FlowLayoutMode, FlowNode, FlowEdge } from "@branchforge/shared";
 
-// Node dimensions — kept in sync with flow-graph-utils.ts and LabelNode.
+// Node dimensions — kept in sync with flow-graph-layout.ts and LabelNode.
 const NODE_WIDTH = 240;
 const NODE_HEIGHT = 120;
 const NODE_GAP_X = 80;


### PR DESCRIPTION
Closes #352

## Summary
Pure module split of `flow-graph-utils.ts` into three domain-focused files with no behavior changes and no transitional barrel.

| Module | Responsibility |
|--------|----------------|
| `flow-graph-routes.ts` | `buildRouteOptions`, `getRouteColor`, `buildRouteColorMap` |
| `flow-graph-edges.ts` | `getEdgeColor`, `getEdgeWidth`, `buildEdges` |
| `flow-graph-layout.ts` | `computeAutoLayout`, `buildLayoutNodes`, `layoutNodes` |

## Changes
- Updated imports in `FlowGraph.tsx`, `useFlowLayoutPositions.ts`, and flow-graph tests
- Renamed `flow-graph-utils.unit.test.ts` → `flow-graph.unit.test.ts`
- Updated worker comment to reference `flow-graph-layout.ts`

## Verification
- `pnpm format:check` — pass
- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @branchforge/frontend test:unit` — 992 tests pass (includes 61 flow-graph tests)

## @oracle
- Initial review: 1 should-fix (stale test filename) — addressed
- Re-review: no remaining must-fix or should-fix findings
- Deferred (P2): shared layout constants between worker and layout module — out of scope for pure move per issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized flow-graph routing, edge styling, and layout functionality into dedicated modules.
  * Preserved existing flow visualization behavior, layout calculations, and public user experience.
  * Updated related layout processing and tests to use the reorganized functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->