### PR TITLE
fix: clear leftover frontend react-doctor findings (#353)

### DIFF
--- a/apps/frontend/doctor.config.json
+++ b/apps/frontend/doctor.config.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://react.doctor/schema/config.json",
+  "ignore": {
+    "overrides": [
+      {
+        "files": [
+          "src/contexts/ToastContext.tsx",
+          "src/components/ide-shared/RouteSettingsDialog.tsx",
+          "src/copy/**"
+        ],
+        "rules": ["deslop/unused-file"]
+      }
+    ]
+  }
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "doctor": "pnpx react-doctor@0.4.2 --verbose",
+    "doctor": "pnpx react-doctor@latest --verbose",
     "doctor:empty": "rm -rf node_modules/.cache/react-doctor"
   },
   "dependencies": {

--- a/apps/frontend/src/components/CharacterEditDialog/CharacterEditDialog.tsx
+++ b/apps/frontend/src/components/CharacterEditDialog/CharacterEditDialog.tsx
@@ -146,6 +146,7 @@ export function CharacterEditDialog({
       previewUrlRef.current = null;
     }
 
+    // react-doctor-disable-next-line react-doctor/no-create-object-url-without-revoke -- URL revoked on replace, remove, dialog close, unmount cleanup, and before successful save close; analyzer misses cross-function pairing
     const preview = URL.createObjectURL(file);
     previewUrlRef.current = preview;
 

--- a/apps/frontend/src/components/CharacterImportWizard/WizardNewCharacters.tsx
+++ b/apps/frontend/src/components/CharacterImportWizard/WizardNewCharacters.tsx
@@ -6,6 +6,7 @@ import {
   ChevronUp,
   BookOpen,
 } from "lucide-react";
+import { useMemo } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getNameTypeBadge, type EditableCharacter } from "./wizard-store";
@@ -32,6 +33,8 @@ export function WizardNewCharacters({
   isImporting,
   existingTags,
 }: WizardNewCharactersProps) {
+  const existingTagSet = useMemo(() => new Set(existingTags), [existingTags]);
+
   return (
     <div className="border border-border/30 rounded-md overflow-hidden">
       <button
@@ -89,7 +92,7 @@ export function WizardNewCharacters({
                         Narrator
                       </span>
                     )}
-                    {existingTags.includes(char.tag) && (
+                    {existingTagSet.has(char.tag) && (
                       <span
                         className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded bg-muted text-muted-foreground border border-border/30"
                         title="This character is already in the database. Re-confirming will update it (idempotent upsert)."

--- a/apps/frontend/src/components/ide-shared/RouteSettingsDialog.tsx
+++ b/apps/frontend/src/components/ide-shared/RouteSettingsDialog.tsx
@@ -13,6 +13,7 @@
  * Intentionally retained orphan (deslop/unused-file): react-doctor
  * reports unused-file at line 0, so inline disable comments cannot
  * suppress it. Same intentional-keep class as `src/copy/*` (#222).
+ * The `deslop/unused-file` rule is also ignored via doctor.config.json.
  */
 
 import { DialogShell } from "@/components/ui/DialogShell";

--- a/apps/frontend/src/components/ide-shared/ZipImportFilesDialog/ZipImportFilesDialogStatus.tsx
+++ b/apps/frontend/src/components/ide-shared/ZipImportFilesDialog/ZipImportFilesDialogStatus.tsx
@@ -29,7 +29,7 @@ export function ZipImportFilesDialogProgress({
       </div>
       <div className="h-2 bg-muted rounded-full overflow-hidden">
         <div
-          className="h-full bg-primary transition-all duration-300"
+          className="h-full bg-primary transition-[width] duration-300"
           style={{ width: `${importState.progress}%` }}
         />
       </div>

--- a/apps/frontend/src/components/ui/CharacterAvatarChip.tsx
+++ b/apps/frontend/src/components/ui/CharacterAvatarChip.tsx
@@ -28,7 +28,7 @@ export function CharacterAvatarChip({
       {onClick ? (
         <button
           type="button"
-          className={`size-8 rounded-full flex items-center justify-center text-white text-xs font-medium shrink-0 shadow-sm hover:ring-2 hover:ring-ring transition-all cursor-pointer border-0 p-0 focus-ring`}
+          className={`size-8 rounded-full flex items-center justify-center text-white text-xs font-medium shrink-0 shadow-sm hover:ring-2 hover:ring-ring transition-shadow cursor-pointer border-0 p-0 focus-ring`}
           style={{ backgroundColor: character.color }}
           aria-label={
             character.isLoveInterest

--- a/apps/frontend/src/components/write-mode/DialogueLine.tsx
+++ b/apps/frontend/src/components/write-mode/DialogueLine.tsx
@@ -4,16 +4,7 @@
  * Individual dialogue/narration line component with speaker dropdown.
  */
 
-import {
-  memo,
-  useState,
-  useCallback,
-  useRef,
-  useEffect,
-  useId,
-  useMemo,
-} from "react";
-import { X, ArrowUpRight } from "lucide-react";
+import { memo, useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { tokenize } from "@/lib/renpy-tags";
 import { getRawOffsetFromPoint } from "./utils/rawOffset";
 import { SpeakerDropdown } from "./SpeakerDropdown";
@@ -21,6 +12,8 @@ import { LineTextArea } from "./LineTextArea";
 import { TechnicalBadgeRow } from "./TechnicalBadgeRow";
 import type { DialogueLineProps } from "./DialogueLine.types";
 import { areDialogueLinePropsEqual } from "./DialogueLine.types";
+import { useDialogueLineSpeaker } from "./useDialogueLineSpeaker";
+import { DialogueLineActions } from "./DialogueLineActions";
 
 export const DialogueLine = memo(function DialogueLine({
   entry,
@@ -38,9 +31,6 @@ export const DialogueLine = memo(function DialogueLine({
   showBadges,
 }: DialogueLineProps) {
   const [isHovered, setIsHovered] = useState(false);
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [openUpward, setOpenUpward] = useState(false);
-  const [focusedOptionIndex, setFocusedOptionIndex] = useState<number>(-1);
   const [popoverType, setPopoverType] = useState<
     "conditions" | "jump" | "visuals" | "menu" | null
   >(null);
@@ -48,16 +38,12 @@ export const DialogueLine = memo(function DialogueLine({
   const [isFocused, setIsFocused] = useState(false);
   const removeHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const internalTextareaRef = useRef<HTMLTextAreaElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const dropdownMenuRef = useRef<HTMLDivElement>(null);
-  const speakerButtonRef = useRef<HTMLButtonElement>(null);
-  const wasDropdownOpenRef = useRef(false);
-  const isDropdownOpenRef = useRef(false);
-  const dropdownId = useId();
   const textOnChangeRef = useRef(onChange);
   const previousTextRef = useRef(entry.text);
   const measureRef = useRef<HTMLSpanElement>(null);
   const isChoice = entry.contentType === "CHOICE";
+
+  const speaker = useDialogueLineSpeaker(entry, characters, onChange);
 
   const resizeTextarea = useCallback(() => {
     const ta = internalTextareaRef.current;
@@ -77,8 +63,7 @@ export const DialogueLine = memo(function DialogueLine({
       resizeTextarea();
     }
     // react-doctor-disable-next-line react-doctor/exhaustive-deps -- mount-only initial textarea sync; intentional empty deps
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
+  }, []);
   useEffect(() => {
     const ta = internalTextareaRef.current;
     if (!ta) return;
@@ -93,13 +78,11 @@ export const DialogueLine = memo(function DialogueLine({
       resizeTextarea();
     }
   }, [entry.id, entry.text, resizeTextarea]);
-
   // react-doctor-disable-next-line react-doctor/advanced-event-handler-refs -- resizeTextarea is transitively stable via refs
   useEffect(() => {
     window.addEventListener("resize", resizeTextarea);
     return () => window.removeEventListener("resize", resizeTextarea);
   }, [resizeTextarea]);
-
   useEffect(() => {
     const m = measureRef.current;
     if (!m) return;
@@ -107,142 +90,12 @@ export const DialogueLine = memo(function DialogueLine({
     ro.observe(m);
     return () => ro.disconnect();
   }, [resizeTextarea]);
-
   // react-doctor-disable-next-line react-doctor/exhaustive-deps -- unmount cleanup reading ref.current is correct
   useEffect(() => {
     return () => {
       if (removeHintTimerRef.current) clearTimeout(removeHintTimerRef.current);
     };
   }, []);
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
-      )
-        setIsDropdownOpen(false);
-    };
-    if (isDropdownOpen) {
-      document.addEventListener("mousedown", handler);
-      return () => document.removeEventListener("mousedown", handler);
-    }
-  }, [isDropdownOpen]);
-
-  const computeDropdownSpaces = useCallback(() => {
-    const trigger = dropdownRef.current;
-    if (!trigger) return null;
-    const scrollArea = trigger.closest(
-      '[data-prose-editor-scroll="true"]'
-    ) as HTMLElement | null;
-    const bounds = scrollArea
-      ? scrollArea.getBoundingClientRect()
-      : { top: 0, bottom: window.innerHeight };
-    const rect = trigger.getBoundingClientRect();
-    return {
-      spaceAbove: rect.top - bounds.top,
-      spaceBelow: bounds.bottom - rect.bottom,
-      triggerRect: rect,
-    };
-  }, []);
-
-  const updateDropdownDirection = useCallback(() => {
-    const menu = dropdownMenuRef.current;
-    if (!menu) return;
-    const spaces = computeDropdownSpaces();
-    if (!spaces) return;
-    const mh = Math.min(menu.scrollHeight, 280) + 8;
-    setOpenUpward(
-      spaces.spaceBelow < mh && spaces.spaceAbove > spaces.spaceBelow
-    );
-  }, [computeDropdownSpaces]);
-
-  const getShouldOpenUpward = useCallback(
-    (mh: number) => {
-      const spaces = computeDropdownSpaces();
-      return spaces
-        ? spaces.spaceBelow < mh && spaces.spaceAbove > spaces.spaceBelow
-        : false;
-    },
-    [computeDropdownSpaces]
-  );
-
-  const estimateDropdownHeight = useCallback(
-    () => Math.min(40 * (characters.length + 1) + 8, 280) + 8,
-    [characters.length]
-  );
-
-  const handleSpeakerToggle = useCallback(() => {
-    const nextOpen = !isDropdownOpenRef.current;
-    if (nextOpen) {
-      setOpenUpward(getShouldOpenUpward(estimateDropdownHeight()));
-      setFocusedOptionIndex(
-        entry.speakerId
-          ? characters.findIndex((c) => c.id === entry.speakerId) + 1
-          : 0
-      );
-    } else {
-      setFocusedOptionIndex(-1);
-    }
-    isDropdownOpenRef.current = nextOpen;
-    setIsDropdownOpen(nextOpen);
-  }, [
-    getShouldOpenUpward,
-    estimateDropdownHeight,
-    entry.speakerId,
-    characters,
-  ]);
-
-  // react-doctor-disable-next-line react-doctor/advanced-event-handler-refs -- updateDropdownDirection transitively stable
-  useEffect(() => {
-    if (!isDropdownOpen) return;
-    const scrollArea = dropdownRef.current?.closest(
-      '[data-prose-editor-scroll="true"]'
-    ) as HTMLElement | null;
-    const raf = requestAnimationFrame(updateDropdownDirection);
-    window.addEventListener("resize", updateDropdownDirection);
-    scrollArea?.addEventListener("scroll", updateDropdownDirection, {
-      passive: true,
-    });
-    return () => {
-      cancelAnimationFrame(raf);
-      window.removeEventListener("resize", updateDropdownDirection);
-      scrollArea?.removeEventListener("scroll", updateDropdownDirection);
-    };
-  }, [isDropdownOpen, updateDropdownDirection]);
-
-  useEffect(() => {
-    // react-doctor-disable-next-line react-doctor/no-event-handler -- focus option scroll is UI sync for keyboard nav, not a fake event handler
-    if (isDropdownOpen && focusedOptionIndex >= 0) {
-      const opt = document.getElementById(
-        `${dropdownId}-option-${focusedOptionIndex}`
-      );
-      if (opt && typeof opt.scrollIntoView === "function") {
-        opt.scrollIntoView({ block: "nearest", inline: "nearest" });
-      }
-    }
-  }, [focusedOptionIndex, isDropdownOpen, dropdownId]);
-
-  useEffect(() => {
-    if (isDropdownOpen) dropdownMenuRef.current?.focus();
-    else if (wasDropdownOpenRef.current) speakerButtonRef.current?.focus();
-    wasDropdownOpenRef.current = isDropdownOpen;
-  }, [isDropdownOpen]);
-
-  const handleSpeakerSelect = useCallback(
-    (speakerId: string | null) => {
-      onChange({
-        id: entry.id,
-        speakerId,
-        text: entry.text,
-        contentType: entry.contentType,
-        choiceData: entry.choiceData,
-      });
-      setIsDropdownOpen(false);
-      setFocusedOptionIndex(-1);
-    },
-    [onChange, entry.id, entry.text, entry.contentType, entry.choiceData]
-  );
 
   const handleTextChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -307,45 +160,6 @@ export const DialogueLine = memo(function DialogueLine({
     [totalEntries, isChoice, index, onAddLine, onDelete, onMoveUp, onMoveDown]
   );
 
-  const handleDropdownKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
-      const total = characters.length + 1;
-      switch (e.key) {
-        case "Escape":
-          e.preventDefault();
-          setIsDropdownOpen(false);
-          setFocusedOptionIndex(-1);
-          break;
-        case "ArrowDown":
-          e.preventDefault();
-          setFocusedOptionIndex((p) => (p < total - 1 ? p + 1 : 0));
-          break;
-        case "ArrowUp":
-          e.preventDefault();
-          setFocusedOptionIndex((p) => (p > 0 ? p - 1 : total - 1));
-          break;
-        case "Home":
-          e.preventDefault();
-          setFocusedOptionIndex(0);
-          break;
-        case "End":
-          e.preventDefault();
-          setFocusedOptionIndex(total - 1);
-          break;
-        case "Enter":
-        case " ":
-          e.preventDefault();
-          if (focusedOptionIndex === 0) handleSpeakerSelect(null);
-          else if (focusedOptionIndex > 0) {
-            const c = characters[focusedOptionIndex - 1];
-            if (c) handleSpeakerSelect(c.id);
-          }
-          break;
-      }
-    },
-    [characters, focusedOptionIndex, handleSpeakerSelect]
-  );
-
   const handleRenderedLineClick = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
       const ta = internalTextareaRef.current;
@@ -357,24 +171,13 @@ export const DialogueLine = memo(function DialogueLine({
     []
   );
 
-  const handleDropdownBlur = useCallback(
-    (e: React.FocusEvent<HTMLDivElement>) => {
-      if (!e.currentTarget.contains(e.relatedTarget))
-        setTimeout(() => {
-          setIsDropdownOpen(false);
-          setFocusedOptionIndex(-1);
-        }, 0);
-    },
-    []
-  );
-
   const character = entry.speakerId
     ? characters.find((c) => c.id === entry.speakerId)
     : null;
   const speakerColor = character?.color;
   const isNarrator = character?.isNarrator ?? false;
   const isStacked = layoutMode === "stacked";
-  const isSpeakerInteractive = isHovered || isDropdownOpen;
+  const isSpeakerInteractive = isHovered || speaker.isDropdownOpen;
   const hasSpeaker = Boolean(entry.speakerId);
   const speakerFontStyle = !hasSpeaker || isNarrator ? "italic" : "normal";
   const choiceTargetName = entry.choiceData?.targetLabelName;
@@ -398,24 +201,24 @@ export const DialogueLine = memo(function DialogueLine({
         <SpeakerDropdown
           isChoice={isChoice}
           isStacked={isStacked}
-          isDropdownOpen={isDropdownOpen}
+          isDropdownOpen={speaker.isDropdownOpen}
           isSpeakerInteractive={isSpeakerInteractive}
           character={character}
           speakerColor={speakerColor}
           isNarrator={isNarrator}
           speakerFontStyle={speakerFontStyle}
-          openUpward={openUpward}
-          focusedOptionIndex={focusedOptionIndex}
-          dropdownId={dropdownId}
+          openUpward={speaker.openUpward}
+          focusedOptionIndex={speaker.focusedOptionIndex}
+          dropdownId={speaker.dropdownId}
           speakerId={entry.speakerId}
           characters={characters}
-          handleSpeakerToggle={handleSpeakerToggle}
-          handleSpeakerSelect={handleSpeakerSelect}
-          handleDropdownKeyDown={handleDropdownKeyDown}
-          handleDropdownBlur={handleDropdownBlur}
-          dropdownRef={dropdownRef}
-          dropdownMenuRef={dropdownMenuRef}
-          speakerButtonRef={speakerButtonRef}
+          handleSpeakerToggle={speaker.handleSpeakerToggle}
+          handleSpeakerSelect={speaker.handleSpeakerSelect}
+          handleDropdownKeyDown={speaker.handleDropdownKeyDown}
+          handleDropdownBlur={speaker.handleDropdownBlur}
+          dropdownRef={speaker.dropdownRef}
+          dropdownMenuRef={speaker.dropdownMenuRef}
+          speakerButtonRef={speaker.speakerButtonRef}
         />
 
         <LineTextArea
@@ -432,35 +235,18 @@ export const DialogueLine = memo(function DialogueLine({
           handleRenderedLineClick={handleRenderedLineClick}
           setIsFocused={setIsFocused}
         />
-
-        {showDelete && (
-          <button
-            type="button"
-            onClick={onDelete}
-            className="z-10 absolute right-0 top-0.5 p-1 rounded text-muted-foreground/70 hover:text-destructive bg-background/90 hover:bg-destructive/10 transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-            title="Delete line (Backspace)"
-          >
-            <X className="size-3.5" />
-          </button>
-        )}
       </div>
 
-      {isChoice && choiceTargetName && (
-        <span
-          className={`text-xs text-muted-foreground/70 flex items-center gap-1 ${isStacked ? "" : "ml-[172px]"}`}
-        >
-          <ArrowUpRight className="size-3" />
-          {choiceTargetName}
-        </span>
-      )}
-
-      {showRemoveHint && (
-        <span
-          className={`text-xs text-muted-foreground/70 animate-in fade-in-0 slide-in-from-top-1 duration-200 ${isStacked ? "" : "ml-[172px]"}`}
-        >
-          Remove choices in Script mode
-        </span>
-      )}
+      <DialogueLineActions
+        visibility={{
+          showDelete,
+          isChoice,
+          isStacked,
+          showRemoveHint,
+        }}
+        onDelete={onDelete}
+        choiceTargetName={choiceTargetName}
+      />
 
       <TechnicalBadgeRow
         showBadges={showBadges}

--- a/apps/frontend/src/components/write-mode/DialogueLineActions.tsx
+++ b/apps/frontend/src/components/write-mode/DialogueLineActions.tsx
@@ -1,0 +1,57 @@
+/**
+ * DialogueLineActions
+ *
+ * Renders the delete button, choice target, and remove-hint for a dialogue line.
+ */
+import { X, ArrowUpRight } from "lucide-react";
+
+interface DialogueLineActionsVisibility {
+  showDelete: boolean;
+  isChoice: boolean;
+  isStacked: boolean;
+  showRemoveHint: boolean;
+}
+
+interface DialogueLineActionsProps {
+  visibility: DialogueLineActionsVisibility;
+  onDelete: () => void;
+  choiceTargetName: string | undefined;
+}
+
+export function DialogueLineActions({
+  visibility,
+  onDelete,
+  choiceTargetName,
+}: DialogueLineActionsProps) {
+  const { showDelete, isChoice, isStacked, showRemoveHint } = visibility;
+
+  return (
+    <>
+      {showDelete && (
+        <button
+          type="button"
+          onClick={onDelete}
+          className="z-10 absolute right-0 top-0.5 p-1 rounded text-muted-foreground/70 hover:text-destructive bg-background/90 hover:bg-destructive/10 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          title="Delete line (Backspace)"
+        >
+          <X className="size-3.5" />
+        </button>
+      )}
+      {isChoice && choiceTargetName && (
+        <span
+          className={`text-xs text-muted-foreground/70 flex items-center gap-1 ${isStacked ? "" : "ml-[172px]"}`}
+        >
+          <ArrowUpRight className="size-3" />
+          {choiceTargetName}
+        </span>
+      )}
+      {showRemoveHint && (
+        <span
+          className={`text-xs text-muted-foreground/70 animate-in fade-in-0 slide-in-from-top-1 duration-200 ${isStacked ? "" : "ml-[172px]"}`}
+        >
+          Remove choices in Script mode
+        </span>
+      )}
+    </>
+  );
+}

--- a/apps/frontend/src/components/write-mode/LabelPropertiesPanel/LabelPropertiesPanelIncomingJumps.tsx
+++ b/apps/frontend/src/components/write-mode/LabelPropertiesPanel/LabelPropertiesPanelIncomingJumps.tsx
@@ -39,9 +39,9 @@ export function LabelPropertiesPanelIncomingJumps({
         <p className="text-xs text-muted-foreground">No incoming jumps</p>
       ) : (
         <div className="space-y-2">
-          {incomingJumps.map((jump, i) => (
+          {incomingJumps.map((jump) => (
             <div
-              key={`${jump.sourceLabelId}-${jump.choiceText}-${i}`}
+              key={`${jump.sourceLabelId}-${jump.choiceText}`}
               className="p-2 rounded-lg bg-muted/30 border border-border/50 text-xs"
             >
               <div className="font-medium text-foreground truncate">

--- a/apps/frontend/src/components/write-mode/LabelPropertiesPanel/LabelPropertiesPanelOutgoingJumps.tsx
+++ b/apps/frontend/src/components/write-mode/LabelPropertiesPanel/LabelPropertiesPanelOutgoingJumps.tsx
@@ -136,9 +136,9 @@ export function LabelPropertiesPanelOutgoingJumps({
           <p className="text-xs text-muted-foreground">No outgoing jumps</p>
         ) : (
           <div className="space-y-2">
-            {outgoingJumps.map((jump, i) => (
+            {outgoingJumps.map((jump) => (
               <OutgoingJumpItem
-                key={`${jump.targetLabelId}-${jump.choiceText}-${i}`}
+                key={`${jump.targetLabelId}-${jump.choiceText}`}
                 jump={jump}
                 statByKey={statByKey}
               />

--- a/apps/frontend/src/components/write-mode/LabelPropertiesPanel/LabelPropertiesPanelOutgoingJumps.tsx
+++ b/apps/frontend/src/components/write-mode/LabelPropertiesPanel/LabelPropertiesPanelOutgoingJumps.tsx
@@ -2,15 +2,18 @@ import { useMemo } from "react";
 import { CollapsibleSection } from "@/components/ide-shared/CollapsibleSection";
 import type { LabelDetail, Stat } from "@branchforge/shared";
 
+interface JumpData {
+  id: string;
+  targetLabelId: string;
+  targetLabelName: string;
+  jumpType: "MENU_CHOICE" | "AUTOMATIC";
+  choiceText: string;
+  conditionFlags?: string[];
+  effects?: Record<string, number>;
+}
+
 interface OutgoingJumpItemProps {
-  jump: {
-    targetLabelId: string;
-    targetLabelName: string;
-    jumpType: "MENU_CHOICE" | "AUTOMATIC";
-    choiceText: string;
-    conditionFlags?: string[];
-    effects?: Record<string, number>;
-  };
+  jump: JumpData;
   statByKey: Map<string, Stat>;
 }
 
@@ -80,20 +83,14 @@ export function LabelPropertiesPanelOutgoingJumps({
 
   const outgoingJumps = useMemo(() => {
     if (!activeLabel?.lines) return [];
-    const jumps: Array<{
-      targetLabelId: string;
-      targetLabelName: string;
-      jumpType: "MENU_CHOICE" | "AUTOMATIC";
-      choiceText: string;
-      conditionFlags?: string[];
-      effects?: Record<string, number>;
-    }> = [];
+    const jumps: JumpData[] = [];
 
     for (const line of activeLabel.lines) {
       if (line.menuOptions) {
-        for (const opt of line.menuOptions) {
+        for (const [optIndex, opt] of line.menuOptions.entries()) {
           if (!opt.targetLabelId) continue;
           jumps.push({
+            id: `${line.id}:menu:${optIndex}`,
             targetLabelId: opt.targetLabelId,
             targetLabelName: opt.targetLabelName,
             jumpType: "MENU_CHOICE",
@@ -107,6 +104,7 @@ export function LabelPropertiesPanelOutgoingJumps({
         const match = line.content.match(/jump\s+(\S+)/);
         if (match) {
           jumps.push({
+            id: `${line.id}:jump`,
             targetLabelId: match[1],
             targetLabelName: match[1],
             jumpType: "AUTOMATIC",
@@ -138,7 +136,7 @@ export function LabelPropertiesPanelOutgoingJumps({
           <div className="space-y-2">
             {outgoingJumps.map((jump) => (
               <OutgoingJumpItem
-                key={`${jump.targetLabelId}-${jump.choiceText}`}
+                key={jump.id}
                 jump={jump}
                 statByKey={statByKey}
               />

--- a/apps/frontend/src/components/write-mode/LabelPropertiesPanel/__tests__/LabelPropertiesPanelOutgoingJumps.test.tsx
+++ b/apps/frontend/src/components/write-mode/LabelPropertiesPanel/__tests__/LabelPropertiesPanelOutgoingJumps.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { LabelDetail } from "@branchforge/shared";
+import { LabelPropertiesPanelOutgoingJumps } from "../LabelPropertiesPanelOutgoingJumps";
+
+function makeLabel(overrides: Partial<LabelDetail> = {}): LabelDetail {
+  return {
+    id: "label-1",
+    projectId: "proj1",
+    title: "Test Label",
+    groupType: null,
+    groupValue: null,
+    labelNumber: 1,
+    sequenceOrder: 0,
+    routeKey: null,
+    status: null,
+    visibility: null,
+    projectFileId: "file-default",
+    fileName: "default.rpy",
+    labelName: null,
+    conditions: null,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    lines: [],
+    characters: [],
+    ...overrides,
+  };
+}
+
+describe("LabelPropertiesPanelOutgoingJumps", () => {
+  it("renders duplicate choiceText+target on different lines as separate items", async () => {
+    const user = userEvent.setup();
+
+    const activeLabel = makeLabel({
+      lines: [
+        {
+          id: "line-1",
+          labelId: "label-1",
+          sequence: 1,
+          contentType: "MENU",
+          content: "",
+          visualType: "GENERATED",
+          visualPrompt: null,
+          speakerId: null,
+          speakerName: null,
+          speakerTag: null,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+          conditions: null,
+          visualStatements: null,
+          menuOptions: [
+            {
+              label: "Ask about the mission",
+              targetLabelId: "label-mission",
+              targetLabelName: "Mission Label",
+            },
+          ],
+        },
+        {
+          id: "line-2",
+          labelId: "label-1",
+          sequence: 2,
+          contentType: "MENU",
+          content: "",
+          visualType: "GENERATED",
+          visualPrompt: null,
+          speakerId: null,
+          speakerName: null,
+          speakerTag: null,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+          conditions: null,
+          visualStatements: null,
+          menuOptions: [
+            {
+              label: "Ask about the mission",
+              targetLabelId: "label-mission",
+              targetLabelName: "Mission Label",
+            },
+          ],
+        },
+      ],
+    });
+
+    render(
+      <LabelPropertiesPanelOutgoingJumps activeLabel={activeLabel} stats={[]} />
+    );
+
+    // CollapsibleSection starts closed; click the header button to open
+    const toggle = screen.getByRole("button", {
+      name: /outgoing jumps/i,
+    });
+    await user.click(toggle);
+
+    // Both items with the same targetLabelName should be present
+    expect(screen.getAllByText("Mission Label")).toHaveLength(2);
+
+    // Both items with the same choiceText should be present
+    expect(screen.getAllByText("Ask about the mission")).toHaveLength(2);
+  });
+
+  it("renders automatic JUMP lines with line-scoped id", async () => {
+    const user = userEvent.setup();
+
+    const activeLabel = makeLabel({
+      lines: [
+        {
+          id: "line-3",
+          labelId: "label-1",
+          sequence: 1,
+          contentType: "JUMP",
+          content: "jump target_label",
+          visualType: "GENERATED",
+          visualPrompt: null,
+          speakerId: null,
+          speakerName: null,
+          speakerTag: null,
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+          conditions: null,
+          visualStatements: null,
+          menuOptions: null,
+        },
+      ],
+    });
+
+    render(
+      <LabelPropertiesPanelOutgoingJumps activeLabel={activeLabel} stats={[]} />
+    );
+
+    const toggle = screen.getByRole("button", {
+      name: /outgoing jumps/i,
+    });
+    await user.click(toggle);
+
+    // target_label appears twice: as label name and as choice text
+    expect(screen.getAllByText("target_label").length).toBe(2);
+  });
+});

--- a/apps/frontend/src/components/write-mode/TechnicalPopover.tsx
+++ b/apps/frontend/src/components/write-mode/TechnicalPopover.tsx
@@ -184,6 +184,7 @@ export function TechnicalPopover({
               </div>
               <ul className="text-xs text-muted-foreground space-y-1.5">
                 {visualsData.map((visual, index) => (
+                  // react-doctor-disable-next-line react-doctor/no-array-index-as-key -- type_target can collide; index is local list order tiebreaker
                   <li
                     key={`${visual.type}_${visual.target}_${index}`}
                     className="flex items-center gap-1.5"

--- a/apps/frontend/src/components/write-mode/useDialogueLineSpeaker.ts
+++ b/apps/frontend/src/components/write-mode/useDialogueLineSpeaker.ts
@@ -1,0 +1,235 @@
+/**
+ * useDialogueLineSpeaker
+ *
+ * Manages speaker dropdown open/close state, positioning, keyboard navigation,
+ * focus management, and outside-click dismissal.
+ */
+import { useState, useCallback, useRef, useEffect, useId } from "react";
+import type { Character } from "@branchforge/shared";
+import type { DialogueEntry } from "@/lib/prose-types";
+
+export interface UseDialogueLineSpeakerReturn {
+  isDropdownOpen: boolean;
+  openUpward: boolean;
+  focusedOptionIndex: number;
+  dropdownId: string;
+  dropdownRef: React.RefObject<HTMLDivElement | null>;
+  dropdownMenuRef: React.RefObject<HTMLDivElement | null>;
+  speakerButtonRef: React.RefObject<HTMLButtonElement | null>;
+  handleSpeakerToggle: () => void;
+  handleSpeakerSelect: (speakerId: string | null) => void;
+  handleDropdownKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  handleDropdownBlur: (e: React.FocusEvent<HTMLDivElement>) => void;
+}
+
+export function useDialogueLineSpeaker(
+  entry: DialogueEntry,
+  characters: Character[],
+  onChange: (entry: DialogueEntry) => void
+): UseDialogueLineSpeakerReturn {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [openUpward, setOpenUpward] = useState(false);
+  const [focusedOptionIndex, setFocusedOptionIndex] = useState<number>(-1);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const dropdownMenuRef = useRef<HTMLDivElement>(null);
+  const speakerButtonRef = useRef<HTMLButtonElement>(null);
+  const wasDropdownOpenRef = useRef(false);
+  const isDropdownOpenRef = useRef(false);
+  const dropdownId = useId();
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      )
+        setIsDropdownOpen(false);
+    };
+    if (isDropdownOpen) {
+      document.addEventListener("mousedown", handler);
+      return () => document.removeEventListener("mousedown", handler);
+    }
+  }, [isDropdownOpen]);
+
+  const computeDropdownSpaces = useCallback(() => {
+    const trigger = dropdownRef.current;
+    if (!trigger) return null;
+    const scrollArea = trigger.closest(
+      '[data-prose-editor-scroll="true"]'
+    ) as HTMLElement | null;
+    const bounds = scrollArea
+      ? scrollArea.getBoundingClientRect()
+      : { top: 0, bottom: window.innerHeight };
+    const rect = trigger.getBoundingClientRect();
+    return {
+      spaceAbove: rect.top - bounds.top,
+      spaceBelow: bounds.bottom - rect.bottom,
+      triggerRect: rect,
+    };
+  }, []);
+
+  const updateDropdownDirection = useCallback(() => {
+    const menu = dropdownMenuRef.current;
+    if (!menu) return;
+    const spaces = computeDropdownSpaces();
+    if (!spaces) return;
+    const mh = Math.min(menu.scrollHeight, 280) + 8;
+    setOpenUpward(
+      spaces.spaceBelow < mh && spaces.spaceAbove > spaces.spaceBelow
+    );
+  }, [computeDropdownSpaces]);
+
+  const getShouldOpenUpward = useCallback(
+    (mh: number) => {
+      const spaces = computeDropdownSpaces();
+      return spaces
+        ? spaces.spaceBelow < mh && spaces.spaceAbove > spaces.spaceBelow
+        : false;
+    },
+    [computeDropdownSpaces]
+  );
+
+  const estimateDropdownHeight = useCallback(
+    () => Math.min(40 * (characters.length + 1) + 8, 280) + 8,
+    [characters.length]
+  );
+
+  const handleSpeakerToggle = useCallback(() => {
+    const nextOpen = !isDropdownOpenRef.current;
+    if (nextOpen) {
+      setOpenUpward(getShouldOpenUpward(estimateDropdownHeight()));
+      setFocusedOptionIndex(
+        entry.speakerId
+          ? characters.findIndex((c) => c.id === entry.speakerId) + 1
+          : 0
+      );
+    } else {
+      setFocusedOptionIndex(-1);
+    }
+    isDropdownOpenRef.current = nextOpen;
+    setIsDropdownOpen(nextOpen);
+  }, [
+    getShouldOpenUpward,
+    estimateDropdownHeight,
+    entry.speakerId,
+    characters,
+  ]);
+
+  // react-doctor-disable-next-line react-doctor/advanced-event-handler-refs -- updateDropdownDirection transitively stable
+  useEffect(() => {
+    if (!isDropdownOpen) return;
+    const scrollArea = dropdownRef.current?.closest(
+      '[data-prose-editor-scroll="true"]'
+    ) as HTMLElement | null;
+    const raf = requestAnimationFrame(updateDropdownDirection);
+    window.addEventListener("resize", updateDropdownDirection);
+    scrollArea?.addEventListener("scroll", updateDropdownDirection, {
+      passive: true,
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", updateDropdownDirection);
+      scrollArea?.removeEventListener("scroll", updateDropdownDirection);
+    };
+  }, [isDropdownOpen, updateDropdownDirection]);
+
+  // Scroll focused option into view
+  useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-event-handler -- focus option scroll is UI sync for keyboard nav, not a fake event handler
+    if (isDropdownOpen && focusedOptionIndex >= 0) {
+      const opt = document.getElementById(
+        `${dropdownId}-option-${focusedOptionIndex}`
+      );
+      if (opt && typeof opt.scrollIntoView === "function") {
+        opt.scrollIntoView({ block: "nearest", inline: "nearest" });
+      }
+    }
+  }, [focusedOptionIndex, isDropdownOpen, dropdownId]);
+
+  // Focus menu on open, return focus to speaker button on close
+  useEffect(() => {
+    if (isDropdownOpen) dropdownMenuRef.current?.focus();
+    else if (wasDropdownOpenRef.current) speakerButtonRef.current?.focus();
+    wasDropdownOpenRef.current = isDropdownOpen;
+  }, [isDropdownOpen]);
+
+  const handleSpeakerSelect = useCallback(
+    (speakerId: string | null) => {
+      onChange({
+        id: entry.id,
+        speakerId,
+        text: entry.text,
+        contentType: entry.contentType,
+        choiceData: entry.choiceData,
+      });
+      setIsDropdownOpen(false);
+      setFocusedOptionIndex(-1);
+    },
+    [onChange, entry.id, entry.text, entry.contentType, entry.choiceData]
+  );
+
+  const handleDropdownKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const total = characters.length + 1;
+      switch (e.key) {
+        case "Escape":
+          e.preventDefault();
+          setIsDropdownOpen(false);
+          setFocusedOptionIndex(-1);
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          setFocusedOptionIndex((p) => (p < total - 1 ? p + 1 : 0));
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setFocusedOptionIndex((p) => (p > 0 ? p - 1 : total - 1));
+          break;
+        case "Home":
+          e.preventDefault();
+          setFocusedOptionIndex(0);
+          break;
+        case "End":
+          e.preventDefault();
+          setFocusedOptionIndex(total - 1);
+          break;
+        case "Enter":
+        case " ":
+          e.preventDefault();
+          if (focusedOptionIndex === 0) handleSpeakerSelect(null);
+          else if (focusedOptionIndex > 0) {
+            const c = characters[focusedOptionIndex - 1];
+            if (c) handleSpeakerSelect(c.id);
+          }
+          break;
+      }
+    },
+    [characters, focusedOptionIndex, handleSpeakerSelect]
+  );
+
+  const handleDropdownBlur = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      if (!e.currentTarget.contains(e.relatedTarget))
+        setTimeout(() => {
+          setIsDropdownOpen(false);
+          setFocusedOptionIndex(-1);
+        }, 0);
+    },
+    []
+  );
+
+  return {
+    isDropdownOpen,
+    openUpward,
+    focusedOptionIndex,
+    dropdownId,
+    dropdownRef,
+    dropdownMenuRef,
+    speakerButtonRef,
+    handleSpeakerToggle,
+    handleSpeakerSelect,
+    handleDropdownKeyDown,
+    handleDropdownBlur,
+  };
+}

--- a/apps/frontend/src/components/write-mode/useDialogueLineSpeaker.ts
+++ b/apps/frontend/src/components/write-mode/useDialogueLineSpeaker.ts
@@ -36,6 +36,11 @@ export function useDialogueLineSpeaker(
   const wasDropdownOpenRef = useRef(false);
   const isDropdownOpenRef = useRef(false);
   const dropdownId = useId();
+  const closeDropdown = useCallback(() => {
+    isDropdownOpenRef.current = false;
+    setIsDropdownOpen(false);
+    setFocusedOptionIndex(-1);
+  }, []);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -44,13 +49,13 @@ export function useDialogueLineSpeaker(
         dropdownRef.current &&
         !dropdownRef.current.contains(e.target as Node)
       )
-        setIsDropdownOpen(false);
+        closeDropdown();
     };
     if (isDropdownOpen) {
       document.addEventListener("mousedown", handler);
       return () => document.removeEventListener("mousedown", handler);
     }
-  }, [isDropdownOpen]);
+  }, [isDropdownOpen, closeDropdown]);
 
   const computeDropdownSpaces = useCallback(() => {
     const trigger = dropdownRef.current;
@@ -163,10 +168,16 @@ export function useDialogueLineSpeaker(
         contentType: entry.contentType,
         choiceData: entry.choiceData,
       });
-      setIsDropdownOpen(false);
-      setFocusedOptionIndex(-1);
+      closeDropdown();
     },
-    [onChange, entry.id, entry.text, entry.contentType, entry.choiceData]
+    [
+      onChange,
+      entry.id,
+      entry.text,
+      entry.contentType,
+      entry.choiceData,
+      closeDropdown,
+    ]
   );
 
   const handleDropdownKeyDown = useCallback(
@@ -175,8 +186,7 @@ export function useDialogueLineSpeaker(
       switch (e.key) {
         case "Escape":
           e.preventDefault();
-          setIsDropdownOpen(false);
-          setFocusedOptionIndex(-1);
+          closeDropdown();
           break;
         case "ArrowDown":
           e.preventDefault();
@@ -205,18 +215,17 @@ export function useDialogueLineSpeaker(
           break;
       }
     },
-    [characters, focusedOptionIndex, handleSpeakerSelect]
+    [characters, focusedOptionIndex, handleSpeakerSelect, closeDropdown]
   );
 
   const handleDropdownBlur = useCallback(
     (e: React.FocusEvent<HTMLDivElement>) => {
       if (!e.currentTarget.contains(e.relatedTarget))
         setTimeout(() => {
-          setIsDropdownOpen(false);
-          setFocusedOptionIndex(-1);
+          closeDropdown();
         }, 0);
     },
-    []
+    [closeDropdown]
   );
 
   return {

--- a/apps/frontend/src/contexts/ThemeContext.tsx
+++ b/apps/frontend/src/contexts/ThemeContext.tsx
@@ -5,44 +5,14 @@ import {
   useMemo,
   type ReactNode,
 } from "react";
-import { ThemeContext, type ThemePalette, type ThemeColors } from "./useTheme";
+import { ThemeContext, type ThemePalette } from "./useTheme";
 import {
   useLocalStorage,
   useLocalStorageBoolean,
 } from "@/hooks/useLocalStorage";
 import { useUserSettings } from "@/hooks/useUserSettings";
 import { isValidTheme } from "@branchforge/shared";
-
-export const themeConfigs: Record<ThemePalette, ThemeColors> = {
-  // Forest green darkened from #40bb82 to #26714e for ≥4.5:1 white-on-green
-  // button contrast while still reading as Forest green on dark UIs.
-  // Hover foregrounds are dark (#0a0a0a) so labels meet ≥4.5:1 on every
-  // hover swatch — the button lightens on hover and the text flips to dark.
-  forest: {
-    primary: "#26714e",
-    hover: "#339668",
-    foreground: "#ffffff",
-    hoverForeground: "#0a0a0a",
-  },
-  periwinkle: {
-    primary: "#5b6ae0",
-    hover: "#727ae8",
-    foreground: "#ffffff",
-    hoverForeground: "#0a0a0a",
-  },
-  "dark-amethyst": {
-    primary: "#9549b6",
-    hover: "#a960c7",
-    foreground: "#ffffff",
-    hoverForeground: "#0a0a0a",
-  },
-  graphite: {
-    primary: "#686a71",
-    hover: "#b0b7c4",
-    foreground: "#ffffff",
-    hoverForeground: "#0a0a0a",
-  },
-};
+import { themeConfigs } from "./themeConfigs";
 
 // Status colors (theme-independent for semantic consistency)
 const STATUS_COLORS = {

--- a/apps/frontend/src/contexts/ToastContext.tsx
+++ b/apps/frontend/src/contexts/ToastContext.tsx
@@ -186,6 +186,7 @@ function ToastContainer({ toasts, onRemove }: ToastContainerProps) {
       className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 pointer-events-none"
     >
       {toasts.map((toast) => (
+        // react-doctor-disable-next-line react-doctor/no-transition-all -- FP: animate-in uses @keyframes enter (opacity/transform), not transition:all; rule docs say Tailwind classNames are out of scope
         <div
           key={toast.id}
           role={toast.variant === "destructive" ? "alert" : "status"}

--- a/apps/frontend/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/ThemeContext.test.tsx
@@ -6,7 +6,8 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { ThemeProvider, themeConfigs } from "../ThemeContext";
+import { ThemeProvider } from "../ThemeContext";
+import { themeConfigs } from "../themeConfigs";
 import { useTheme, type ThemePalette } from "../useTheme";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastProvider } from "@/contexts/ToastContext";

--- a/apps/frontend/src/contexts/themeConfigs.ts
+++ b/apps/frontend/src/contexts/themeConfigs.ts
@@ -1,0 +1,33 @@
+import type { ThemePalette } from "@branchforge/shared";
+import type { ThemeColors } from "./useTheme";
+
+export const themeConfigs: Record<ThemePalette, ThemeColors> = {
+  // Forest green darkened from #40bb82 to #26714e for ≥4.5:1 white-on-green
+  // button contrast while still reading as Forest green on dark UIs.
+  // Hover foregrounds are dark (#0a0a0a) so labels meet ≥4.5:1 on every
+  // hover swatch — the button lightens on hover and the text flips to dark.
+  forest: {
+    primary: "#26714e",
+    hover: "#339668",
+    foreground: "#ffffff",
+    hoverForeground: "#0a0a0a",
+  },
+  periwinkle: {
+    primary: "#5b6ae0",
+    hover: "#727ae8",
+    foreground: "#ffffff",
+    hoverForeground: "#0a0a0a",
+  },
+  "dark-amethyst": {
+    primary: "#9549b6",
+    hover: "#a960c7",
+    foreground: "#ffffff",
+    hoverForeground: "#0a0a0a",
+  },
+  graphite: {
+    primary: "#686a71",
+    hover: "#b0b7c4",
+    foreground: "#ffffff",
+    hoverForeground: "#0a0a0a",
+  },
+};

--- a/apps/frontend/src/hooks/useLocalStorage.ts
+++ b/apps/frontend/src/hooks/useLocalStorage.ts
@@ -153,16 +153,16 @@ export function useLocalStorage<T>(
 
   // Re-read from localStorage when key changes
   useEffect(() => {
-    // react-doctor-disable-next-line react-doctor/no-derived-state
-    setState(
-      readStorageValue(
-        prefixedKey,
-        defaultValueRef.current,
-        deserializerRef.current,
-        validateRef.current,
-        ssrSafeRef.current
-      )
+    const next = readStorageValue(
+      prefixedKey,
+      defaultValueRef.current,
+      deserializerRef.current,
+      validateRef.current,
+      ssrSafeRef.current
     );
+    stateRef.current = next;
+    // react-doctor-disable-next-line react-doctor/no-derived-state
+    setState(next);
   }, [prefixedKey]);
 
   const setItem = useCallback(
@@ -198,6 +198,7 @@ export function useLocalStorage<T>(
 
   const removeItem = useCallback(() => {
     if (ssrSafe && !isStorageAvailable()) {
+      stateRef.current = defaultValueRef.current;
       setState(defaultValueRef.current);
       return;
     }
@@ -208,6 +209,7 @@ export function useLocalStorage<T>(
       logStorageWarning("remove", prefixedKey, error);
     }
 
+    stateRef.current = defaultValueRef.current;
     setState(defaultValueRef.current);
   }, [prefixedKey, ssrSafe]);
 

--- a/apps/frontend/src/hooks/useLocalStorage.ts
+++ b/apps/frontend/src/hooks/useLocalStorage.ts
@@ -146,6 +146,10 @@ export function useLocalStorage<T>(
   const [state, setState] = useState<T>(() =>
     readStorageValue(prefixedKey, defaultValue, deserializer, validate, ssrSafe)
   );
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
 
   // Re-read from localStorage when key changes
   useEffect(() => {
@@ -163,16 +167,16 @@ export function useLocalStorage<T>(
 
   const setItem = useCallback(
     (value: SetStateAction<T>) => {
-      setState((previousValue) => {
-        const nextValue =
-          typeof value === "function"
-            ? (value as (prev: T) => T)(previousValue)
-            : value;
+      const nextValue =
+        typeof value === "function"
+          ? (value as (prev: T) => T)(stateRef.current)
+          : value;
 
-        if (ssrSafe && !isStorageAvailable()) {
-          return nextValue;
-        }
+      // Keep ref in sync immediately so chained functional updaters see
+      // the latest value before the next render flushes state.
+      stateRef.current = nextValue;
 
+      if (!(ssrSafe && !isStorageAvailable())) {
         try {
           if (nextValue === undefined) {
             window.localStorage.removeItem(prefixedKey);
@@ -185,9 +189,9 @@ export function useLocalStorage<T>(
         } catch (error) {
           logStorageWarning("save", prefixedKey, error);
         }
+      }
 
-        return nextValue;
-      });
+      setState(nextValue);
     },
     [prefixedKey, ssrSafe]
   );

--- a/apps/frontend/src/hooks/useTextUndo.ts
+++ b/apps/frontend/src/hooks/useTextUndo.ts
@@ -17,6 +17,7 @@ export function useTextUndo(
     future: [],
   };
 
+  // react-doctor-disable-next-line react-doctor/no-derived-state -- undo stack owns present; initial state derived from content prop by design
   const [state, setState] = useState<UndoState>(initialState);
   const stateRef = useRef<UndoState>(initialState);
 
@@ -24,6 +25,7 @@ export function useTextUndo(
 
   const commitState = useCallback((nextState: UndoState) => {
     stateRef.current = nextState;
+    // react-doctor-disable-next-line react-doctor/no-derived-state -- commit helper for intentional undo-owned present; not prop-derived render state
     setState(nextState);
   }, []);
 
@@ -125,6 +127,7 @@ export function useTextUndo(
   );
 
   // Sync internal state with content prop when it changes from external sources
+  // react-doctor-disable-next-line react-doctor/no-derived-state-effect -- undo stack must own present and sync when external content changes
   useEffect(() => {
     if (content !== lastSyncedContentRef.current) {
       const nextState: UndoState = {
@@ -132,7 +135,7 @@ export function useTextUndo(
         present: content,
         future: [],
       };
-      // react-doctor-disable-next-line react-doctor/no-derived-state
+      // react-doctor-disable-next-line react-doctor/no-derived-state -- reset present from external content change through undo-owned commit path
       commitState(nextState);
       lastSyncedContentRef.current = content;
     }

--- a/apps/frontend/src/hooks/useWriteAutosave.ts
+++ b/apps/frontend/src/hooks/useWriteAutosave.ts
@@ -297,11 +297,16 @@ export function useWriteAutosave({
     prevProjectIdRef.current = projectId;
   }, [projectId]);
 
+  const hashFn = useCallback(
+    (nextDraft: LabelDialogueDraft) =>
+      `${nextDraft.labelId ?? "none"}:${hashDialogueEntries(nextDraft.entries)}`,
+    []
+  );
+
   const { saveStatus, isDirty, triggerSave, resetSavedHash } =
     useAutosave<LabelDialogueDraft>({
       data: draft,
-      hashFn: (nextDraft) =>
-        `${nextDraft.labelId ?? "none"}:${hashDialogueEntries(nextDraft.entries)}`,
+      hashFn,
       debounceMs: 1000,
       skipSaveRef,
       onSave: useCallback(

--- a/apps/frontend/src/hooks/useWriteTabs.ts
+++ b/apps/frontend/src/hooks/useWriteTabs.ts
@@ -160,7 +160,7 @@ export function useWriteTabs({
 
   useEffect(() => {
     if (tabsState.nextActiveLabelId !== undefined) {
-      // react-doctor-disable-next-line react-doctor/no-pass-data-to-parent
+      // react-doctor-disable-next-line react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent
       setActiveLabelId(tabsState.nextActiveLabelId);
       dispatch({ type: "CLEAR_NEXT_ACTIVE" });
     }
@@ -267,7 +267,7 @@ export function useWriteTabs({
 
     // react-doctor-disable-next-line react-doctor/no-event-handler
     if (nextActiveLabelId !== activeLabelId) {
-      // react-doctor-disable-next-line react-doctor/no-pass-data-to-parent
+      // react-doctor-disable-next-line react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent
       setActiveLabelId(nextActiveLabelId);
     }
   }, [

--- a/apps/frontend/src/pages/ide/WriteMode.tsx
+++ b/apps/frontend/src/pages/ide/WriteMode.tsx
@@ -174,18 +174,18 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
     [handleSelectLabel]
   );
 
-  const editorSaveProps = useMemo(
+  // react-doctor-disable-next-line react-doctor/no-usememo-simple-expression -- referential stability for editorSaveState passed to WriteModeView
+  const editorSaveState = useMemo(
     () => ({
       isSaving: saveStatus === "saving",
       lastSaved: saveStatus === "saved" ? lastSaved : null,
       saveError: saveStatus === "error",
+      saveConflict: activeLabelId
+        ? (conflictByLabel.get(activeLabelId) ?? false)
+        : false,
     }),
-    [lastSaved, saveStatus]
+    [lastSaved, saveStatus, activeLabelId, conflictByLabel]
   );
-
-  const hasConflict = activeLabelId
-    ? conflictByLabel.get(activeLabelId)
-    : false;
 
   if (!currentProject) {
     return <NoProjectSelected onOpenSettings={onOpenSettings} />;
@@ -221,19 +221,18 @@ export function WriteMode({ projectName, onOpenSettings }: WriteModeProps) {
         projectId={currentProject.id}
         projectLabelCount={labels.length}
         onCreateLabel={createLabel}
-        isCreatingLabel={isCreatingLabel}
         onUpdateLabel={updateLabel}
-        isUpdatingLabel={isUpdatingLabel}
         onDeleteLabel={deleteLabel}
-        isDeletingLabel={isDeletingLabel}
+        labelMutationState={{
+          isCreatingLabel,
+          isUpdatingLabel,
+          isDeletingLabel,
+        }}
         editorRef={editorRef}
         activeLabel={activeLabel}
         characters={characters}
         onChange={handleContentChange}
-        isSaving={editorSaveProps.isSaving}
-        lastSaved={editorSaveProps.lastSaved}
-        saveError={editorSaveProps.saveError}
-        saveConflict={Boolean(hasConflict)}
+        editorSaveState={editorSaveState}
         onUndoStateChange={setProseUndoState}
         onWordCountChange={setWordCountState}
         stats={stats}

--- a/apps/frontend/src/pages/ide/components/WriteModeView.tsx
+++ b/apps/frontend/src/pages/ide/components/WriteModeView.tsx
@@ -33,19 +33,14 @@ export function WriteModeView({
   projectId,
   projectLabelCount,
   onCreateLabel,
-  isCreatingLabel,
   onUpdateLabel,
-  isUpdatingLabel,
   onDeleteLabel,
-  isDeletingLabel,
+  labelMutationState,
   editorRef,
   activeLabel,
   characters,
   onChange,
-  isSaving,
-  lastSaved,
-  saveError,
-  saveConflict,
+  editorSaveState,
   onUndoStateChange,
   onWordCountChange,
   stats,
@@ -150,11 +145,11 @@ export function WriteModeView({
               onCreateLabel={async (data) => {
                 await onCreateLabel({ projectId, ...data });
               }}
-              isCreatingLabel={isCreatingLabel}
+              isCreatingLabel={labelMutationState.isCreatingLabel}
               onUpdateLabel={async (labelId, data) => {
                 return onUpdateLabel(labelId, data);
               }}
-              isUpdatingLabel={isUpdatingLabel}
+              isUpdatingLabel={labelMutationState.isUpdatingLabel}
               onEditLabel={handleEditLabel}
               onDeleteRequest={handleDeleteRequest}
             />
@@ -231,10 +226,10 @@ export function WriteModeView({
                 characters={characters}
                 onChange={onChange}
                 isFocusMode={isFocusMode}
-                isSaving={isSaving}
-                lastSaved={lastSaved}
-                saveError={saveError}
-                saveConflict={saveConflict}
+                isSaving={editorSaveState.isSaving}
+                lastSaved={editorSaveState.lastSaved}
+                saveError={editorSaveState.saveError}
+                saveConflict={editorSaveState.saveConflict}
                 onUndoStateChange={onUndoStateChange}
                 onWordCountChange={onWordCountChange}
                 showBadges={showBadges}
@@ -293,8 +288,8 @@ export function WriteModeView({
           projectId={projectId}
           onEditSave={handleEditSave}
           onDeleteConfirmAction={handleDeleteConfirmAction}
-          isUpdatingLabel={isUpdatingLabel}
-          isDeletingLabel={isDeletingLabel}
+          isUpdatingLabel={labelMutationState.isUpdatingLabel}
+          isDeletingLabel={labelMutationState.isDeletingLabel}
         />
       </div>
     </>

--- a/apps/frontend/src/pages/ide/components/WriteModeView.types.ts
+++ b/apps/frontend/src/pages/ide/components/WriteModeView.types.ts
@@ -24,6 +24,19 @@ export interface SidebarState {
   setIsRightCollapsed: Dispatch<SetStateAction<boolean>>;
 }
 
+export interface LabelMutationState {
+  isCreatingLabel: boolean;
+  isUpdatingLabel: boolean;
+  isDeletingLabel: boolean;
+}
+
+export interface EditorSaveState {
+  isSaving: boolean;
+  lastSaved: Date | null;
+  saveError: boolean;
+  saveConflict: boolean;
+}
+
 export interface WriteModeViewProps {
   // Focus mode
   isFocusMode: boolean;
@@ -47,24 +60,19 @@ export interface WriteModeViewProps {
   projectId: string;
   projectLabelCount: number;
   onCreateLabel: (data: CreateLabelInput) => Promise<unknown>;
-  isCreatingLabel: boolean;
   onUpdateLabel: (
     labelId: string,
     data: UpdateLabelInput
   ) => Promise<PublicLabel>;
-  isUpdatingLabel: boolean;
   onDeleteLabel: (labelId: string) => Promise<void>;
-  isDeletingLabel: boolean;
+  labelMutationState: LabelMutationState;
 
   // Editor
   editorRef: RefObject<ProseEditorRef | null>;
   activeLabel: LabelDetail | undefined;
   characters: Character[];
   onChange: (entries: DialogueEntry[]) => void;
-  isSaving: boolean;
-  lastSaved: Date | null;
-  saveError: boolean;
-  saveConflict: boolean;
+  editorSaveState: EditorSaveState;
   onUndoStateChange: Dispatch<
     SetStateAction<{ canUndo: boolean; canRedo: boolean }>
   >;


### PR DESCRIPTION
## Summary
- Clears the leftover post-#351 react-doctor set from #353: impure `useLocalStorage` updater, unstable `useWriteAutosave` hashFn, Set lookup, transition-* specificity, jump/visual key noise, `themeConfigs` extraction, WriteModeView boolean grouping, and DialogueLine split under the giant-component threshold.
- Documents intentional keeps / FPs via adjacent suppress comments and `apps/frontend/doctor.config.json` (ToastContext, RouteSettingsDialog, `src/copy/**` unused-file).
- Bumps the frontend doctor script to `react-doctor@latest`; scan is clean at **100/100**.

## Test plan
- [x] `pnpm --filter @branchforge/frontend doctor` → 100/100
- [x] `pnpm --filter @branchforge/frontend typecheck`
- [x] `pnpm --filter @branchforge/frontend lint` (pre-existing warnings only)
- [x] `pnpm --filter @branchforge/frontend test:unit` (flow-graph perf timeout flake under parallel load; passes on re-run)
- [ ] Smoke write-mode save/autosave + dialogue speaker/delete affordances

Closes #353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved speaker selection in Write mode with smoother keyboard navigation, focus handling, and dropdown positioning.
  * Improved performance when identifying previously imported character tags.
  * Improved local settings persistence, including safer updates in supported environments.
  * Refined progress-bar and avatar hover animations for smoother visual feedback.
  * Streamlined save and label-status handling across the writing workspace.
* **Maintenance**
  * Updated theme configuration and development quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->