### PR TITLE
feat(frontend): add dirty-form guards to form dialogs (#285)

### DIFF
--- a/.changeset/dirty-form-guards.md
+++ b/.changeset/dirty-form-guards.md
@@ -1,0 +1,5 @@
+---
+"@branchforge/frontend": patch
+---
+
+Add dirty-form guards to form dialogs: disable Save when clean, warn before discarding unsaved changes, and center confirm dialogs in the viewport.

--- a/apps/frontend/src/components/CharacterEditDialog/CharacterEditDialog.tsx
+++ b/apps/frontend/src/components/CharacterEditDialog/CharacterEditDialog.tsx
@@ -42,7 +42,19 @@ export interface CharacterEditDialogProps {
   characterId?: string;
 }
 
-type CharacterSnapshot = Record<string, unknown>;
+interface CharacterSnapshot {
+  name: string;
+  displayName: string;
+  renpyTag: string;
+  color: string;
+  routeAffiliation: string;
+  conditionalPrefix: string;
+  notes: string;
+  isLoveInterest: boolean;
+  isNarrator: boolean;
+  avatarUrl?: string;
+  hasAvatarFile: boolean;
+}
 
 function buildSnapshot(f: CharacterFormState): CharacterSnapshot {
   return {
@@ -71,6 +83,7 @@ function buildSnapshotFromChar(char: Character): CharacterSnapshot {
     notes: char.notes ?? "",
     isLoveInterest: char.isLoveInterest,
     isNarrator: char.isNarrator,
+    // Match RESET_EXISTING / INITIAL_EMPTY (undefined, not null/"").
     avatarUrl: char.avatarUrl ?? undefined,
     hasAvatarFile: false,
   };

--- a/apps/frontend/src/components/CharacterEditDialog/CharacterEditDialog.tsx
+++ b/apps/frontend/src/components/CharacterEditDialog/CharacterEditDialog.tsx
@@ -5,7 +5,7 @@
  * Used by CharacterDialog (list view) and reference panels.
  */
 
-import { useEffect, useReducer, useRef } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import {
   Dialog,
@@ -16,16 +16,21 @@ import {
 import { Button } from "@/components/ui/button";
 import { useCharacters } from "@/hooks/useCharacters";
 import { useToast } from "@/contexts/ToastContext";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { useDirtyForm } from "@/hooks/useDirtyForm";
+import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
 import {
   AVATAR_MAX_SIZE,
   AVATAR_MAX_SIZE_MB,
   isValidAvatarMimeType,
+  type Character,
 } from "@branchforge/shared";
 import {
   INITIAL_EMPTY,
   formReducer,
   validateForm,
 } from "./CharacterEditDialog.utils";
+import type { CharacterFormState } from "./CharacterEditDialog.utils";
 import { CharacterEditDialogBasicSection } from "./CharacterEditDialogBasicSection";
 import { CharacterEditDialogAvatarSection } from "./CharacterEditDialogAvatarSection";
 import { CharacterEditDialogDetailsSection } from "./CharacterEditDialogDetailsSection";
@@ -35,6 +40,40 @@ export interface CharacterEditDialogProps {
   onOpenChange: (open: boolean) => void;
   projectId: string;
   characterId?: string;
+}
+
+type CharacterSnapshot = Record<string, unknown>;
+
+function buildSnapshot(f: CharacterFormState): CharacterSnapshot {
+  return {
+    name: f.name,
+    displayName: f.displayName,
+    renpyTag: f.renpyTag,
+    color: f.color,
+    routeAffiliation: f.routeAffiliation,
+    conditionalPrefix: f.conditionalPrefix,
+    notes: f.notes,
+    isLoveInterest: f.isLoveInterest,
+    isNarrator: f.isNarrator,
+    avatarUrl: f.avatarUrl,
+    hasAvatarFile: !!f.avatarFile,
+  };
+}
+
+function buildSnapshotFromChar(char: Character): CharacterSnapshot {
+  return {
+    name: char.name,
+    displayName: char.displayName,
+    renpyTag: char.renpyTag,
+    color: char.color,
+    routeAffiliation: char.routeAffiliation ?? "",
+    conditionalPrefix: char.conditionalPrefix ?? "",
+    notes: char.notes ?? "",
+    isLoveInterest: char.isLoveInterest,
+    isNarrator: char.isNarrator,
+    avatarUrl: char.avatarUrl ?? undefined,
+    hasAvatarFile: false,
+  };
 }
 
 export function CharacterEditDialog({
@@ -60,6 +99,9 @@ export function CharacterEditDialog({
   const { error } = useToast();
 
   const [form, dispatch] = useReducer(formReducer, INITIAL_EMPTY);
+  const [initialSnapshot, setInitialSnapshot] = useState<CharacterSnapshot>(
+    () => buildSnapshot(INITIAL_EMPTY)
+  );
   // Track preview URL for cleanup
   const previewUrlRef = useRef<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -78,6 +120,15 @@ export function CharacterEditDialog({
     isUploadingAvatar ||
     isDeletingAvatar;
 
+  const currentSnapshot = buildSnapshot(form);
+  const { isDirty } = useDirtyForm(initialSnapshot, currentSnapshot);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
+
   // Initialize form state when dialog opens/closes
   useEffect(() => {
     if (!open) {
@@ -90,6 +141,7 @@ export function CharacterEditDialog({
       initializedForCharacterIdRef.current = null;
       hasInitializedRef.current = false;
       createdCharIdRef.current = null;
+      setInitialSnapshot(buildSnapshot(INITIAL_EMPTY));
     } else if (!isLoadingCharacters) {
       if (characterId && characterId !== initializedForCharacterIdRef.current) {
         hasInitializedRef.current = false;
@@ -101,6 +153,7 @@ export function CharacterEditDialog({
           initializedForCharacterIdRef.current = characterId;
           hasInitializedRef.current = true;
           dispatch({ type: "RESET_EXISTING", char });
+          setInitialSnapshot(buildSnapshotFromChar(char));
         }
       }
     }
@@ -239,60 +292,75 @@ export function CharacterEditDialog({
   const isEditMode = !!characterId;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl w-full max-h-[90vh] p-0 gap-0 flex flex-col overflow-hidden">
-        {/* Header */}
-        <div className="p-6 max-sm:p-4 border-b border-border/30 shrink-0">
-          <DialogTitle>
-            {isEditMode ? "Edit Character" : "Add Character"}
-          </DialogTitle>
-          <DialogDescription>
-            {isEditMode
-              ? "Update character details and avatar."
-              : "Create a new character for your project."}
-          </DialogDescription>
-        </div>
-
-        {/* Scrollable form content */}
-        <div className="flex-1 overflow-y-auto p-6 max-sm:p-4">
-          <div className="space-y-4">
-            <CharacterEditDialogBasicSection
-              form={form}
-              handleFieldChange={handleFieldChange}
-              isSaving={isSaving}
-              isEditMode={isEditMode}
-            />
-            <CharacterEditDialogAvatarSection
-              form={form}
-              handleAvatarSelect={handleAvatarSelect}
-              handleAvatarRemove={handleAvatarRemove}
-              isSaving={isSaving}
-              fileInputRef={fileInputRef}
-            />
-            <CharacterEditDialogDetailsSection
-              form={form}
-              handleFieldChange={handleFieldChange}
-              isSaving={isSaving}
-            />
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-2xl w-full max-h-[90vh] p-0 gap-0 flex flex-col overflow-hidden">
+          {/* Header */}
+          <div className="p-6 max-sm:p-4 border-b border-border/30 shrink-0">
+            <DialogTitle>
+              {isEditMode ? "Edit Character" : "Add Character"}
+            </DialogTitle>
+            <DialogDescription>
+              {isEditMode
+                ? "Update character details and avatar."
+                : "Create a new character for your project."}
+            </DialogDescription>
           </div>
-        </div>
 
-        {/* Footer — sticky on mobile */}
-        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end gap-2 shrink-0">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-            disabled={isSaving}
-          >
-            Cancel
-          </Button>
-          <Button type="button" onClick={handleSave} disabled={isSaving}>
-            {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
-            Save
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
+          {/* Scrollable form content */}
+          <div className="flex-1 overflow-y-auto p-6 max-sm:p-4">
+            <div className="space-y-4">
+              <CharacterEditDialogBasicSection
+                form={form}
+                handleFieldChange={handleFieldChange}
+                isSaving={isSaving}
+                isEditMode={isEditMode}
+              />
+              <CharacterEditDialogAvatarSection
+                form={form}
+                handleAvatarSelect={handleAvatarSelect}
+                handleAvatarRemove={handleAvatarRemove}
+                isSaving={isSaving}
+                fileInputRef={fileInputRef}
+              />
+              <CharacterEditDialogDetailsSection
+                form={form}
+                handleFieldChange={handleFieldChange}
+                isSaving={isSaving}
+              />
+            </div>
+          </div>
+
+          {/* Footer — sticky on mobile */}
+          <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end gap-2 shrink-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={!isDirty || isSaving}
+            >
+              {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
+              Save
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -98,6 +98,7 @@ export function ProjectSettingsDialog({
   // and writing refs during render. The extra render that the
   // tracker produces is the cost of this pattern.)
   const [activeTab, setActiveTab] = useState<SettingsTab>(defaultTab);
+  const [visualSystemDirty, setVisualSystemDirty] = useState(false);
   // react-doctor-disable-next-line react-doctor/no-derived-useState, react-doctor/rerender-state-only-in-handlers
   const [prevOpen, setPrevOpen] = useState(open);
   // react-doctor-disable-next-line react-doctor/no-derived-useState, react-doctor/rerender-state-only-in-handlers
@@ -107,10 +108,11 @@ export function ProjectSettingsDialog({
     setPrevDefaultTab(defaultTab);
     if (open) {
       setActiveTab(defaultTab);
+    } else {
+      setVisualSystemDirty(false);
     }
   }
 
-  const [visualSystemDirty, setVisualSystemDirty] = useState(false);
   const {
     handleOpenChange,
     confirmDiscard,
@@ -148,7 +150,10 @@ export function ProjectSettingsDialog({
           {/* Tabs */}
           <Tabs
             value={activeTab}
-            onValueChange={(next) => setActiveTab(next as SettingsTab)}
+            onValueChange={(next) => {
+              if (next !== "visual") setVisualSystemDirty(false);
+              setActiveTab(next as SettingsTab);
+            }}
             className="flex flex-col flex-1 min-h-0"
           >
             <div className="px-3 pt-2 pb-3 shrink-0 sm:px-6">

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -29,6 +29,8 @@ import {
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsPanel } from "@/components/ui/tabs";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
 import { CharacterSettingsContent } from "@/components/characters/CharacterSettingsContent";
 import { RouteSettingsContent } from "@/components/routes/RouteSettingsContent";
 import { VisualSystemFormContent } from "@/components/visual-system/VisualSystemDialog";
@@ -108,82 +110,104 @@ export function ProjectSettingsDialog({
     }
   }
 
+  const [visualSystemDirty, setVisualSystemDirty] = useState(false);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(visualSystemDirty, onOpenChange);
+
   return (
-    <Dialog
-      open={open}
-      onOpenChange={onOpenChange}
-      aria-label="Project Settings"
-    >
-      <DialogContent className="max-w-3xl w-full max-h-[80vh] min-h-[500px] max-md:min-h-0 p-0 gap-0 flex flex-col overflow-hidden">
-        {/* Header */}
-        <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between shrink-0">
-          <div>
-            <h2 className="text-lg font-medium">Project Settings</h2>
-            <p className="text-sm text-muted-foreground mt-1">
-              Configure characters, routes, visual system, and world bible
-              elements.
-            </p>
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={handleOpenChange}
+        aria-label="Project Settings"
+      >
+        <DialogContent className="max-w-3xl w-full max-h-[80vh] min-h-[500px] max-md:min-h-0 p-0 gap-0 flex flex-col overflow-hidden">
+          {/* Header */}
+          <div className="p-6 max-sm:p-4 border-b border-border/30 flex items-start justify-between shrink-0">
+            <div>
+              <h2 className="text-lg font-medium">Project Settings</h2>
+              <p className="text-sm text-muted-foreground mt-1">
+                Configure characters, routes, visual system, and world bible
+                elements.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => handleOpenChange(false)}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Close project settings"
+            >
+              <X className="size-5" />
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={() => onOpenChange(false)}
-            className="text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="Close project settings"
+
+          {/* Tabs */}
+          <Tabs
+            value={activeTab}
+            onValueChange={(next) => setActiveTab(next as SettingsTab)}
+            className="flex flex-col flex-1 min-h-0"
           >
-            <X className="size-5" />
-          </button>
-        </div>
+            <div className="px-3 pt-2 pb-3 shrink-0 sm:px-6">
+              <TabsList ariaLabel="Project settings sections" scrollable>
+                {TAB_ORDER.map((tab) => {
+                  const Icon = TAB_ICONS[tab];
+                  return (
+                    <TabsTrigger key={tab} value={tab}>
+                      <span className="inline-flex items-center gap-1.5">
+                        <Icon className="size-3.5" />
+                        {TAB_LABELS[tab]}
+                      </span>
+                    </TabsTrigger>
+                  );
+                })}
+              </TabsList>
+            </div>
 
-        {/* Tabs */}
-        <Tabs
-          value={activeTab}
-          onValueChange={(next) => setActiveTab(next as SettingsTab)}
-          className="flex flex-col flex-1 min-h-0"
-        >
-          <div className="px-3 pt-2 pb-3 shrink-0 sm:px-6">
-            <TabsList ariaLabel="Project settings sections" scrollable>
-              {TAB_ORDER.map((tab) => {
-                const Icon = TAB_ICONS[tab];
-                return (
-                  <TabsTrigger key={tab} value={tab}>
-                    <span className="inline-flex items-center gap-1.5">
-                      <Icon className="size-3.5" />
-                      {TAB_LABELS[tab]}
-                    </span>
-                  </TabsTrigger>
-                );
-              })}
-            </TabsList>
+            <div className="flex-1 overflow-y-auto p-6 max-sm:p-4">
+              <TabsPanel value="characters" className="space-y-4">
+                <CharactersTabContent projectId={projectId} />
+              </TabsPanel>
+              <TabsPanel value="routes" className="space-y-4">
+                <RouteSettingsContent projectId={projectId} columns={2} />
+              </TabsPanel>
+              <TabsPanel value="world" className="space-y-4">
+                <WorldElementsSettingsContent projectId={projectId} />
+              </TabsPanel>
+              <TabsPanel value="visual" className="space-y-4">
+                <VisualSystemTabContent
+                  projectId={projectId}
+                  onDirtyChange={setVisualSystemDirty}
+                />
+              </TabsPanel>
+            </div>
+          </Tabs>
+
+          {/* Footer */}
+          <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end shrink-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+            >
+              Close
+            </Button>
           </div>
-
-          <div className="flex-1 overflow-y-auto p-6 max-sm:p-4">
-            <TabsPanel value="characters" className="space-y-4">
-              <CharactersTabContent projectId={projectId} />
-            </TabsPanel>
-            <TabsPanel value="routes" className="space-y-4">
-              <RouteSettingsContent projectId={projectId} columns={2} />
-            </TabsPanel>
-            <TabsPanel value="world" className="space-y-4">
-              <WorldElementsSettingsContent projectId={projectId} />
-            </TabsPanel>
-            <TabsPanel value="visual" className="space-y-4">
-              <VisualSystemTabContent projectId={projectId} />
-            </TabsPanel>
-          </div>
-        </Tabs>
-
-        {/* Footer */}
-        <div className="p-6 max-sm:p-4 border-t border-border/30 flex justify-end shrink-0">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-          >
-            Close
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }
 
@@ -214,9 +238,13 @@ function CharactersTabContent({ projectId }: CharactersTabContentProps) {
 
 interface VisualSystemTabContentProps {
   projectId: string;
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
-function VisualSystemTabContent({ projectId }: VisualSystemTabContentProps) {
+function VisualSystemTabContent({
+  projectId,
+  onDirtyChange,
+}: VisualSystemTabContentProps) {
   const { config, isLoading, isError, isSaving, updateConfig, refetch } =
     useVisualSystem(projectId);
 
@@ -287,6 +315,7 @@ function VisualSystemTabContent({ projectId }: VisualSystemTabContentProps) {
       // button (or the X in the header). Keeping Cancel visible
       // preserves visual parity with the standalone dialog.
       onClose={() => {}}
+      onDirtyChange={onDirtyChange}
     />
   );
 }

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -99,6 +99,7 @@ export function ProjectSettingsDialog({
   // tracker produces is the cost of this pattern.)
   const [activeTab, setActiveTab] = useState<SettingsTab>(defaultTab);
   const [visualSystemDirty, setVisualSystemDirty] = useState(false);
+  const [visualFormSession, setVisualFormSession] = useState(0);
   // react-doctor-disable-next-line react-doctor/no-derived-useState, react-doctor/rerender-state-only-in-handlers
   const [prevOpen, setPrevOpen] = useState(open);
   // react-doctor-disable-next-line react-doctor/no-derived-useState, react-doctor/rerender-state-only-in-handlers
@@ -108,8 +109,7 @@ export function ProjectSettingsDialog({
     setPrevDefaultTab(defaultTab);
     if (open) {
       setActiveTab(defaultTab);
-    } else {
-      setVisualSystemDirty(false);
+      setVisualFormSession((s) => s + 1);
     }
   }
 
@@ -151,7 +151,6 @@ export function ProjectSettingsDialog({
           <Tabs
             value={activeTab}
             onValueChange={(next) => {
-              if (next !== "visual") setVisualSystemDirty(false);
               setActiveTab(next as SettingsTab);
             }}
             className="flex flex-col flex-1 min-h-0"
@@ -184,6 +183,7 @@ export function ProjectSettingsDialog({
               </TabsPanel>
               <TabsPanel value="visual" className="space-y-4">
                 <VisualSystemTabContent
+                  key={visualFormSession}
                   projectId={projectId}
                   onDirtyChange={setVisualSystemDirty}
                 />
@@ -311,7 +311,6 @@ function VisualSystemTabContent({
 
   return (
     <VisualSystemFormContent
-      key="visual-system-tab"
       initialConfig={config}
       isSaving={isSaving}
       onSave={handleSave}

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -120,6 +120,13 @@ export function ProjectSettingsDialog({
     setDiscardDialogOpen,
   } = useDirtyDialogWarning(visualSystemDirty, onOpenChange);
 
+  const handleConfirmDiscard = () => {
+    // Clear lifted dirty flag before close so a reopen does not inherit a
+    // stale dirty=true while the remounted form is clean.
+    setVisualSystemDirty(false);
+    confirmDiscard();
+  };
+
   return (
     <>
       <Dialog
@@ -206,7 +213,7 @@ export function ProjectSettingsDialog({
       <ConfirmDialog
         open={discardDialogOpen}
         onOpenChange={setDiscardDialogOpen}
-        onConfirm={confirmDiscard}
+        onConfirm={handleConfirmDiscard}
         title="Discard unsaved changes?"
         description="You have unsaved changes. Are you sure you want to discard them?"
         confirmLabel="Discard"

--- a/apps/frontend/src/components/__tests__/DialogA11y.test.tsx
+++ b/apps/frontend/src/components/__tests__/DialogA11y.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { useState } from "react";
@@ -98,5 +98,15 @@ describe("Dialog keyboard navigation", () => {
     expect(screen.getByTestId("middle-button")).toBeInTheDocument();
     expect(screen.getByTestId("last-button")).toBeInTheDocument();
     expect(screen.getByTestId("outside-button")).toBeInTheDocument();
+  });
+
+  it("prevents default on native cancel event to block native dialog Escape close", () => {
+    render(<TestDialogWrapper />);
+    const dialog = document.querySelector("dialog")!;
+    const cancelEvent = new Event("cancel", { cancelable: true });
+    act(() => {
+      dialog.dispatchEvent(cancelEvent);
+    });
+    expect(cancelEvent.defaultPrevented).toBe(true);
   });
 });

--- a/apps/frontend/src/components/__tests__/DialogA11y.test.tsx
+++ b/apps/frontend/src/components/__tests__/DialogA11y.test.tsx
@@ -11,6 +11,9 @@ import { describe, it, expect } from "vitest";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { useDirtyForm } from "@/hooks/useDirtyForm";
+import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
 import { useState } from "react";
 
 function TestDialogWrapper({ initialOpen = true }: { initialOpen?: boolean }) {
@@ -41,6 +44,52 @@ function TestDialogWrapper({ initialOpen = true }: { initialOpen?: boolean }) {
 
 function getActiveElement() {
   return document.activeElement as HTMLElement | null;
+}
+
+function PersistentDirtyDialog() {
+  const [open, setOpen] = useState(true);
+  const [name, setName] = useState("edited");
+  const { isDirty } = useDirtyForm({ name: "original" }, { name });
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, setOpen);
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={handleOpenChange}
+        aria-label="Persistent dirty"
+      >
+        <DialogContent>
+          <DialogTitle>Persistent dirty</DialogTitle>
+          <input
+            aria-label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <button type="button" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </button>
+          <button type="button" onClick={() => setOpen(false)}>
+            Save and close
+          </button>
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
+  );
 }
 
 describe("Dialog keyboard navigation", () => {
@@ -108,5 +157,38 @@ describe("Dialog keyboard navigation", () => {
       dialog.dispatchEvent(cancelEvent);
     });
     expect(cancelEvent.defaultPrevented).toBe(true);
+  });
+
+  it("does not re-enter dirty guard on prop-driven close after successful save", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<PersistentDirtyDialog />);
+
+    // Form starts dirty (name diverges from baseline)
+    expect(screen.getByLabelText("Name")).toHaveValue("edited");
+
+    // Simulate save-success close: parent sets open=false while still dirty
+    await user.click(screen.getByRole("button", { name: /save and close/i }));
+
+    // Prop-driven dialog.close() must not bounce into handleOpenChange(false)
+    expect(
+      screen.queryByRole("heading", { name: /discard unsaved changes/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: /persistent dirty/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not reopen discard prompt after confirmDiscard on a persistent dirty form", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<PersistentDirtyDialog />);
+
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(screen.getByText(/discard unsaved changes/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^discard$/i }));
+
+    expect(
+      screen.queryByRole("heading", { name: /discard unsaved changes/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/ide-shared/ProjectEditDialog.tsx
+++ b/apps/frontend/src/components/ide-shared/ProjectEditDialog.tsx
@@ -12,6 +12,9 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { FormErrorMessage } from "@/components/ui/form-error-message";
 import type { Project, UpdateProjectBody } from "@/lib/api/projects";
+import { useDirtyForm } from "@/hooks/useDirtyForm";
+import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 interface ProjectEditDialogProps {
   open: boolean;
@@ -74,6 +77,20 @@ export function ProjectEditDialog({
   const [isSaving, setIsSaving] = useState(false);
   const previousOpenRef = useRef(false);
   const previousProjectIdRef = useRef<string | null>(null);
+  const projectSnapshot = project
+    ? { name: project.name, description: (project.description ?? "").trim() }
+    : { name: "", description: "" };
+  const formSnapshot = {
+    name: formState.name.trim(),
+    description: formState.description.trim(),
+  };
+  const { isDirty } = useDirtyForm(projectSnapshot, formSnapshot);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
 
   const nameErrorId = "edit-project-name-error";
 
@@ -104,11 +121,6 @@ export function ProjectEditDialog({
       previousProjectIdRef.current = null;
     }
   }, [open, project]);
-
-  const hasChanges =
-    project &&
-    (formState.name.trim() !== project.name ||
-      formState.description.trim() !== (project.description ?? "").trim());
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -168,87 +180,101 @@ export function ProjectEditDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[500px] max-w-[95vw]">
-        <DialogHeader className="flex flex-row items-center justify-between gap-y-0 pb-4">
-          <DialogTitle>Edit Project</DialogTitle>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => onOpenChange(false)}
-            aria-label="Close"
-          >
-            <X className="size-5" />
-          </Button>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="w-[500px] max-w-[95vw]">
+          <DialogHeader className="flex flex-row items-center justify-between gap-y-0 pb-4">
+            <DialogTitle>Edit Project</DialogTitle>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => handleOpenChange(false)}
+              aria-label="Close"
+            >
+              <X className="size-5" />
+            </Button>
+          </DialogHeader>
 
-        {!isProjectOwner ? (
-          <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-600 dark:text-amber-400">
-            This project is read-only. Only the project owner can edit project
-            details.
-          </div>
-        ) : (
-          <form onSubmit={handleSubmit} className="space-y-4" noValidate>
-            <div className="space-y-2">
-              <Label htmlFor="edit-project-name">Project name *</Label>
-              <Input
-                id="edit-project-name"
-                value={formState.name}
-                onChange={(e) =>
-                  dispatch({ type: "SET_NAME", payload: e.target.value })
-                }
-                disabled={isSaving}
-                maxLength={200}
-                aria-required="true"
-                aria-invalid={formState.error ? true : undefined}
-                aria-describedby={formState.error ? nameErrorId : undefined}
+          {!isProjectOwner ? (
+            <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-600 dark:text-amber-400">
+              This project is read-only. Only the project owner can edit project
+              details.
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+              <div className="space-y-2">
+                <Label htmlFor="edit-project-name">Project name *</Label>
+                <Input
+                  id="edit-project-name"
+                  value={formState.name}
+                  onChange={(e) =>
+                    dispatch({ type: "SET_NAME", payload: e.target.value })
+                  }
+                  disabled={isSaving}
+                  maxLength={200}
+                  aria-required="true"
+                  aria-invalid={formState.error ? true : undefined}
+                  aria-describedby={formState.error ? nameErrorId : undefined}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="edit-project-description">Description</Label>
+                <Textarea
+                  id="edit-project-description"
+                  value={formState.description}
+                  onChange={(e) =>
+                    dispatch({
+                      type: "SET_DESCRIPTION",
+                      payload: e.target.value,
+                    })
+                  }
+                  disabled={isSaving}
+                  maxLength={2000}
+                  rows={4}
+                  className="resize-y"
+                />
+              </div>
+
+              <FormErrorMessage
+                id={nameErrorId}
+                message={formState.error ?? undefined}
               />
-            </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="edit-project-description">Description</Label>
-              <Textarea
-                id="edit-project-description"
-                value={formState.description}
-                onChange={(e) =>
-                  dispatch({ type: "SET_DESCRIPTION", payload: e.target.value })
-                }
-                disabled={isSaving}
-                maxLength={2000}
-                rows={4}
-                className="resize-y"
-              />
-            </div>
-
-            <FormErrorMessage
-              id={nameErrorId}
-              message={formState.error ?? undefined}
-            />
-
-            <div className="flex justify-end gap-2 pt-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={isSaving}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" disabled={isSaving || !hasChanges}>
-                {isSaving ? (
-                  <>
-                    <Loader2 className="mr-2 size-4 animate-spin" />
-                    Saving…
-                  </>
-                ) : (
-                  "Save Changes"
-                )}
-              </Button>
-            </div>
-          </form>
-        )}
-      </DialogContent>
-    </Dialog>
+              <div className="flex justify-end gap-2 pt-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isSaving || !isDirty}>
+                  {isSaving ? (
+                    <>
+                      <Loader2 className="mr-2 size-4 animate-spin" />
+                      Saving…
+                    </>
+                  ) : (
+                    "Save Changes"
+                  )}
+                </Button>
+              </div>
+            </form>
+          )}
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }

--- a/apps/frontend/src/components/ide-shared/ProjectEditDialog.tsx
+++ b/apps/frontend/src/components/ide-shared/ProjectEditDialog.tsx
@@ -78,7 +78,10 @@ export function ProjectEditDialog({
   const previousOpenRef = useRef(false);
   const previousProjectIdRef = useRef<string | null>(null);
   const projectSnapshot = project
-    ? { name: project.name, description: (project.description ?? "").trim() }
+    ? {
+        name: (project.name ?? "").trim(),
+        description: (project.description ?? "").trim(),
+      }
     : { name: "", description: "" };
   const formSnapshot = {
     name: formState.name.trim(),

--- a/apps/frontend/src/components/ide-shared/__tests__/ProjectEditDialog.dirty.test.tsx
+++ b/apps/frontend/src/components/ide-shared/__tests__/ProjectEditDialog.dirty.test.tsx
@@ -172,4 +172,25 @@ describe("ProjectEditDialog — dirty form guard (SF-1)", () => {
     // The dialog closed (onOpenChange(false) was called from handleSubmit)
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
+
+  it("shows discard confirmation when Escape is pressed with dirty form", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(
+      <ProjectEditDialog
+        open
+        project={mockProject}
+        isProjectOwner
+        onOpenChange={onOpenChange}
+        onUpdate={onUpdate}
+      />
+    );
+
+    const nameInput = screen.getByLabelText(/project name/i);
+    await user.type(nameInput, "2");
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByText(/discard unsaved changes/i)).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
 });

--- a/apps/frontend/src/components/ide-shared/__tests__/ProjectEditDialog.dirty.test.tsx
+++ b/apps/frontend/src/components/ide-shared/__tests__/ProjectEditDialog.dirty.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Tests for the dirty-form guard on ProjectEditDialog (oracle SF-1).
+ *
+ * Verifies that the Save Changes button is disabled when the form is
+ * clean, that unsaved changes trigger a discard confirmation on Cancel,
+ * and that the dialog closes cleanly on successful save without showing
+ * the discard prompt.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Project } from "@/lib/api/projects";
+import { ProjectEditDialog } from "@/components/ide-shared/ProjectEditDialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockProject: Project = {
+  id: "project-1",
+  name: "Test Project",
+  description: "A test project description",
+  source: "GITLAB",
+  duoEndingEnabled: false,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+const updatedProject: Project = {
+  ...mockProject,
+  name: "Updated Project",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ProjectEditDialog — dirty form guard (SF-1)", () => {
+  const onOpenChange = vi.fn();
+  const onUpdate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disables Save Changes when the form is clean", () => {
+    render(
+      <ProjectEditDialog
+        open
+        project={mockProject}
+        isProjectOwner
+        onOpenChange={onOpenChange}
+        onUpdate={onUpdate}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /save changes/i })
+    ).toBeDisabled();
+  });
+
+  it("enables Save Changes after editing the name field", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(
+      <ProjectEditDialog
+        open
+        project={mockProject}
+        isProjectOwner
+        onOpenChange={onOpenChange}
+        onUpdate={onUpdate}
+      />
+    );
+
+    const nameInput = screen.getByLabelText(/project name/i);
+    await user.type(nameInput, "2");
+
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeEnabled();
+  });
+
+  it("shows discard confirmation when Cancel is clicked with dirty form", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(
+      <ProjectEditDialog
+        open
+        project={mockProject}
+        isProjectOwner
+        onOpenChange={onOpenChange}
+        onUpdate={onUpdate}
+      />
+    );
+
+    // Edit the name so the form becomes dirty
+    const nameInput = screen.getByLabelText(/project name/i);
+    await user.type(nameInput, "2");
+
+    // Click the Cancel button
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    // ConfirmDialog should appear with the discard message
+    expect(screen.getByText(/discard unsaved changes/i)).toBeInTheDocument();
+  });
+
+  it("calls onOpenChange(false) when Discard is clicked", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(
+      <ProjectEditDialog
+        open
+        project={mockProject}
+        isProjectOwner
+        onOpenChange={onOpenChange}
+        onUpdate={onUpdate}
+      />
+    );
+
+    const nameInput = screen.getByLabelText(/project name/i);
+    await user.type(nameInput, "2");
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    await user.click(screen.getByRole("button", { name: /^discard$/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the dialog open when Keep editing is clicked after dirty cancel", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(
+      <ProjectEditDialog
+        open
+        project={mockProject}
+        isProjectOwner
+        onOpenChange={onOpenChange}
+        onUpdate={onUpdate}
+      />
+    );
+
+    const nameInput = screen.getByLabelText(/project name/i);
+    await user.type(nameInput, "2");
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    await user.click(screen.getByRole("button", { name: /^keep editing$/i }));
+
+    // The discard dialog is dismissed but the main dialog stays open
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("closes dialog via onOpenChange(false) on successful save without discard prompt", async () => {
+    onUpdate.mockResolvedValue(updatedProject);
+    const user = userEvent.setup({ delay: null });
+    render(
+      <ProjectEditDialog
+        open
+        project={mockProject}
+        isProjectOwner
+        onOpenChange={onOpenChange}
+        onUpdate={onUpdate}
+      />
+    );
+
+    const nameInput = screen.getByLabelText(/project name/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Updated Project");
+
+    await user.click(screen.getByRole("button", { name: /^save changes$/i }));
+
+    // The update API was called with correct args
+    expect(onUpdate).toHaveBeenCalledWith("project-1", {
+      name: "Updated Project",
+      description: "A test project description",
+    });
+
+    // The dialog closed (onOpenChange(false) was called from handleSubmit)
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/frontend/src/components/pair-groups/PairGroupEditDialog.dirty.test.tsx
+++ b/apps/frontend/src/components/pair-groups/PairGroupEditDialog.dirty.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Dirty-form guard coverage for PairGroupEditDialog create/edit forms.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PairGroupWithNames } from "@branchforge/shared";
+import { PairGroupEditDialog } from "@/components/pair-groups/PairGroupEditDialog";
+
+vi.mock("@/hooks/usePairGroups", () => ({
+  usePairGroups: vi.fn(),
+}));
+
+vi.mock("@/hooks/useCharacters", () => ({
+  useCharacters: vi.fn(),
+}));
+
+import { usePairGroups } from "@/hooks/usePairGroups";
+import { useCharacters } from "@/hooks/useCharacters";
+
+const mockPairGroup: PairGroupWithNames = {
+  id: "pg-1",
+  projectId: "project-1",
+  characterAId: "char-a",
+  characterBId: "char-b",
+  characterAName: "Alex",
+  characterBName: "Blake",
+  duoEndingLabel: "best_friends_ending",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+describe("PairGroupEditDialog — dirty form guard", () => {
+  const createPairGroup = vi.fn();
+  const updatePairGroup = vi.fn();
+  const onOpenChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useCharacters).mockReturnValue({
+      characters: [
+        { id: "char-a", displayName: "Alex" },
+        { id: "char-b", displayName: "Blake" },
+      ],
+    } as never);
+
+    vi.mocked(usePairGroups).mockReturnValue({
+      pairGroups: [mockPairGroup],
+      isLoading: false,
+      error: null,
+      isDeleting: false,
+      isUpdating: false,
+      isCreating: false,
+      refresh: vi.fn(),
+      createPairGroup,
+      updatePairGroup,
+      deletePairGroup: vi.fn(),
+    } as never);
+  });
+
+  it("disables Create when the create form is clean", () => {
+    render(
+      <PairGroupEditDialog
+        open
+        onOpenChange={onOpenChange}
+        projectId="project-1"
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /create pair group/i })
+    ).toBeDisabled();
+  });
+
+  it("shows discard confirmation when Cancel is clicked on a dirty create form", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(
+      <PairGroupEditDialog
+        open
+        onOpenChange={onOpenChange}
+        projectId="project-1"
+      />
+    );
+
+    await user.type(screen.getByLabelText(/duo ending label/i), "new_ending");
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    expect(screen.getByText(/discard unsaved changes/i)).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("closes via onOpenChange(false) on successful create without discard prompt", async () => {
+    createPairGroup.mockResolvedValue(mockPairGroup);
+    const user = userEvent.setup({ delay: null });
+    render(
+      <PairGroupEditDialog
+        open
+        onOpenChange={onOpenChange}
+        projectId="project-1"
+      />
+    );
+
+    await user.click(screen.getByLabelText(/character a/i));
+    await user.click(screen.getByRole("option", { name: "Alex" }));
+    await user.click(screen.getByLabelText(/character b/i));
+    await user.click(screen.getByRole("option", { name: "Blake" }));
+    await user.type(screen.getByLabelText(/duo ending label/i), "new_ending");
+
+    await user.click(
+      screen.getByRole("button", { name: /create pair group/i })
+    );
+
+    expect(createPairGroup).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(
+      screen.queryByRole("heading", { name: /discard unsaved changes/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables Save when the edit form is clean", () => {
+    render(
+      <PairGroupEditDialog
+        open
+        onOpenChange={onOpenChange}
+        projectId="project-1"
+        pairGroupId="pg-1"
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+  });
+
+  it("shows discard confirmation on Escape for a dirty edit form", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(
+      <PairGroupEditDialog
+        open
+        onOpenChange={onOpenChange}
+        projectId="project-1"
+        pairGroupId="pg-1"
+      />
+    );
+
+    const input = screen.getByLabelText(/duo ending label/i);
+    await user.clear(input);
+    await user.type(input, "changed_ending");
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByText(/discard unsaved changes/i)).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("closes via onOpenChange(false) on successful edit save without discard prompt", async () => {
+    updatePairGroup.mockResolvedValue({
+      ...mockPairGroup,
+      duoEndingLabel: "changed_ending",
+    });
+    const user = userEvent.setup({ delay: null });
+    render(
+      <PairGroupEditDialog
+        open
+        onOpenChange={onOpenChange}
+        projectId="project-1"
+        pairGroupId="pg-1"
+      />
+    );
+
+    const input = screen.getByLabelText(/duo ending label/i);
+    await user.clear(input);
+    await user.type(input, "changed_ending");
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(updatePairGroup).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(
+      screen.queryByRole("heading", { name: /discard unsaved changes/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/pair-groups/PairGroupEditDialog.tsx
+++ b/apps/frontend/src/components/pair-groups/PairGroupEditDialog.tsx
@@ -5,7 +5,7 @@
  * Pattern matches RouteEditDialog — standalone dialog with form.
  */
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Loader2 } from "lucide-react";
 import {
   Dialog,
@@ -24,6 +24,9 @@ import { usePairGroups } from "@/hooks/usePairGroups";
 import { useCharacters } from "@/hooks/useCharacters";
 import type { PairGroupWithNames } from "@branchforge/shared";
 import { trimRequiredDuoEndingLabel } from "./pair-group-label";
+import { useDirtyForm } from "@/hooks/useDirtyForm";
+import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 // ============================================================================
 // Types
@@ -80,12 +83,14 @@ function CreateForm({
   characters,
   isSaving,
   onSave,
-  onCancel,
+  onClose,
+  onDirtyChange,
 }: {
   characters: Array<{ id: string; displayName: string }>;
   isSaving: boolean;
   onSave: (form: PairGroupFormState) => Promise<void>;
-  onCancel: () => void;
+  onClose: () => void;
+  onDirtyChange: (dirty: boolean) => void;
 }) {
   const [form, setForm] = useState<PairGroupFormState>({
     characterAId: "",
@@ -93,6 +98,15 @@ function CreateForm({
     duoEndingLabel: "",
   });
   const [errors, setErrors] = useState<PairGroupFormErrors>({});
+
+  const { isDirty } = useDirtyForm(
+    { characterAId: "", characterBId: "", duoEndingLabel: "" },
+    form
+  );
+
+  useEffect(() => {
+    onDirtyChange(isDirty);
+  }, [isDirty, onDirtyChange]);
 
   const handleChange = (field: keyof PairGroupFormState, value: string) => {
     setForm((prev) => {
@@ -205,12 +219,16 @@ function CreateForm({
         <Button
           type="button"
           variant="outline"
-          onClick={onCancel}
+          onClick={onClose}
           disabled={isSaving}
         >
           Cancel
         </Button>
-        <Button type="button" onClick={handleSave} disabled={isSaving}>
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || isSaving}
+        >
           {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
           Create Pair Group
         </Button>
@@ -227,17 +245,28 @@ function EditForm({
   pairGroup,
   isSaving,
   onSave,
-  onCancel,
+  onClose,
+  onDirtyChange,
 }: {
   pairGroup: PairGroupWithNames;
   isSaving: boolean;
   onSave: (data: { duoEndingLabel?: string }) => Promise<void>;
-  onCancel: () => void;
+  onClose: () => void;
+  onDirtyChange: (dirty: boolean) => void;
 }) {
   const [form, setForm] = useState({
     duoEndingLabel: pairGroup.duoEndingLabel,
   });
   const [error, setError] = useState<string | null>(null);
+
+  const { isDirty } = useDirtyForm(
+    { duoEndingLabel: pairGroup.duoEndingLabel },
+    form
+  );
+
+  useEffect(() => {
+    onDirtyChange(isDirty);
+  }, [isDirty, onDirtyChange]);
 
   const handleSave = async () => {
     const labelResult = trimRequiredDuoEndingLabel(form.duoEndingLabel);
@@ -289,12 +318,16 @@ function EditForm({
         <Button
           type="button"
           variant="outline"
-          onClick={onCancel}
+          onClick={onClose}
           disabled={isSaving}
         >
           Cancel
         </Button>
-        <Button type="button" onClick={handleSave} disabled={isSaving}>
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || isSaving}
+        >
           {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
           Save
         </Button>
@@ -326,6 +359,13 @@ export function PairGroupEditDialog({
 
   const isEditMode = !!pairGroupId;
   const isSaving = isCreating || isUpdating;
+  const [isDirty, setIsDirty] = useState(false);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
 
   const sortedCharacters = characters
     .toSorted((a, b) => a.displayName.localeCompare(b.displayName))
@@ -369,7 +409,7 @@ export function PairGroupEditDialog({
 
   if (isEditMode && isLoadingPairGroups) {
     return (
-      <Dialog open={effectiveOpen} onOpenChange={onOpenChange}>
+      <Dialog open={effectiveOpen} onOpenChange={handleOpenChange}>
         <DialogContent className="max-w-md w-full">
           <DialogHeader>
             <DialogTitle>Edit Pair Group</DialogTitle>
@@ -384,37 +424,50 @@ export function PairGroupEditDialog({
   }
 
   return (
-    <Dialog open={effectiveOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md w-full">
-        <DialogHeader>
-          <DialogTitle>
-            {isEditMode ? "Edit Pair Group" : "Add Pair Group"}
-          </DialogTitle>
-          <DialogDescription>
-            {isEditMode
-              ? "Update the duo ending settings."
-              : "Create a new pair group for duo ending tracking."}
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={effectiveOpen} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-md w-full">
+          <DialogHeader>
+            <DialogTitle>
+              {isEditMode ? "Edit Pair Group" : "Add Pair Group"}
+            </DialogTitle>
+            <DialogDescription>
+              {isEditMode
+                ? "Update the duo ending settings."
+                : "Create a new pair group for duo ending tracking."}
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="mt-4">
-          {isEditMode && existingPairGroup ? (
-            <EditForm
-              pairGroup={existingPairGroup}
-              isSaving={isSaving}
-              onSave={handleUpdate}
-              onCancel={() => onOpenChange(false)}
-            />
-          ) : (
-            <CreateForm
-              characters={sortedCharacters}
-              isSaving={isSaving}
-              onSave={handleCreate}
-              onCancel={() => onOpenChange(false)}
-            />
-          )}
-        </div>
-      </DialogContent>
-    </Dialog>
+          <div className="mt-4">
+            {isEditMode && existingPairGroup ? (
+              <EditForm
+                pairGroup={existingPairGroup}
+                isSaving={isSaving}
+                onSave={handleUpdate}
+                onClose={() => handleOpenChange(false)}
+                onDirtyChange={setIsDirty}
+              />
+            ) : (
+              <CreateForm
+                characters={sortedCharacters}
+                isSaving={isSaving}
+                onSave={handleCreate}
+                onClose={() => handleOpenChange(false)}
+                onDirtyChange={setIsDirty}
+              />
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }

--- a/apps/frontend/src/components/pair-groups/PairGroupEditDialog.tsx
+++ b/apps/frontend/src/components/pair-groups/PairGroupEditDialog.tsx
@@ -5,7 +5,7 @@
  * Pattern matches RouteEditDialog — standalone dialog with form.
  */
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Loader2 } from "lucide-react";
 import {
   Dialog,
@@ -83,14 +83,14 @@ function CreateForm({
   characters,
   isSaving,
   onSave,
-  onClose,
-  onDirtyChange,
+  open,
+  onOpenChange,
 }: {
   characters: Array<{ id: string; displayName: string }>;
   isSaving: boolean;
   onSave: (form: PairGroupFormState) => Promise<void>;
-  onClose: () => void;
-  onDirtyChange: (dirty: boolean) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }) {
   const [form, setForm] = useState<PairGroupFormState>({
     characterAId: "",
@@ -104,9 +104,12 @@ function CreateForm({
     form
   );
 
-  useEffect(() => {
-    onDirtyChange(isDirty);
-  }, [isDirty, onDirtyChange]);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
 
   const handleChange = (field: keyof PairGroupFormState, value: string) => {
     setForm((prev) => {
@@ -131,7 +134,12 @@ function CreateForm({
       setErrors(validationErrors);
       return;
     }
-    await onSave(form);
+    try {
+      await onSave(form);
+      onOpenChange(false);
+    } catch {
+      // Keep dialog open on error
+    }
   };
 
   const charOptions = characters.map((c) => ({
@@ -143,97 +151,124 @@ function CreateForm({
   );
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-1">
-        <Label htmlFor="pair-char-a" className="text-xs">
-          Character A *
-        </Label>
-        <Select
-          id="pair-char-a"
-          options={charOptions}
-          value={form.characterAId || undefined}
-          onChange={(value: string) => handleChange("characterAId", value)}
-          placeholder="Select character A..."
-          disabled={isSaving || characters.length === 0}
-          aria-required="true"
-          aria-invalid={!!errors.characterAId}
-          aria-describedby={
-            errors.characterAId ? "pair-char-a-error" : undefined
-          }
-        />
-        <FormErrorMessage
-          id="pair-char-a-error"
-          message={errors.characterAId}
-        />
-      </div>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-md w-full">
+          <DialogHeader>
+            <DialogTitle>Add Pair Group</DialogTitle>
+            <DialogDescription>
+              Create a new pair group for duo ending tracking.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-4">
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <Label htmlFor="pair-char-a" className="text-xs">
+                  Character A *
+                </Label>
+                <Select
+                  id="pair-char-a"
+                  options={charOptions}
+                  value={form.characterAId || undefined}
+                  onChange={(value: string) =>
+                    handleChange("characterAId", value)
+                  }
+                  placeholder="Select character A..."
+                  disabled={isSaving || characters.length === 0}
+                  aria-required="true"
+                  aria-invalid={!!errors.characterAId}
+                  aria-describedby={
+                    errors.characterAId ? "pair-char-a-error" : undefined
+                  }
+                />
+                <FormErrorMessage
+                  id="pair-char-a-error"
+                  message={errors.characterAId}
+                />
+              </div>
 
-      <div className="space-y-1">
-        <Label htmlFor="pair-char-b" className="text-xs">
-          Character B *
-        </Label>
-        <Select
-          id="pair-char-b"
-          options={availableB}
-          value={form.characterBId || undefined}
-          onChange={(value: string) => handleChange("characterBId", value)}
-          placeholder="Select character B..."
-          disabled={isSaving || !form.characterAId}
-          aria-required="true"
-          aria-invalid={!!errors.characterBId}
-          aria-describedby={
-            errors.characterBId ? "pair-char-b-error" : undefined
-          }
-        />
-        <FormErrorMessage
-          id="pair-char-b-error"
-          message={errors.characterBId}
-        />
-      </div>
+              <div className="space-y-1">
+                <Label htmlFor="pair-char-b" className="text-xs">
+                  Character B *
+                </Label>
+                <Select
+                  id="pair-char-b"
+                  options={availableB}
+                  value={form.characterBId || undefined}
+                  onChange={(value: string) =>
+                    handleChange("characterBId", value)
+                  }
+                  placeholder="Select character B..."
+                  disabled={isSaving || !form.characterAId}
+                  aria-required="true"
+                  aria-invalid={!!errors.characterBId}
+                  aria-describedby={
+                    errors.characterBId ? "pair-char-b-error" : undefined
+                  }
+                />
+                <FormErrorMessage
+                  id="pair-char-b-error"
+                  message={errors.characterBId}
+                />
+              </div>
 
-      <div className="space-y-1">
-        <Label htmlFor="pair-duo-label" className="text-xs">
-          Duo Ending Label *
-        </Label>
-        <Input
-          id="pair-duo-label"
-          type="text"
-          placeholder="e.g., best_friends_ending"
-          value={form.duoEndingLabel}
-          onChange={(event) =>
-            handleChange("duoEndingLabel", event.target.value)
-          }
-          disabled={isSaving}
-          aria-required="true"
-          aria-invalid={!!errors.duoEndingLabel}
-          aria-describedby={
-            errors.duoEndingLabel ? "pair-duo-label-error" : undefined
-          }
-        />
-        <FormErrorMessage
-          id="pair-duo-label-error"
-          message={errors.duoEndingLabel}
-        />
-      </div>
+              <div className="space-y-1">
+                <Label htmlFor="pair-duo-label" className="text-xs">
+                  Duo Ending Label *
+                </Label>
+                <Input
+                  id="pair-duo-label"
+                  type="text"
+                  placeholder="e.g., best_friends_ending"
+                  value={form.duoEndingLabel}
+                  onChange={(event) =>
+                    handleChange("duoEndingLabel", event.target.value)
+                  }
+                  disabled={isSaving}
+                  aria-required="true"
+                  aria-invalid={!!errors.duoEndingLabel}
+                  aria-describedby={
+                    errors.duoEndingLabel ? "pair-duo-label-error" : undefined
+                  }
+                />
+                <FormErrorMessage
+                  id="pair-duo-label-error"
+                  message={errors.duoEndingLabel}
+                />
+              </div>
 
-      <div className="flex justify-end gap-2 pt-2">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onClose}
-          disabled={isSaving}
-        >
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          onClick={handleSave}
-          disabled={!isDirty || isSaving}
-        >
-          {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
-          Create Pair Group
-        </Button>
-      </div>
-    </div>
+              <div className="flex justify-end gap-2 pt-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={!isDirty || isSaving}
+                >
+                  {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
+                  Create Pair Group
+                </Button>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }
 
@@ -245,14 +280,14 @@ function EditForm({
   pairGroup,
   isSaving,
   onSave,
-  onClose,
-  onDirtyChange,
+  open,
+  onOpenChange,
 }: {
   pairGroup: PairGroupWithNames;
   isSaving: boolean;
   onSave: (data: { duoEndingLabel?: string }) => Promise<void>;
-  onClose: () => void;
-  onDirtyChange: (dirty: boolean) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }) {
   const [form, setForm] = useState({
     duoEndingLabel: pairGroup.duoEndingLabel,
@@ -264,9 +299,12 @@ function EditForm({
     form
   );
 
-  useEffect(() => {
-    onDirtyChange(isDirty);
-  }, [isDirty, onDirtyChange]);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
 
   const handleSave = async () => {
     const labelResult = trimRequiredDuoEndingLabel(form.duoEndingLabel);
@@ -276,63 +314,93 @@ function EditForm({
     }
     setError(null);
 
-    await onSave({
-      duoEndingLabel: labelResult.value,
-    });
+    try {
+      await onSave({
+        duoEndingLabel: labelResult.value,
+      });
+      onOpenChange(false);
+    } catch {
+      // Keep dialog open on error
+    }
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-3 py-2">
-        <Badge variant="outline">{pairGroup.characterAName}</Badge>
-        <span className="text-muted-foreground text-sm">&amp;</span>
-        <Badge variant="outline">{pairGroup.characterBName}</Badge>
-      </div>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-md w-full">
+          <DialogHeader>
+            <DialogTitle>Edit Pair Group</DialogTitle>
+            <DialogDescription>
+              Update the duo ending settings.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-4">
+            <div className="space-y-4">
+              <div className="flex items-center gap-3 py-2">
+                <Badge variant="outline">{pairGroup.characterAName}</Badge>
+                <span className="text-muted-foreground text-sm">&amp;</span>
+                <Badge variant="outline">{pairGroup.characterBName}</Badge>
+              </div>
 
-      <div className="space-y-1">
-        <Label htmlFor="edit-pair-duo-label" className="text-xs">
-          Duo Ending Label *
-        </Label>
-        <Input
-          id="edit-pair-duo-label"
-          type="text"
-          value={form.duoEndingLabel}
-          onChange={(event) =>
-            setForm((prev) => ({
-              ...prev,
-              duoEndingLabel: event.target.value,
-            }))
-          }
-          disabled={isSaving}
-          aria-required="true"
-          aria-invalid={!!error}
-          aria-describedby={error ? "edit-pair-duo-label-error" : undefined}
-        />
-        <FormErrorMessage
-          id="edit-pair-duo-label-error"
-          message={error ?? undefined}
-        />
-      </div>
+              <div className="space-y-1">
+                <Label htmlFor="edit-pair-duo-label" className="text-xs">
+                  Duo Ending Label *
+                </Label>
+                <Input
+                  id="edit-pair-duo-label"
+                  type="text"
+                  value={form.duoEndingLabel}
+                  onChange={(event) =>
+                    setForm((prev) => ({
+                      ...prev,
+                      duoEndingLabel: event.target.value,
+                    }))
+                  }
+                  disabled={isSaving}
+                  aria-required="true"
+                  aria-invalid={!!error}
+                  aria-describedby={
+                    error ? "edit-pair-duo-label-error" : undefined
+                  }
+                />
+                <FormErrorMessage
+                  id="edit-pair-duo-label-error"
+                  message={error ?? undefined}
+                />
+              </div>
 
-      <div className="flex justify-end gap-2 pt-2">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onClose}
-          disabled={isSaving}
-        >
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          onClick={handleSave}
-          disabled={!isDirty || isSaving}
-        >
-          {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
-          Save
-        </Button>
-      </div>
-    </div>
+              <div className="flex justify-end gap-2 pt-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={!isDirty || isSaving}
+                >
+                  {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
+                  Save
+                </Button>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }
 
@@ -359,13 +427,6 @@ export function PairGroupEditDialog({
 
   const isEditMode = !!pairGroupId;
   const isSaving = isCreating || isUpdating;
-  const [isDirty, setIsDirty] = useState(false);
-  const {
-    handleOpenChange,
-    confirmDiscard,
-    discardDialogOpen,
-    setDiscardDialogOpen,
-  } = useDirtyDialogWarning(isDirty, onOpenChange);
 
   const sortedCharacters = characters
     .toSorted((a, b) => a.displayName.localeCompare(b.displayName))
@@ -385,31 +446,21 @@ export function PairGroupEditDialog({
   const effectiveOpen = open && pairGroupStillExists;
 
   const handleCreate = async (form: PairGroupFormState) => {
-    try {
-      await createPairGroup({
-        characterAId: form.characterAId,
-        characterBId: form.characterBId,
-        duoEndingLabel: form.duoEndingLabel.trim(),
-      });
-      onOpenChange(false);
-    } catch {
-      // Error toast shown by hook — keep dialog open
-    }
+    await createPairGroup({
+      characterAId: form.characterAId,
+      characterBId: form.characterBId,
+      duoEndingLabel: form.duoEndingLabel.trim(),
+    });
   };
 
   const handleUpdate = async (data: { duoEndingLabel?: string }) => {
     if (!pairGroupId) return;
-    try {
-      await updatePairGroup(pairGroupId, data);
-      onOpenChange(false);
-    } catch {
-      // Error toast shown by hook — keep dialog open
-    }
+    await updatePairGroup(pairGroupId, data);
   };
 
   if (isEditMode && isLoadingPairGroups) {
     return (
-      <Dialog open={effectiveOpen} onOpenChange={handleOpenChange}>
+      <Dialog open={effectiveOpen} onOpenChange={onOpenChange}>
         <DialogContent className="max-w-md w-full">
           <DialogHeader>
             <DialogTitle>Edit Pair Group</DialogTitle>
@@ -423,51 +474,21 @@ export function PairGroupEditDialog({
     );
   }
 
-  return (
-    <>
-      <Dialog open={effectiveOpen} onOpenChange={handleOpenChange}>
-        <DialogContent className="max-w-md w-full">
-          <DialogHeader>
-            <DialogTitle>
-              {isEditMode ? "Edit Pair Group" : "Add Pair Group"}
-            </DialogTitle>
-            <DialogDescription>
-              {isEditMode
-                ? "Update the duo ending settings."
-                : "Create a new pair group for duo ending tracking."}
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="mt-4">
-            {isEditMode && existingPairGroup ? (
-              <EditForm
-                pairGroup={existingPairGroup}
-                isSaving={isSaving}
-                onSave={handleUpdate}
-                onClose={() => handleOpenChange(false)}
-                onDirtyChange={setIsDirty}
-              />
-            ) : (
-              <CreateForm
-                characters={sortedCharacters}
-                isSaving={isSaving}
-                onSave={handleCreate}
-                onClose={() => handleOpenChange(false)}
-                onDirtyChange={setIsDirty}
-              />
-            )}
-          </div>
-        </DialogContent>
-      </Dialog>
-      <ConfirmDialog
-        open={discardDialogOpen}
-        onOpenChange={setDiscardDialogOpen}
-        onConfirm={confirmDiscard}
-        title="Discard unsaved changes?"
-        description="You have unsaved changes. Are you sure you want to discard them?"
-        confirmLabel="Discard"
-        cancelLabel="Keep editing"
-      />
-    </>
+  return isEditMode && existingPairGroup ? (
+    <EditForm
+      open={effectiveOpen}
+      onOpenChange={onOpenChange}
+      pairGroup={existingPairGroup}
+      isSaving={isSaving}
+      onSave={handleUpdate}
+    />
+  ) : (
+    <CreateForm
+      open={effectiveOpen}
+      onOpenChange={onOpenChange}
+      characters={sortedCharacters}
+      isSaving={isSaving}
+      onSave={handleCreate}
+    />
   );
 }

--- a/apps/frontend/src/components/pair-groups/PairGroupsDialog.test.tsx
+++ b/apps/frontend/src/components/pair-groups/PairGroupsDialog.test.tsx
@@ -132,4 +132,49 @@ describe("PairGroupsDialog", () => {
     // Assert discard ConfirmDialog appears
     expect(screen.getByText(/discard unsaved changes/i)).toBeInTheDocument();
   });
+
+  it("disables delete on other rows while any inline label edit is active", async () => {
+    const user = userEvent.setup({ delay: null });
+    const second: PairGroupWithNames = {
+      ...mockPairGroup,
+      id: "pg-2",
+      duoEndingLabel: "rivals_ending",
+      characterAName: "Casey",
+      characterBName: "Drew",
+    };
+
+    vi.mocked(usePairGroups).mockReturnValue({
+      pairGroups: [mockPairGroup, second],
+      isLoading: false,
+      error: null,
+      isDeleting: false,
+      isUpdating: false,
+      refresh: vi.fn(),
+      createPairGroup: vi.fn(),
+      updatePairGroup,
+      deletePairGroup: vi.fn(),
+      isCreating: false,
+    } as never);
+
+    render(
+      <PairGroupsDialog
+        open
+        onOpenChange={vi.fn()}
+        projectId="project-1"
+        characters={["Alex", "Blake", "Casey", "Drew"]}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /edit pair group best_friends_ending/i,
+      })
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: /delete pair group rivals_ending/i,
+      })
+    ).toBeDisabled();
+  });
 });

--- a/apps/frontend/src/components/pair-groups/PairGroupsDialog.test.tsx
+++ b/apps/frontend/src/components/pair-groups/PairGroupsDialog.test.tsx
@@ -97,4 +97,39 @@ describe("PairGroupsDialog", () => {
       screen.getByRole("button", { name: /save label/i })
     ).toBeInTheDocument();
   });
+
+  it("shows discard confirmation when closing while inline edit has unsaved changes", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onOpenChange = vi.fn();
+
+    render(
+      <PairGroupsDialog
+        open
+        onOpenChange={onOpenChange}
+        projectId="project-1"
+        characters={["Alex", "Blake"]}
+      />
+    );
+
+    // Start inline edit on the pair group
+    await user.click(
+      screen.getByRole("button", {
+        name: /edit pair group best_friends_ending/i,
+      })
+    );
+
+    // Change the label value to make inline form dirty
+    const input = screen.getByDisplayValue("best_friends_ending");
+    await user.clear(input);
+    await user.type(input, "changed_label");
+
+    // Click the dialog backdrop to trigger close (simulates Escape/backdrop)
+    const dialog = document.querySelector(
+      'dialog[aria-label="Pair Groups"]'
+    ) as HTMLElement;
+    await user.click(dialog);
+
+    // Assert discard ConfirmDialog appears
+    expect(screen.getByText(/discard unsaved changes/i)).toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/components/pair-groups/PairGroupsDialog.tsx
+++ b/apps/frontend/src/components/pair-groups/PairGroupsDialog.tsx
@@ -336,7 +336,12 @@ export function PairGroupsDialog(props: PairGroupsDialogProps) {
                           type="button"
                           variant="ghost"
                           size="sm"
-                          onClick={() => setDeleteTarget(pg)}
+                          onClick={() => {
+                            setEditingLabelId(null);
+                            setEditLabelValue("");
+                            setEditLabelError(null);
+                            setDeleteTarget(pg);
+                          }}
                           disabled={isDeletingPairGroup || isEditing}
                           className="text-destructive hover:text-destructive"
                           aria-label={`Delete pair group ${pg.duoEndingLabel}`}

--- a/apps/frontend/src/components/pair-groups/PairGroupsDialog.tsx
+++ b/apps/frontend/src/components/pair-groups/PairGroupsDialog.tsx
@@ -13,7 +13,7 @@
  * opens the PairGroupEditDialog.
  */
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { Loader2, Plus, Pencil, Trash2, X, Check } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -28,6 +28,7 @@ import { trimRequiredDuoEndingLabel } from "@/components/pair-groups/pair-group-
 import { useProject } from "@/hooks/useProject";
 import { usePairGroups } from "@/hooks/usePairGroups";
 import { useToast } from "@/contexts/ToastContext";
+import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
 import type { PairGroupWithNames } from "@branchforge/shared";
 
 // ============================================================================
@@ -73,6 +74,11 @@ export function PairGroupsDialog(props: PairGroupsDialogProps) {
   const [isDeletingConfirm, setIsDeletingConfirm] = useState(false);
 
   const editInputRef = useRef<HTMLInputElement>(null);
+  // Dirty form detection for inline label editing.
+  const isDirty =
+    editingLabelId !== null &&
+    editLabelValue !==
+      (pairGroups.find((pg) => pg.id === editingLabelId)?.duoEndingLabel ?? "");
 
   // Focus/select once when an inline edit session starts — not on every
   // keystroke via a recreated ref callback.
@@ -83,20 +89,29 @@ export function PairGroupsDialog(props: PairGroupsDialogProps) {
     input.focus();
     input.select();
   }, [editingLabelId]);
-
   // Reset transient UI state when the dialog closes, handled in the
   // onOpenChange event handler (not a useEffect) so state resets
   // happen in the same synchronous event as the close action.
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) {
-      setCreatingNew(false);
-      setEditingLabelId(null);
-      setEditLabelValue("");
-      setEditLabelError(null);
-      setDeleteTarget(null);
-    }
-    onOpenChange(nextOpen);
-  };
+  const handleClose = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        setCreatingNew(false);
+        setEditingLabelId(null);
+        setEditLabelValue("");
+        setEditLabelError(null);
+        setDeleteTarget(null);
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange]
+  );
+
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, handleClose);
 
   const handleToggleDuoEnding = async (checked: boolean) => {
     try {
@@ -365,6 +380,17 @@ export function PairGroupsDialog(props: PairGroupsDialogProps) {
         confirmLabel="Delete Pair Group"
         isLoading={isDeletingConfirm}
         loadingLabel="Deleting..."
+      />
+
+      {/* Discard unsaved changes confirmation */}
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
       />
     </Dialog>
   );

--- a/apps/frontend/src/components/pair-groups/PairGroupsDialog.tsx
+++ b/apps/frontend/src/components/pair-groups/PairGroupsDialog.tsx
@@ -342,7 +342,9 @@ export function PairGroupsDialog(props: PairGroupsDialogProps) {
                             setEditLabelError(null);
                             setDeleteTarget(pg);
                           }}
-                          disabled={isDeletingPairGroup || isEditing}
+                          disabled={
+                            isDeletingPairGroup || editingLabelId !== null
+                          }
                           className="text-destructive hover:text-destructive"
                           aria-label={`Delete pair group ${pg.duoEndingLabel}`}
                         >

--- a/apps/frontend/src/components/routes/RouteEditDialog.tsx
+++ b/apps/frontend/src/components/routes/RouteEditDialog.tsx
@@ -21,6 +21,9 @@ import { FormErrorMessage } from "@/components/ui/form-error-message";
 import { useRouteConfigs } from "@/hooks/useRouteConfigs";
 import { isValidJumpPrefix, isValidRouteKey } from "@branchforge/shared";
 import type { RouteConfig } from "@branchforge/shared";
+import { useDirtyForm } from "@/hooks/useDirtyForm";
+import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 export interface RouteEditDialogProps {
   open: boolean;
@@ -79,14 +82,18 @@ function RouteFormContent({
   isSaving,
   onSave,
   onClose,
+  onDirtyChange,
+  onSaveSuccess,
 }: {
   routeId: string | undefined;
   routeConfigs: RouteConfig[];
   isSaving: boolean;
   onSave: (routeId: string | undefined, form: RouteFormState) => Promise<void>;
   onClose: () => void;
+  onDirtyChange: (dirty: boolean) => void;
+  onSaveSuccess: () => void;
 }) {
-  const [form, setForm] = useState<RouteFormState>(() => {
+  const [initialFormSnapshot] = useState<RouteFormState>(() => {
     if (!routeId) return INITIAL_FORM;
     const route = routeConfigs.find((item: RouteConfig) => item.id === routeId);
     if (!route) return INITIAL_FORM;
@@ -97,7 +104,13 @@ function RouteFormContent({
       isShared: route.isShared,
     };
   });
+  const [form, setForm] = useState<RouteFormState>(initialFormSnapshot);
   const [errors, setErrors] = useState<RouteFormErrors>({});
+  const { isDirty } = useDirtyForm(initialFormSnapshot, form);
+
+  useEffect(() => {
+    onDirtyChange(isDirty);
+  }, [isDirty, onDirtyChange]);
 
   // react-doctor-disable-next-line react-doctor/no-event-handler
   const isEditMode = !!routeId;
@@ -133,7 +146,7 @@ function RouteFormContent({
 
     try {
       await onSave(routeId, form);
-      onClose();
+      onSaveSuccess();
     } catch {
       // Error handled by hook toast
     }
@@ -260,7 +273,11 @@ function RouteFormContent({
           >
             Cancel
           </Button>
-          <Button type="button" onClick={handleSave} disabled={isSaving}>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={isSaving || !isDirty}
+          >
             {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
             Save
           </Button>
@@ -286,10 +303,17 @@ export function RouteEditDialog({
   } = useRouteConfigs(projectId);
 
   const isSaving = isCreatingRouteConfig || isUpdatingRouteConfig;
+  const [isDirty, setIsDirty] = useState(false);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
 
   if (isLoadingRouteConfigs) {
     return (
-      <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent className="max-w-xl w-full">
           <DialogHeader>
             <DialogTitle>{routeId ? "Edit Route" : "Add Route"}</DialogTitle>
@@ -304,32 +328,45 @@ export function RouteEditDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-xl w-full">
-        <RouteFormContent
-          key={`${routeId ?? "new"}-${open}`}
-          routeId={routeId}
-          routeConfigs={routeConfigs}
-          isSaving={isSaving}
-          onSave={async (id, formData) => {
-            if (id) {
-              await updateRouteConfig(id, {
-                routeName: formData.routeName.trim(),
-                jumpPrefix: formData.jumpPrefix.trim(),
-                isShared: formData.isShared,
-              });
-            } else {
-              await createRouteConfig({
-                routeKey: formData.routeKey.trim(),
-                routeName: formData.routeName.trim(),
-                jumpPrefix: formData.jumpPrefix.trim(),
-                isShared: formData.isShared,
-              });
-            }
-          }}
-          onClose={() => onOpenChange(false)}
-        />
-      </DialogContent>
-    </Dialog>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-xl w-full">
+          <RouteFormContent
+            key={`${routeId ?? "new"}-${open}`}
+            routeId={routeId}
+            routeConfigs={routeConfigs}
+            isSaving={isSaving}
+            onSave={async (id, formData) => {
+              if (id) {
+                await updateRouteConfig(id, {
+                  routeName: formData.routeName.trim(),
+                  jumpPrefix: formData.jumpPrefix.trim(),
+                  isShared: formData.isShared,
+                });
+              } else {
+                await createRouteConfig({
+                  routeKey: formData.routeKey.trim(),
+                  routeName: formData.routeName.trim(),
+                  jumpPrefix: formData.jumpPrefix.trim(),
+                  isShared: formData.isShared,
+                });
+              }
+            }}
+            onClose={() => handleOpenChange(false)}
+            onDirtyChange={setIsDirty}
+            onSaveSuccess={() => onOpenChange(false)}
+          />
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }

--- a/apps/frontend/src/components/routes/RouteEditDialog.tsx
+++ b/apps/frontend/src/components/routes/RouteEditDialog.tsx
@@ -81,17 +81,15 @@ function RouteFormContent({
   routeConfigs,
   isSaving,
   onSave,
-  onClose,
-  onDirtyChange,
-  onSaveSuccess,
+  open,
+  onOpenChange,
 }: {
   routeId: string | undefined;
   routeConfigs: RouteConfig[];
   isSaving: boolean;
   onSave: (routeId: string | undefined, form: RouteFormState) => Promise<void>;
-  onClose: () => void;
-  onDirtyChange: (dirty: boolean) => void;
-  onSaveSuccess: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }) {
   const [initialFormSnapshot] = useState<RouteFormState>(() => {
     if (!routeId) return INITIAL_FORM;
@@ -107,10 +105,12 @@ function RouteFormContent({
   const [form, setForm] = useState<RouteFormState>(initialFormSnapshot);
   const [errors, setErrors] = useState<RouteFormErrors>({});
   const { isDirty } = useDirtyForm(initialFormSnapshot, form);
-
-  useEffect(() => {
-    onDirtyChange(isDirty);
-  }, [isDirty, onDirtyChange]);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
 
   // react-doctor-disable-next-line react-doctor/no-event-handler
   const isEditMode = !!routeId;
@@ -120,9 +120,9 @@ function RouteFormContent({
     // react-doctor-disable-next-line react-doctor/no-event-handler
     if (isEditMode && !routeConfigs.find((item) => item.id === routeId)) {
       // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect
-      onClose();
+      onOpenChange(false);
     }
-  }, [isEditMode, routeId, routeConfigs, onClose]);
+  }, [isEditMode, routeId, routeConfigs, onOpenChange]);
 
   const handleChange = (
     field: keyof RouteFormState,
@@ -146,7 +146,7 @@ function RouteFormContent({
 
     try {
       await onSave(routeId, form);
-      onSaveSuccess();
+      onOpenChange(false);
     } catch {
       // Error handled by hook toast
     }
@@ -154,135 +154,158 @@ function RouteFormContent({
 
   return (
     <>
-      <DialogHeader>
-        <DialogTitle>{isEditMode ? "Edit Route" : "Add Route"}</DialogTitle>
-        <DialogDescription>
-          {isEditMode
-            ? "Update the route settings."
-            : "Create a new route for your project."}
-        </DialogDescription>
-      </DialogHeader>
-
-      <div className="space-y-4 mt-4">
-        <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
-          <div className="space-y-1">
-            <Label htmlFor="route-key" className="text-xs">
-              Route Key *
-            </Label>
-            <Input
-              id="route-key"
-              type="text"
-              placeholder="hero"
-              value={form.routeKey}
-              onChange={(event) => handleChange("routeKey", event.target.value)}
-              disabled={isSaving || isEditMode}
-              aria-required="true"
-              aria-invalid={!!errors.routeKey}
-              aria-describedby={
-                errors.routeKey
-                  ? "route-key-hint route-key-error"
-                  : "route-key-hint"
-              }
-            />
-            <p id="route-key-hint" className="text-xs text-muted-foreground">
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-xl w-full">
+          <DialogHeader>
+            <DialogTitle>{isEditMode ? "Edit Route" : "Add Route"}</DialogTitle>
+            <DialogDescription>
               {isEditMode
-                ? "Route key cannot be changed after creation"
-                : "Unique identifier (letters, numbers, underscores, hyphens)"}
-            </p>
-            <FormErrorMessage id="route-key-error" message={errors.routeKey} />
-          </div>
+                ? "Update the route settings."
+                : "Create a new route for your project."}
+            </DialogDescription>
+          </DialogHeader>
 
-          <div className="space-y-1">
-            <Label htmlFor="route-name" className="text-xs">
-              Route Name *
-            </Label>
-            <Input
-              id="route-name"
-              type="text"
-              placeholder="Hero's Route"
-              value={form.routeName}
-              onChange={(event) =>
-                handleChange("routeName", event.target.value)
-              }
-              disabled={isSaving}
-              aria-required="true"
-              aria-invalid={!!errors.routeName}
-              aria-describedby={
-                errors.routeName ? "route-name-error" : undefined
-              }
-            />
-            <FormErrorMessage
-              id="route-name-error"
-              message={errors.routeName}
-            />
-          </div>
-        </div>
+          <div className="space-y-4 mt-4">
+            <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="route-key" className="text-xs">
+                  Route Key *
+                </Label>
+                <Input
+                  id="route-key"
+                  type="text"
+                  placeholder="hero"
+                  value={form.routeKey}
+                  onChange={(event) =>
+                    handleChange("routeKey", event.target.value)
+                  }
+                  disabled={isSaving || isEditMode}
+                  aria-required="true"
+                  aria-invalid={!!errors.routeKey}
+                  aria-describedby={
+                    errors.routeKey
+                      ? "route-key-hint route-key-error"
+                      : "route-key-hint"
+                  }
+                />
+                <p
+                  id="route-key-hint"
+                  className="text-xs text-muted-foreground"
+                >
+                  {isEditMode
+                    ? "Route key cannot be changed after creation"
+                    : "Unique identifier (letters, numbers, underscores, hyphens)"}
+                </p>
+                <FormErrorMessage
+                  id="route-key-error"
+                  message={errors.routeKey}
+                />
+              </div>
 
-        <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
-          <div className="space-y-1">
-            <Label htmlFor="jump-prefix" className="text-xs">
-              Jump Prefix *
-            </Label>
-            <Input
-              id="jump-prefix"
-              type="text"
-              placeholder="hero_"
-              value={form.jumpPrefix}
-              onChange={(event) =>
-                handleChange("jumpPrefix", event.target.value)
-              }
-              disabled={isSaving}
-              aria-required="true"
-              aria-invalid={!!errors.jumpPrefix}
-              aria-describedby={
-                errors.jumpPrefix ? "jump-prefix-error" : undefined
-              }
-            />
-            <FormErrorMessage
-              id="jump-prefix-error"
-              message={errors.jumpPrefix}
-            />
-          </div>
+              <div className="space-y-1">
+                <Label htmlFor="route-name" className="text-xs">
+                  Route Name *
+                </Label>
+                <Input
+                  id="route-name"
+                  type="text"
+                  placeholder="Hero's Route"
+                  value={form.routeName}
+                  onChange={(event) =>
+                    handleChange("routeName", event.target.value)
+                  }
+                  disabled={isSaving}
+                  aria-required="true"
+                  aria-invalid={!!errors.routeName}
+                  aria-describedby={
+                    errors.routeName ? "route-name-error" : undefined
+                  }
+                />
+                <FormErrorMessage
+                  id="route-name-error"
+                  message={errors.routeName}
+                />
+              </div>
+            </div>
 
-          <div className="space-y-1">
-            <Label htmlFor="route-type" className="text-xs">
-              Route Type
-            </Label>
-            <Select
-              id="route-type"
-              value={form.isShared ? "shared" : "exclusive"}
-              onChange={(value) => handleChange("isShared", value === "shared")}
-              disabled={isSaving}
-              options={[
-                { value: "exclusive", label: "Exclusive Route" },
-                { value: "shared", label: "Shared/Common Route" },
-              ]}
-            />
-            <p className="text-xs text-muted-foreground">
-              Shared routes appear in all story branches
-            </p>
-          </div>
-        </div>
+            <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="jump-prefix" className="text-xs">
+                  Jump Prefix *
+                </Label>
+                <Input
+                  id="jump-prefix"
+                  type="text"
+                  placeholder="hero_"
+                  value={form.jumpPrefix}
+                  onChange={(event) =>
+                    handleChange("jumpPrefix", event.target.value)
+                  }
+                  disabled={isSaving}
+                  aria-required="true"
+                  aria-invalid={!!errors.jumpPrefix}
+                  aria-describedby={
+                    errors.jumpPrefix ? "jump-prefix-error" : undefined
+                  }
+                />
+                <FormErrorMessage
+                  id="jump-prefix-error"
+                  message={errors.jumpPrefix}
+                />
+              </div>
 
-        <div className="flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={onClose}
-            disabled={isSaving}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            onClick={handleSave}
-            disabled={isSaving || !isDirty}
-          >
-            {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
-            Save
-          </Button>
-        </div>
-      </div>
+              <div className="space-y-1">
+                <Label htmlFor="route-type" className="text-xs">
+                  Route Type
+                </Label>
+                <Select
+                  id="route-type"
+                  value={form.isShared ? "shared" : "exclusive"}
+                  onChange={(value) =>
+                    handleChange("isShared", value === "shared")
+                  }
+                  disabled={isSaving}
+                  options={[
+                    { value: "exclusive", label: "Exclusive Route" },
+                    { value: "shared", label: "Shared/Common Route" },
+                  ]}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Shared routes appear in all story branches
+                </p>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isSaving}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSave}
+                disabled={isSaving || !isDirty}
+              >
+                {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
+                Save
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
     </>
   );
 }
@@ -303,17 +326,10 @@ export function RouteEditDialog({
   } = useRouteConfigs(projectId);
 
   const isSaving = isCreatingRouteConfig || isUpdatingRouteConfig;
-  const [isDirty, setIsDirty] = useState(false);
-  const {
-    handleOpenChange,
-    confirmDiscard,
-    discardDialogOpen,
-    setDiscardDialogOpen,
-  } = useDirtyDialogWarning(isDirty, onOpenChange);
 
   if (isLoadingRouteConfigs) {
     return (
-      <Dialog open={open} onOpenChange={handleOpenChange}>
+      <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="max-w-xl w-full">
           <DialogHeader>
             <DialogTitle>{routeId ? "Edit Route" : "Add Route"}</DialogTitle>
@@ -328,45 +344,29 @@ export function RouteEditDialog({
   }
 
   return (
-    <>
-      <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogContent className="max-w-xl w-full">
-          <RouteFormContent
-            key={`${routeId ?? "new"}-${open}`}
-            routeId={routeId}
-            routeConfigs={routeConfigs}
-            isSaving={isSaving}
-            onSave={async (id, formData) => {
-              if (id) {
-                await updateRouteConfig(id, {
-                  routeName: formData.routeName.trim(),
-                  jumpPrefix: formData.jumpPrefix.trim(),
-                  isShared: formData.isShared,
-                });
-              } else {
-                await createRouteConfig({
-                  routeKey: formData.routeKey.trim(),
-                  routeName: formData.routeName.trim(),
-                  jumpPrefix: formData.jumpPrefix.trim(),
-                  isShared: formData.isShared,
-                });
-              }
-            }}
-            onClose={() => handleOpenChange(false)}
-            onDirtyChange={setIsDirty}
-            onSaveSuccess={() => onOpenChange(false)}
-          />
-        </DialogContent>
-      </Dialog>
-      <ConfirmDialog
-        open={discardDialogOpen}
-        onOpenChange={setDiscardDialogOpen}
-        onConfirm={confirmDiscard}
-        title="Discard unsaved changes?"
-        description="You have unsaved changes. Are you sure you want to discard them?"
-        confirmLabel="Discard"
-        cancelLabel="Keep editing"
-      />
-    </>
+    <RouteFormContent
+      key={`${routeId ?? "new"}-${open}`}
+      routeId={routeId}
+      routeConfigs={routeConfigs}
+      isSaving={isSaving}
+      onSave={async (id, formData) => {
+        if (id) {
+          await updateRouteConfig(id, {
+            routeName: formData.routeName.trim(),
+            jumpPrefix: formData.jumpPrefix.trim(),
+            isShared: formData.isShared,
+          });
+        } else {
+          await createRouteConfig({
+            routeKey: formData.routeKey.trim(),
+            routeName: formData.routeName.trim(),
+            jumpPrefix: formData.jumpPrefix.trim(),
+            isShared: formData.isShared,
+          });
+        }
+      }}
+      open={open}
+      onOpenChange={onOpenChange}
+    />
   );
 }

--- a/apps/frontend/src/components/stats/StatEditDialog.tsx
+++ b/apps/frontend/src/components/stats/StatEditDialog.tsx
@@ -4,7 +4,7 @@
  * Modal for creating or editing a single stat.
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Loader2 } from "lucide-react";
 import {
   Dialog,
@@ -19,6 +19,9 @@ import { Label } from "@/components/ui/label";
 import { FormErrorMessage } from "@/components/ui/form-error-message";
 import { useStats } from "@/hooks/useStats";
 import type { Stat } from "@branchforge/shared";
+import { useDirtyForm } from "@/hooks/useDirtyForm";
+import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 interface StatEditDialogProps {
   open: boolean;
@@ -81,6 +84,7 @@ interface StatFormContentProps {
   stats: Stat[];
   isSaving: boolean;
   onSave: (statId: string | undefined, form: StatFormState) => Promise<void>;
+  onDirtyChange: (dirty: boolean) => void;
   onClose: () => void;
 }
 
@@ -90,6 +94,7 @@ function StatFormContent({
   isSaving,
   onSave,
   onClose,
+  onDirtyChange,
 }: StatFormContentProps) {
   const [form, setForm] = useState<StatFormState>(() => {
     if (!statId) return initialForm;
@@ -104,6 +109,25 @@ function StatFormContent({
     };
   });
   const [errors, setErrors] = useState<StatFormErrors>({});
+
+  const initialSnapshot = useMemo(() => {
+    if (!statId) return initialForm;
+    const stat = stats.find((item: Stat) => item.id === statId);
+    if (!stat) return initialForm;
+    return {
+      key: stat.key,
+      name: stat.name,
+      minValue: stat.minValue,
+      maxValue: stat.maxValue,
+      description: stat.description ?? "",
+    };
+  }, [statId, stats]);
+
+  const { isDirty } = useDirtyForm(initialSnapshot, form);
+
+  useEffect(() => {
+    onDirtyChange(isDirty);
+  }, [isDirty, onDirtyChange]);
 
   // react-doctor-disable-next-line react-doctor/no-event-handler
   const isEditMode = !!statId;
@@ -151,7 +175,6 @@ function StatFormContent({
 
     try {
       await onSave(statId, form);
-      onClose();
     } catch {
       // Error handled by hook toast
     }
@@ -259,7 +282,11 @@ function StatFormContent({
         >
           Cancel
         </Button>
-        <Button type="button" onClick={handleSave} disabled={isSaving}>
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || isSaving}
+        >
           {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
           Save
         </Button>
@@ -288,6 +315,14 @@ export function StatEditDialog({
   const isSaving = isCreatingStat || isUpdatingStat;
   const isEditMode = !!statId;
 
+  const [isDirty, setIsDirty] = useState(false);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
+
   const handleSave = async (id: string | undefined, form: StatFormState) => {
     if (id) {
       await updateStat(id, {
@@ -305,40 +340,48 @@ export function StatEditDialog({
         description: form.description.trim() || undefined,
       });
     }
+    onOpenChange(false);
   };
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(newOpen) => {
-        if (!newOpen) onOpenChange(false);
-      }}
-    >
-      <DialogContent className="max-w-xl w-full">
-        <DialogHeader>
-          <DialogTitle>{isEditMode ? "Edit Stat" : "Add Stat"}</DialogTitle>
-          <DialogDescription>
-            {isEditMode
-              ? "Update the stat settings."
-              : "Create a new stat for your project."}
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-xl w-full">
+          <DialogHeader>
+            <DialogTitle>{isEditMode ? "Edit Stat" : "Add Stat"}</DialogTitle>
+            <DialogDescription>
+              {isEditMode
+                ? "Update the stat settings."
+                : "Create a new stat for your project."}
+            </DialogDescription>
+          </DialogHeader>
 
-        {isEditMode && isLoadingStats ? (
-          <div className="flex justify-center py-8">
-            <Loader2 className="size-6 animate-spin" />
-          </div>
-        ) : (
-          <StatFormContent
-            key={`${statId ?? "new"}-${open}`}
-            statId={statId}
-            stats={stats}
-            isSaving={isSaving}
-            onSave={handleSave}
-            onClose={() => onOpenChange(false)}
-          />
-        )}
-      </DialogContent>
-    </Dialog>
+          {isEditMode && isLoadingStats ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="size-6 animate-spin" />
+            </div>
+          ) : (
+            <StatFormContent
+              key={`${statId ?? "new"}-${open}`}
+              statId={statId}
+              stats={stats}
+              isSaving={isSaving}
+              onSave={handleSave}
+              onDirtyChange={setIsDirty}
+              onClose={() => handleOpenChange(false)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }

--- a/apps/frontend/src/components/stats/StatEditDialog.tsx
+++ b/apps/frontend/src/components/stats/StatEditDialog.tsx
@@ -80,21 +80,21 @@ function validateStat(form: StatFormState): StatFormErrors {
 // --- Inner form component (keyed to avoid syncing state with props) ---
 
 interface StatFormContentProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   statId: string | undefined;
   stats: Stat[];
   isSaving: boolean;
   onSave: (statId: string | undefined, form: StatFormState) => Promise<void>;
-  onDirtyChange: (dirty: boolean) => void;
-  onClose: () => void;
 }
 
 function StatFormContent({
+  open,
+  onOpenChange,
   statId,
   stats,
   isSaving,
   onSave,
-  onClose,
-  onDirtyChange,
 }: StatFormContentProps) {
   const [form, setForm] = useState<StatFormState>(() => {
     if (!statId) return initialForm;
@@ -124,10 +124,12 @@ function StatFormContent({
   }, [statId, stats]);
 
   const { isDirty } = useDirtyForm(initialSnapshot, form);
-
-  useEffect(() => {
-    onDirtyChange(isDirty);
-  }, [isDirty, onDirtyChange]);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
 
   // react-doctor-disable-next-line react-doctor/no-event-handler
   const isEditMode = !!statId;
@@ -136,10 +138,9 @@ function StatFormContent({
   useEffect(() => {
     // react-doctor-disable-next-line react-doctor/no-event-handler
     if (isEditMode && !stats.find((item) => item.id === statId)) {
-      // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect
-      onClose();
+      handleOpenChange(false);
     }
-  }, [isEditMode, statId, stats, onClose]);
+  }, [isEditMode, statId, stats, handleOpenChange]);
 
   const handleChange = (field: keyof StatFormState, value: string) => {
     setForm((prev) => {
@@ -172,126 +173,159 @@ function StatFormContent({
       setErrors(validationErrors);
       return;
     }
-
     try {
       await onSave(statId, form);
+      onOpenChange(false);
     } catch {
       // Error handled by hook toast
     }
   };
 
   return (
-    <div className="space-y-4 mt-4">
-      <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
-        <div className="space-y-1">
-          <Label htmlFor="stat-key" className="text-xs">
-            Key *
-          </Label>
-          <Input
-            id="stat-key"
-            type="text"
-            placeholder="affection_luna"
-            value={form.key}
-            onChange={(event) => handleChange("key", event.target.value)}
-            disabled={isSaving || isEditMode}
-            aria-required="true"
-            aria-invalid={!!errors.key}
-            aria-describedby={errors.key ? "stat-key-error" : undefined}
-          />
-          <p className="text-xs text-muted-foreground">
-            {isEditMode
-              ? "Key cannot be changed after creation"
-              : "Unique identifier (lowercase, underscores)"}
-          </p>
-          <FormErrorMessage id="stat-key-error" message={errors.key} />
-        </div>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-xl w-full">
+          <DialogHeader>
+            <DialogTitle>{isEditMode ? "Edit Stat" : "Add Stat"}</DialogTitle>
+            <DialogDescription>
+              {isEditMode
+                ? "Update the stat settings."
+                : "Create a new stat for your project."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 mt-4">
+            <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="stat-key" className="text-xs">
+                  Key *
+                </Label>
+                <Input
+                  id="stat-key"
+                  type="text"
+                  placeholder="affection_luna"
+                  value={form.key}
+                  onChange={(event) => handleChange("key", event.target.value)}
+                  disabled={isSaving || isEditMode}
+                  aria-required="true"
+                  aria-invalid={!!errors.key}
+                  aria-describedby={errors.key ? "stat-key-error" : undefined}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {isEditMode
+                    ? "Key cannot be changed after creation"
+                    : "Unique identifier (lowercase, underscores)"}
+                </p>
+                <FormErrorMessage id="stat-key-error" message={errors.key} />
+              </div>
 
-        <div className="space-y-1">
-          <Label htmlFor="stat-name" className="text-xs">
-            Name *
-          </Label>
-          <Input
-            id="stat-name"
-            type="text"
-            placeholder="Luna Affection"
-            value={form.name}
-            onChange={(event) => handleChange("name", event.target.value)}
-            disabled={isSaving}
-            aria-required="true"
-            aria-invalid={!!errors.name}
-            aria-describedby={errors.name ? "stat-name-error" : undefined}
-          />
-          <FormErrorMessage id="stat-name-error" message={errors.name} />
-        </div>
-      </div>
+              <div className="space-y-1">
+                <Label htmlFor="stat-name" className="text-xs">
+                  Name *
+                </Label>
+                <Input
+                  id="stat-name"
+                  type="text"
+                  placeholder="Luna Affection"
+                  value={form.name}
+                  onChange={(event) => handleChange("name", event.target.value)}
+                  disabled={isSaving}
+                  aria-required="true"
+                  aria-invalid={!!errors.name}
+                  aria-describedby={errors.name ? "stat-name-error" : undefined}
+                />
+                <FormErrorMessage id="stat-name-error" message={errors.name} />
+              </div>
+            </div>
 
-      <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
-        <div className="space-y-1">
-          <Label htmlFor="stat-min" className="text-xs">
-            Min Value
-          </Label>
-          <Input
-            id="stat-min"
-            type="number"
-            value={form.minValue}
-            onChange={(event) => handleChange("minValue", event.target.value)}
-            disabled={isSaving}
-            aria-invalid={!!errors.range}
-            aria-describedby={errors.range ? "stat-range-error" : undefined}
-          />
-        </div>
+            <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="stat-min" className="text-xs">
+                  Min Value
+                </Label>
+                <Input
+                  id="stat-min"
+                  type="number"
+                  value={form.minValue}
+                  onChange={(event) =>
+                    handleChange("minValue", event.target.value)
+                  }
+                  disabled={isSaving}
+                  aria-invalid={!!errors.range}
+                  aria-describedby={
+                    errors.range ? "stat-range-error" : undefined
+                  }
+                />
+              </div>
 
-        <div className="space-y-1">
-          <Label htmlFor="stat-max" className="text-xs">
-            Max Value
-          </Label>
-          <Input
-            id="stat-max"
-            type="number"
-            value={form.maxValue}
-            onChange={(event) => handleChange("maxValue", event.target.value)}
-            disabled={isSaving}
-            aria-invalid={!!errors.range}
-            aria-describedby={errors.range ? "stat-range-error" : undefined}
-          />
-        </div>
-      </div>
+              <div className="space-y-1">
+                <Label htmlFor="stat-max" className="text-xs">
+                  Max Value
+                </Label>
+                <Input
+                  id="stat-max"
+                  type="number"
+                  value={form.maxValue}
+                  onChange={(event) =>
+                    handleChange("maxValue", event.target.value)
+                  }
+                  disabled={isSaving}
+                  aria-invalid={!!errors.range}
+                  aria-describedby={
+                    errors.range ? "stat-range-error" : undefined
+                  }
+                />
+              </div>
+            </div>
 
-      <FormErrorMessage id="stat-range-error" message={errors.range} />
+            <FormErrorMessage id="stat-range-error" message={errors.range} />
 
-      <div className="space-y-1">
-        <Label htmlFor="stat-description" className="text-xs">
-          Description
-        </Label>
-        <Input
-          id="stat-description"
-          type="text"
-          placeholder="Tracks how much Luna trusts the player"
-          value={form.description}
-          onChange={(event) => handleChange("description", event.target.value)}
-          disabled={isSaving}
-        />
-      </div>
+            <div className="space-y-1">
+              <Label htmlFor="stat-description" className="text-xs">
+                Description
+              </Label>
+              <Input
+                id="stat-description"
+                type="text"
+                placeholder="Tracks how much Luna trusts the player"
+                value={form.description}
+                onChange={(event) =>
+                  handleChange("description", event.target.value)
+                }
+                disabled={isSaving}
+              />
+            </div>
 
-      <div className="flex justify-end gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onClose}
-          disabled={isSaving}
-        >
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          onClick={handleSave}
-          disabled={!isDirty || isSaving}
-        >
-          {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
-          Save
-        </Button>
-      </div>
-    </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isSaving}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSave}
+                disabled={!isDirty || isSaving}
+              >
+                {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
+                Save
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }
 
@@ -315,14 +349,6 @@ export function StatEditDialog({
   const isSaving = isCreatingStat || isUpdatingStat;
   const isEditMode = !!statId;
 
-  const [isDirty, setIsDirty] = useState(false);
-  const {
-    handleOpenChange,
-    confirmDiscard,
-    discardDialogOpen,
-    setDiscardDialogOpen,
-  } = useDirtyDialogWarning(isDirty, onOpenChange);
-
   const handleSave = async (id: string | undefined, form: StatFormState) => {
     if (id) {
       await updateStat(id, {
@@ -340,48 +366,33 @@ export function StatEditDialog({
         description: form.description.trim() || undefined,
       });
     }
-    onOpenChange(false);
   };
 
   return (
     <>
-      <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogContent className="max-w-xl w-full">
-          <DialogHeader>
-            <DialogTitle>{isEditMode ? "Edit Stat" : "Add Stat"}</DialogTitle>
-            <DialogDescription>
-              {isEditMode
-                ? "Update the stat settings."
-                : "Create a new stat for your project."}
-            </DialogDescription>
-          </DialogHeader>
-
-          {isEditMode && isLoadingStats ? (
+      {isEditMode && isLoadingStats ? (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+          <DialogContent className="max-w-xl w-full">
+            <DialogHeader>
+              <DialogTitle>Edit Stat</DialogTitle>
+              <DialogDescription>Update the stat settings.</DialogDescription>
+            </DialogHeader>
             <div className="flex justify-center py-8">
               <Loader2 className="size-6 animate-spin" />
             </div>
-          ) : (
-            <StatFormContent
-              key={`${statId ?? "new"}-${open}`}
-              statId={statId}
-              stats={stats}
-              isSaving={isSaving}
-              onSave={handleSave}
-              onDirtyChange={setIsDirty}
-              onClose={() => handleOpenChange(false)}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
-      <ConfirmDialog
-        open={discardDialogOpen}
-        onOpenChange={setDiscardDialogOpen}
-        onConfirm={confirmDiscard}
-        title="Discard unsaved changes?"
-        description="You have unsaved changes. Are you sure you want to discard them?"
-        confirmLabel="Discard"
-        cancelLabel="Keep editing"
-      />
+          </DialogContent>
+        </Dialog>
+      ) : (
+        <StatFormContent
+          key={`${statId ?? "new"}-${open}`}
+          open={open}
+          onOpenChange={onOpenChange}
+          statId={statId}
+          stats={stats}
+          isSaving={isSaving}
+          onSave={handleSave}
+        />
+      )}
     </>
   );
 }

--- a/apps/frontend/src/components/stats/StatEditDialog.tsx
+++ b/apps/frontend/src/components/stats/StatEditDialog.tsx
@@ -134,13 +134,15 @@ function StatFormContent({
   // react-doctor-disable-next-line react-doctor/no-event-handler
   const isEditMode = !!statId;
 
-  // Close dialog if editing a stat that no longer exists
+  // Close dialog if editing a stat that no longer exists (unguarded —
+  // discard prompt would be wrong for a deleted entity).
   useEffect(() => {
     // react-doctor-disable-next-line react-doctor/no-event-handler
     if (isEditMode && !stats.find((item) => item.id === statId)) {
-      handleOpenChange(false);
+      // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect
+      onOpenChange(false);
     }
-  }, [isEditMode, statId, stats, handleOpenChange]);
+  }, [isEditMode, statId, stats, onOpenChange]);
 
   const handleChange = (field: keyof StatFormState, value: string) => {
     setForm((prev) => {

--- a/apps/frontend/src/components/ui/confirm-dialog.tsx
+++ b/apps/frontend/src/components/ui/confirm-dialog.tsx
@@ -7,6 +7,7 @@
 
 import { useCallback, useEffect, useEffectEvent, useId, useRef } from "react";
 import { cn } from "@/lib/utils";
+import { nativeDialogOverlayClassName } from "@/components/ui/native-dialog-overlay";
 import { Button } from "@/components/ui/button";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { Loader2 } from "lucide-react";
@@ -135,11 +136,14 @@ export function ConfirmDialog({
       aria-labelledby={titleId}
       aria-describedby={descriptionId}
       aria-modal="true"
-      className="backdrop:bg-black/50 m-auto border-0 p-0 bg-transparent text-[hsl(var(--foreground))]"
+      className={cn(
+        nativeDialogOverlayClassName,
+        "backdrop:bg-black/50 backdrop:backdrop-blur-sm"
+      )}
     >
       <div
         className={cn(
-          "bg-background rounded-lg shadow-lg max-w-md w-full",
+          "bg-background rounded-lg shadow-lg max-w-md w-full max-sm:w-[calc(100%-16px)] max-sm:max-w-[calc(100%-16px)]",
           className
         )}
       >

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -68,12 +68,18 @@ export function Dialog({
         handleClose();
       }
     };
+    const onCancel = (e: Event) => {
+      e.preventDefault();
+      handleClose();
+    };
 
     dialog.addEventListener("close", onClose);
     dialog.addEventListener("click", onClick);
+    dialog.addEventListener("cancel", onCancel);
     return () => {
       dialog.removeEventListener("close", onClose);
       dialog.removeEventListener("click", onClick);
+      dialog.removeEventListener("cancel", onCancel);
     };
   }, [closeOnBackdropClick, dialogRef]);
 

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useId, useEffect, useEffectEvent, useMemo, useRef, use } from "react";
 import { cn } from "@/lib/utils";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { nativeDialogOverlayClassName } from "@/components/ui/native-dialog-overlay";
 
 interface DialogContextValue {
   titleId: string;
@@ -90,39 +91,10 @@ export function Dialog({
         aria-label={ariaLabel}
         aria-labelledby={ariaLabel ? undefined : titleId}
         aria-modal="true"
-        // Center the dialog content with a full-viewport flex overlay,
-        // scoped to the `open` variant (targets `&[open]`). Four
-        // constraints drive the exact class set:
-        //
-        //   1. Keep closed dialogs hidden. The UA
-        //      `dialog:not([open]) { display: none }` is a user-agent
-        //      rule, which any *unconditional* author `display` utility
-        //      (e.g. a bare `flex`) always wins over regardless of
-        //      specificity — silently making every closed <dialog>
-        //      visible. So `hidden` by default, `open:flex` only when
-        //      `[open]`.
-        //
-        //   2. Make the dialog actually fill the viewport so flexbox can
-        //      center. The UA gives `<dialog>` `width: fit-content`, so
-        //      `inset:0` alone does NOT stretch it (it shrink-wraps and
-        //      sits at the top-left). We need an explicit size —
-        //      `open:w-full open:h-full` — to claim the full viewport.
-        //      (`open:fixed open:inset-0` pins it at 0,0.)
-        //
-        //   3. Defeat the UA size cap. The UA also sets `max-width` /
-        //      `max-height` on the dialog that clip it short of the
-        //      viewport (observed ~38px inset), which throws off the
-        //      flex centering by ~19px each axis. `open:max-w-none
-        //      open:max-h-none` removes that cap so the box is the full
-        //      viewport and content centers exactly.
-        //
-        //   4. NO `transform`. A transform (the previous
-        //      `-translate-x/y-1/2` centering) establishes a containing
-        //      block for `position: fixed` descendants, breaking portaled
-        //      tooltips/selects that rely on viewport-relative fixed
-        //      positioning. None of the classes above have that side
-        //      effect, so those portals keep anchoring to the viewport.
-        className="hidden open:flex open:fixed open:inset-0 open:w-full open:h-full open:max-w-none open:max-h-none open:items-center open:justify-center backdrop:bg-black/30 backdrop:backdrop-blur-sm m-0 border-0 p-0 bg-transparent text-[hsl(var(--foreground))]"
+        className={cn(
+          nativeDialogOverlayClassName,
+          "backdrop:bg-black/30 backdrop:backdrop-blur-sm"
+        )}
       >
         {children}
       </dialog>

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -1,5 +1,13 @@
 import * as React from "react";
-import { useId, useEffect, useEffectEvent, useMemo, useRef, use } from "react";
+import {
+  useId,
+  useEffect,
+  useLayoutEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  use,
+} from "react";
 import { cn } from "@/lib/utils";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { nativeDialogOverlayClassName } from "@/components/ui/native-dialog-overlay";
@@ -37,23 +45,30 @@ export function Dialog({
   "aria-labelledby": ariaLabelledBy,
 }: DialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  // When the controlled `open` prop becomes false we call dialog.close(),
+  // which fires a native `close` event. Ignore that event so dirty-guarded
+  // onOpenChange(false) from confirmDiscard / successful save is not
+  // re-entered while the form is still dirty.
+  const ignoreNextCloseRef = useRef(false);
 
   const handleClose = useEffectEvent(() => onOpenChange?.(false));
 
   // Trap focus within the dialog when open
   useFocusTrap(dialogRef, open ?? false);
 
-  // Sync open prop with native dialog showModal/close API via ref callback
-  // (runs at commit time, same timing as event handlers)
-  const syncDialogRef = (el: HTMLDialogElement | null) => {
-    dialogRef.current = el;
+  // Sync open prop with native dialog showModal/close API. useLayoutEffect
+  // (not a render-time ref write) keeps lint clean while still running
+  // before paint; the close listener below consults ignoreNextCloseRef.
+  useLayoutEffect(() => {
+    const el = dialogRef.current;
     if (!el) return;
     if (open && !el.open) {
       el.showModal?.();
     } else if (!open && el.open) {
+      ignoreNextCloseRef.current = true;
       el.close?.();
     }
-  };
+  }, [open]);
 
   // Listen for native close event (Escape key, programmatic close)
   // Also handle backdrop click via the native click event on the dialog element
@@ -61,7 +76,13 @@ export function Dialog({
     const dialog = dialogRef.current;
     if (!dialog) return;
 
-    const onClose = () => handleClose();
+    const onClose = () => {
+      if (ignoreNextCloseRef.current) {
+        ignoreNextCloseRef.current = false;
+        return;
+      }
+      handleClose();
+    };
     const onClick = (e: MouseEvent) => {
       // Backdrop click: target is the dialog element itself (not its children)
       if (closeOnBackdropClick && e.target === dialog) {
@@ -93,7 +114,7 @@ export function Dialog({
   return (
     <DialogContext.Provider value={contextValue}>
       <dialog
-        ref={syncDialogRef}
+        ref={dialogRef}
         aria-label={ariaLabel}
         aria-labelledby={ariaLabel ? undefined : titleId}
         aria-modal="true"

--- a/apps/frontend/src/components/ui/native-dialog-overlay.ts
+++ b/apps/frontend/src/components/ui/native-dialog-overlay.ts
@@ -1,0 +1,14 @@
+/**
+ * Tailwind classes for a viewport-centered native `<dialog>` overlay.
+ *
+ * The UA positions `<dialog>` with `width: fit-content` and size caps, so
+ * `m-auto` alone leaves modals at the top. A full-viewport flex overlay
+ * (`open:fixed`, `open:w-full`, `open:h-full`, `open:items-center`,
+ * `open:justify-center`) centers content without transforms (transforms
+ * break viewport-fixed portaled children).
+ *
+ * Use `hidden` + `open:flex` so closed dialogs stay hidden — an unconditional
+ * `flex` would override the UA `dialog:not([open]) { display: none }`.
+ */
+export const nativeDialogOverlayClassName =
+  "hidden open:flex open:fixed open:inset-0 open:w-full open:h-full open:max-w-none open:max-h-none open:items-center open:justify-center m-0 border-0 p-0 bg-transparent text-[hsl(var(--foreground))]";

--- a/apps/frontend/src/components/variables/VariableEditDialog.tsx
+++ b/apps/frontend/src/components/variables/VariableEditDialog.tsx
@@ -4,7 +4,7 @@
  * Modal for creating or editing a single variable.
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Loader2 } from "lucide-react";
 import {
   Dialog,
@@ -19,6 +19,9 @@ import { Label } from "@/components/ui/label";
 import { FormErrorMessage } from "@/components/ui/form-error-message";
 import { useVariables } from "@/hooks/useVariables";
 import type { Variable } from "@branchforge/shared";
+import { useDirtyForm } from "@/hooks/useDirtyForm";
+import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 interface VariableEditDialogProps {
   open: boolean;
@@ -77,6 +80,7 @@ interface VariableFormContentProps {
     form: VariableFormState
   ) => Promise<void>;
   onClose: () => void;
+  onDirtyChange: (dirty: boolean) => void;
 }
 
 function VariableFormContent({
@@ -85,6 +89,7 @@ function VariableFormContent({
   isSaving,
   onSave,
   onClose,
+  onDirtyChange,
 }: VariableFormContentProps) {
   const [form, setForm] = useState<VariableFormState>(() => {
     if (!variableId) return initialForm;
@@ -96,6 +101,21 @@ function VariableFormContent({
       category: variable.category ?? "",
     };
   });
+  const initialSnapshot: VariableFormState = useMemo(() => {
+    if (!variableId) return initialForm;
+    const variable = variables.find((v) => v.id === variableId);
+    if (!variable) return initialForm;
+    return {
+      key: variable.key,
+      description: variable.description ?? "",
+      category: variable.category ?? "",
+    };
+  }, [variableId, variables]);
+  const { isDirty } = useDirtyForm(initialSnapshot, form);
+  useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect
+    onDirtyChange(isDirty);
+  }, [isDirty, onDirtyChange]);
   const [errors, setErrors] = useState<VariableFormErrors>({});
 
   // react-doctor-disable-next-line react-doctor/no-event-handler
@@ -129,7 +149,6 @@ function VariableFormContent({
 
     try {
       await onSave(variableId, form);
-      onClose();
     } catch {
       // Error handled by hook toast
     }
@@ -215,7 +234,11 @@ function VariableFormContent({
         >
           Cancel
         </Button>
-        <Button type="button" onClick={handleSave} disabled={isSaving}>
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || isSaving}
+        >
           {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
           Save
         </Button>
@@ -242,6 +265,14 @@ export function VariableEditDialog({
   const isSaving = isCreatingVariable || isUpdatingVariable;
   const isEditMode = !!variableId;
 
+  const [isDirty, setIsDirty] = useState(false);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
+
   const handleSave = async (
     id: string | undefined,
     form: VariableFormState
@@ -258,37 +289,51 @@ export function VariableEditDialog({
         category: form.category.trim() || undefined,
       });
     }
+    onOpenChange(false);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-xl w-full">
-        <DialogHeader>
-          <DialogTitle>
-            {isEditMode ? "Edit Variable" : "Add Variable"}
-          </DialogTitle>
-          <DialogDescription>
-            {isEditMode
-              ? "Update variable details."
-              : "Create a new variable for branching logic."}
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-xl w-full">
+          <DialogHeader>
+            <DialogTitle>
+              {isEditMode ? "Edit Variable" : "Add Variable"}
+            </DialogTitle>
+            <DialogDescription>
+              {isEditMode
+                ? "Update variable details."
+                : "Create a new variable for branching logic."}
+            </DialogDescription>
+          </DialogHeader>
 
-        {isEditMode && isLoadingVariables ? (
-          <div className="flex justify-center py-8">
-            <Loader2 className="size-6 animate-spin" />
-          </div>
-        ) : (
-          <VariableFormContent
-            key={`${variableId ?? "new"}-${open}`}
-            variableId={variableId}
-            variables={variables}
-            isSaving={isSaving}
-            onSave={handleSave}
-            onClose={() => onOpenChange(false)}
-          />
-        )}
-      </DialogContent>
-    </Dialog>
+          {isEditMode && isLoadingVariables ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="size-6 animate-spin" />
+            </div>
+          ) : (
+            <VariableFormContent
+              key={`${variableId ?? "new"}-${open}`}
+              variableId={variableId}
+              variables={variables}
+              isSaving={isSaving}
+              onSave={handleSave}
+              onClose={() => handleOpenChange(false)}
+              onDirtyChange={setIsDirty}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }

--- a/apps/frontend/src/components/variables/VariableEditDialog.tsx
+++ b/apps/frontend/src/components/variables/VariableEditDialog.tsx
@@ -72,6 +72,8 @@ function validateVariable(form: VariableFormState): VariableFormErrors {
 }
 
 interface VariableFormContentProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   variableId: string | undefined;
   variables: Variable[];
   isSaving: boolean;
@@ -79,17 +81,15 @@ interface VariableFormContentProps {
     variableId: string | undefined,
     form: VariableFormState
   ) => Promise<void>;
-  onClose: () => void;
-  onDirtyChange: (dirty: boolean) => void;
 }
 
 function VariableFormContent({
+  open,
+  onOpenChange,
   variableId,
   variables,
   isSaving,
   onSave,
-  onClose,
-  onDirtyChange,
 }: VariableFormContentProps) {
   const [form, setForm] = useState<VariableFormState>(() => {
     if (!variableId) return initialForm;
@@ -112,23 +112,22 @@ function VariableFormContent({
     };
   }, [variableId, variables]);
   const { isDirty } = useDirtyForm(initialSnapshot, form);
-  useEffect(() => {
-    // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect
-    onDirtyChange(isDirty);
-  }, [isDirty, onDirtyChange]);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
   const [errors, setErrors] = useState<VariableFormErrors>({});
 
-  // react-doctor-disable-next-line react-doctor/no-event-handler
   const isEditMode = !!variableId;
 
   // Close dialog if editing a variable that no longer exists
   useEffect(() => {
-    // react-doctor-disable-next-line react-doctor/no-event-handler
     if (isEditMode && !variables.find((item) => item.id === variableId)) {
-      // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect
-      onClose();
+      onOpenChange(false);
     }
-  }, [isEditMode, variableId, variables, onClose]);
+  }, [isEditMode, variableId, variables, onOpenChange]);
 
   const handleChange = (field: keyof VariableFormState, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }));
@@ -149,101 +148,138 @@ function VariableFormContent({
 
     try {
       await onSave(variableId, form);
+      onOpenChange(false);
     } catch {
       // Error handled by hook toast
     }
   };
 
   return (
-    <div className="space-y-4 mt-4">
-      <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
-        <div className="space-y-1">
-          <Label htmlFor="variable-key" className="text-xs">
-            Variable Key *
-          </Label>
-          <Input
-            id="variable-key"
-            type="text"
-            placeholder="met_alex"
-            value={form.key}
-            onChange={(event) => handleChange("key", event.target.value)}
-            disabled={isSaving || isEditMode}
-            aria-required="true"
-            aria-invalid={!!errors.key}
-            aria-describedby={errors.key ? "variable-key-error" : undefined}
-          />
-          <p className="text-xs text-muted-foreground">
-            {isEditMode
-              ? "Key cannot be changed after creation"
-              : "Unique identifier (letters, numbers, underscores)"}
-          </p>
-          <FormErrorMessage id="variable-key-error" message={errors.key} />
-        </div>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-xl w-full">
+          <DialogHeader>
+            <DialogTitle>
+              {isEditMode ? "Edit Variable" : "Add Variable"}
+            </DialogTitle>
+            <DialogDescription>
+              {isEditMode
+                ? "Update variable details."
+                : "Create a new variable for branching logic."}
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="space-y-1">
-          <Label htmlFor="variable-category" className="text-xs">
-            Category
-          </Label>
-          <Input
-            id="variable-category"
-            type="text"
-            placeholder="Relationships"
-            value={form.category}
-            onChange={(event) => handleChange("category", event.target.value)}
-            disabled={isSaving}
-            aria-invalid={!!errors.category}
-            aria-describedby={
-              errors.category ? "variable-category-error" : undefined
-            }
-          />
-          <FormErrorMessage
-            id="variable-category-error"
-            message={errors.category}
-          />
-        </div>
-      </div>
+          <div className="space-y-4 mt-4">
+            <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="variable-key" className="text-xs">
+                  Variable Key *
+                </Label>
+                <Input
+                  id="variable-key"
+                  type="text"
+                  placeholder="met_alex"
+                  value={form.key}
+                  onChange={(event) => handleChange("key", event.target.value)}
+                  disabled={isSaving || isEditMode}
+                  aria-required="true"
+                  aria-invalid={!!errors.key}
+                  aria-describedby={
+                    errors.key ? "variable-key-error" : undefined
+                  }
+                />
+                <p className="text-xs text-muted-foreground">
+                  {isEditMode
+                    ? "Key cannot be changed after creation"
+                    : "Unique identifier (letters, numbers, underscores)"}
+                </p>
+                <FormErrorMessage
+                  id="variable-key-error"
+                  message={errors.key}
+                />
+              </div>
 
-      <div className="space-y-1">
-        <Label htmlFor="variable-description" className="text-xs">
-          Description
-        </Label>
-        <Input
-          id="variable-description"
-          type="text"
-          placeholder="Player has met Alex"
-          value={form.description}
-          onChange={(event) => handleChange("description", event.target.value)}
-          disabled={isSaving}
-          aria-invalid={!!errors.description}
-          aria-describedby={
-            errors.description ? "variable-description-error" : undefined
-          }
-        />
-        <FormErrorMessage
-          id="variable-description-error"
-          message={errors.description}
-        />
-      </div>
+              <div className="space-y-1">
+                <Label htmlFor="variable-category" className="text-xs">
+                  Category
+                </Label>
+                <Input
+                  id="variable-category"
+                  type="text"
+                  placeholder="Relationships"
+                  value={form.category}
+                  onChange={(event) =>
+                    handleChange("category", event.target.value)
+                  }
+                  disabled={isSaving}
+                  aria-invalid={!!errors.category}
+                  aria-describedby={
+                    errors.category ? "variable-category-error" : undefined
+                  }
+                />
+                <FormErrorMessage
+                  id="variable-category-error"
+                  message={errors.category}
+                />
+              </div>
+            </div>
 
-      <div className="flex justify-end gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onClose}
-          disabled={isSaving}
-        >
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          onClick={handleSave}
-          disabled={!isDirty || isSaving}
-        >
-          {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
-          Save
-        </Button>
-      </div>
-    </div>
+            <div className="space-y-1">
+              <Label htmlFor="variable-description" className="text-xs">
+                Description
+              </Label>
+              <Input
+                id="variable-description"
+                type="text"
+                placeholder="Player has met Alex"
+                value={form.description}
+                onChange={(event) =>
+                  handleChange("description", event.target.value)
+                }
+                disabled={isSaving}
+                aria-invalid={!!errors.description}
+                aria-describedby={
+                  errors.description ? "variable-description-error" : undefined
+                }
+              />
+              <FormErrorMessage
+                id="variable-description-error"
+                message={errors.description}
+              />
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isSaving}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSave}
+                disabled={!isDirty || isSaving}
+              >
+                {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
+                Save
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }
 
@@ -265,14 +301,6 @@ export function VariableEditDialog({
   const isSaving = isCreatingVariable || isUpdatingVariable;
   const isEditMode = !!variableId;
 
-  const [isDirty, setIsDirty] = useState(false);
-  const {
-    handleOpenChange,
-    confirmDiscard,
-    discardDialogOpen,
-    setDiscardDialogOpen,
-  } = useDirtyDialogWarning(isDirty, onOpenChange);
-
   const handleSave = async (
     id: string | undefined,
     form: VariableFormState
@@ -289,51 +317,33 @@ export function VariableEditDialog({
         category: form.category.trim() || undefined,
       });
     }
-    onOpenChange(false);
   };
 
-  return (
-    <>
-      <Dialog open={open} onOpenChange={handleOpenChange}>
+  if (isEditMode && isLoadingVariables) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="max-w-xl w-full">
           <DialogHeader>
-            <DialogTitle>
-              {isEditMode ? "Edit Variable" : "Add Variable"}
-            </DialogTitle>
-            <DialogDescription>
-              {isEditMode
-                ? "Update variable details."
-                : "Create a new variable for branching logic."}
-            </DialogDescription>
+            <DialogTitle>Edit Variable</DialogTitle>
+            <DialogDescription>Update variable details.</DialogDescription>
           </DialogHeader>
-
-          {isEditMode && isLoadingVariables ? (
-            <div className="flex justify-center py-8">
-              <Loader2 className="size-6 animate-spin" />
-            </div>
-          ) : (
-            <VariableFormContent
-              key={`${variableId ?? "new"}-${open}`}
-              variableId={variableId}
-              variables={variables}
-              isSaving={isSaving}
-              onSave={handleSave}
-              onClose={() => handleOpenChange(false)}
-              onDirtyChange={setIsDirty}
-            />
-          )}
+          <div className="flex justify-center py-8">
+            <Loader2 className="size-6 animate-spin" />
+          </div>
         </DialogContent>
       </Dialog>
+    );
+  }
 
-      <ConfirmDialog
-        open={discardDialogOpen}
-        onOpenChange={setDiscardDialogOpen}
-        onConfirm={confirmDiscard}
-        title="Discard unsaved changes?"
-        description="You have unsaved changes. Are you sure you want to discard them?"
-        confirmLabel="Discard"
-        cancelLabel="Keep editing"
-      />
-    </>
+  return (
+    <VariableFormContent
+      key={`${variableId ?? "new"}-${open}`}
+      open={open}
+      onOpenChange={onOpenChange}
+      variableId={variableId}
+      variables={variables}
+      isSaving={isSaving}
+      onSave={handleSave}
+    />
   );
 }

--- a/apps/frontend/src/components/variables/VariableEditDialog.tsx
+++ b/apps/frontend/src/components/variables/VariableEditDialog.tsx
@@ -91,16 +91,6 @@ function VariableFormContent({
   isSaving,
   onSave,
 }: VariableFormContentProps) {
-  const [form, setForm] = useState<VariableFormState>(() => {
-    if (!variableId) return initialForm;
-    const variable = variables.find((item: Variable) => item.id === variableId);
-    if (!variable) return initialForm;
-    return {
-      key: variable.key,
-      description: variable.description ?? "",
-      category: variable.category ?? "",
-    };
-  });
   const initialSnapshot: VariableFormState = useMemo(() => {
     if (!variableId) return initialForm;
     const variable = variables.find((v) => v.id === variableId);
@@ -111,6 +101,7 @@ function VariableFormContent({
       category: variable.category ?? "",
     };
   }, [variableId, variables]);
+  const [form, setForm] = useState<VariableFormState>(initialSnapshot);
   const { isDirty } = useDirtyForm(initialSnapshot, form);
   const {
     handleOpenChange,

--- a/apps/frontend/src/components/visual-system/VisualSystemDialog.tsx
+++ b/apps/frontend/src/components/visual-system/VisualSystemDialog.tsx
@@ -140,7 +140,10 @@ export function VisualSystemFormContent({
         : INITIAL_VISUAL_SYSTEM_FORM,
     [initialConfig]
   );
-  const { isDirty, resetDirty } = useDirtyForm(initialSnapshot, form);
+  const { isDirty, resetDirty, checkDirty } = useDirtyForm(
+    initialSnapshot,
+    form
+  );
   const handleChange = <K extends keyof VisualSystemFormState>(
     field: K,
     value: VisualSystemFormState[K]
@@ -148,7 +151,9 @@ export function VisualSystemFormContent({
     const next = { ...form, [field]: value };
     setForm(next);
     setErrors((prev) => ({ ...prev, [field]: undefined }));
-    onDirtyChange?.(JSON.stringify(next) !== JSON.stringify(initialSnapshot));
+    // Notify parent from the hook baseline (survives resetDirty), not a
+    // separate JSON compare against the prop snapshot.
+    onDirtyChange?.(checkDirty(next));
   };
 
   const handleSave = async () => {

--- a/apps/frontend/src/components/visual-system/VisualSystemDialog.tsx
+++ b/apps/frontend/src/components/visual-system/VisualSystemDialog.tsx
@@ -5,7 +5,7 @@
  * around it. Used by `ProjectSettingsDialog` (as a tab panel).
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useDirtyForm } from "@/hooks/useDirtyForm";
@@ -141,15 +141,14 @@ export function VisualSystemFormContent({
     [initialConfig]
   );
   const { isDirty, resetDirty } = useDirtyForm(initialSnapshot, form);
-  useEffect(() => {
-    onDirtyChange?.(isDirty);
-  }, [isDirty, onDirtyChange]);
   const handleChange = <K extends keyof VisualSystemFormState>(
     field: K,
     value: VisualSystemFormState[K]
   ) => {
-    setForm((prev) => ({ ...prev, [field]: value }));
+    const next = { ...form, [field]: value };
+    setForm(next);
     setErrors((prev) => ({ ...prev, [field]: undefined }));
+    onDirtyChange?.(JSON.stringify(next) !== JSON.stringify(initialSnapshot));
   };
 
   const handleSave = async () => {
@@ -161,6 +160,7 @@ export function VisualSystemFormContent({
     try {
       await onSave(form);
       resetDirty();
+      onDirtyChange?.(false);
       onClose();
     } catch {
       // Error handled by hook toast

--- a/apps/frontend/src/components/visual-system/VisualSystemDialog.tsx
+++ b/apps/frontend/src/components/visual-system/VisualSystemDialog.tsx
@@ -5,9 +5,10 @@
  * around it. Used by `ProjectSettingsDialog` (as a tab panel).
  */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useDirtyForm } from "@/hooks/useDirtyForm";
 import {
   generateVisualName,
   type VisualSystemConfig,
@@ -88,12 +89,12 @@ function validateForm(form: VisualSystemFormState): VisualSystemFormErrors {
 // ============================================================================
 // Form content
 // ============================================================================
-
 interface VisualSystemFormContentProps {
   initialConfig: VisualSystemConfig | null;
   isSaving: boolean;
   onSave: (form: VisualSystemFormState) => Promise<void>;
   onClose: () => void;
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
 /**
@@ -105,6 +106,7 @@ export function VisualSystemFormContent({
   isSaving,
   onSave,
   onClose,
+  onDirtyChange,
 }: VisualSystemFormContentProps) {
   const [form, setForm] = useState<VisualSystemFormState>(
     initialConfig
@@ -129,6 +131,19 @@ export function VisualSystemFormContent({
     }
   }
 
+  // Track dirty state so the outer dialog can guard against accidental
+  // dismissal when the form has unsaved changes.
+  const initialSnapshot = useMemo(
+    () =>
+      initialConfig
+        ? toVisualSystemFormState(initialConfig)
+        : INITIAL_VISUAL_SYSTEM_FORM,
+    [initialConfig]
+  );
+  const { isDirty, resetDirty } = useDirtyForm(initialSnapshot, form);
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
   const handleChange = <K extends keyof VisualSystemFormState>(
     field: K,
     value: VisualSystemFormState[K]
@@ -145,6 +160,7 @@ export function VisualSystemFormContent({
     }
     try {
       await onSave(form);
+      resetDirty();
       onClose();
     } catch {
       // Error handled by hook toast
@@ -235,7 +251,11 @@ export function VisualSystemFormContent({
         {/* No Cancel button — the dialog's X / the outer Close
             button (in `ProjectSettingsDialog`) is the equivalent.
             Save persists; close discards unsaved changes. */}
-        <Button type="button" onClick={handleSave} disabled={isSaving}>
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || isSaving}
+        >
           {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
           Save
         </Button>

--- a/apps/frontend/src/components/world-elements/WorldElementEditDialog.tsx
+++ b/apps/frontend/src/components/world-elements/WorldElementEditDialog.tsx
@@ -131,7 +131,7 @@ function ElementFormContent({
     description: form.description,
     tags: form.tags,
   };
-  const { isDirty, resetDirty } = useDirtyForm(initialSnapshot, snapshot);
+  const { isDirty } = useDirtyForm(initialSnapshot, snapshot);
 
   const {
     handleOpenChange,
@@ -177,7 +177,6 @@ function ElementFormContent({
 
     try {
       await onSave(elementId, form);
-      resetDirty();
       onOpenChange(false);
     } catch {
       // Error handled by hook toast

--- a/apps/frontend/src/components/world-elements/WorldElementEditDialog.tsx
+++ b/apps/frontend/src/components/world-elements/WorldElementEditDialog.tsx
@@ -4,7 +4,7 @@
  * Modal for creating or editing a single world element.
  */
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Loader2, Plus, X } from "lucide-react";
 import {
   Dialog,
@@ -20,6 +20,9 @@ import { FormErrorMessage } from "@/components/ui/form-error-message";
 import { Select, type SelectOption } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useWorldElements } from "@/hooks/useWorldElements";
+import { useDirtyForm } from "@/hooks/useDirtyForm";
+import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import type { WorldElement, WorldElementType } from "@branchforge/shared";
 
 interface WorldElementEditDialogProps {
@@ -85,14 +88,15 @@ interface ElementFormContentProps {
     form: ElementFormState
   ) => Promise<void>;
   onClose: () => void;
+  onDirtyChange?: (dirty: boolean) => void;
 }
-
 function ElementFormContent({
   elementId,
   elements,
   isSaving,
   onSave,
   onClose,
+  onDirtyChange,
 }: ElementFormContentProps) {
   const [form, setForm] = useState<ElementFormState>(() => {
     if (!elementId) return INITIAL_FORM;
@@ -107,6 +111,31 @@ function ElementFormContent({
   });
   const [errors, setErrors] = useState<ElementFormErrors>({});
   const [newTag, setNewTag] = useState("");
+
+  const [initialSnapshot] = useState<ElementFormState>(() => {
+    if (!elementId) return INITIAL_FORM;
+    const element = elements.find((e) => e.id === elementId);
+    return element
+      ? {
+          name: element.name,
+          type: element.type,
+          description: element.description ?? "",
+          tags: element.tags ?? [],
+        }
+      : INITIAL_FORM;
+  });
+
+  const snapshot = {
+    name: form.name,
+    type: form.type,
+    description: form.description,
+    tags: form.tags,
+  };
+  const { isDirty, resetDirty } = useDirtyForm(initialSnapshot, snapshot);
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
 
   const handleChange = (
     field: keyof ElementFormState,
@@ -145,6 +174,7 @@ function ElementFormContent({
 
     try {
       await onSave(elementId, form);
+      resetDirty();
       onClose();
     } catch {
       // Error handled by hook toast
@@ -276,7 +306,11 @@ function ElementFormContent({
         >
           Cancel
         </Button>
-        <Button type="button" onClick={handleSave} disabled={isSaving}>
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || isSaving}
+        >
           {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
           Save
         </Button>
@@ -303,6 +337,15 @@ export function WorldElementEditDialog({
   const isSaving = isCreatingElement || isUpdatingElement;
   const isEditMode = !!elementId;
 
+  const [isDirty, setIsDirty] = useState(false);
+
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
+
   const handleSave = async (id: string | undefined, form: ElementFormState) => {
     if (id) {
       await updateElement(id, {
@@ -322,34 +365,46 @@ export function WorldElementEditDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-xl w-full">
-        <DialogHeader>
-          <DialogTitle>
-            {isEditMode ? "Edit World Element" : "Add World Element"}
-          </DialogTitle>
-          <DialogDescription>
-            {isEditMode
-              ? "Update world element details."
-              : "Create a new entry for your world bible."}
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-xl w-full">
+          <DialogHeader>
+            <DialogTitle>
+              {isEditMode ? "Edit World Element" : "Add World Element"}
+            </DialogTitle>
+            <DialogDescription>
+              {isEditMode
+                ? "Update world element details."
+                : "Create a new entry for your world bible."}
+            </DialogDescription>
+          </DialogHeader>
 
-        {isEditMode && isLoadingElements ? (
-          <div className="flex justify-center py-8">
-            <Loader2 className="size-6 animate-spin" />
-          </div>
-        ) : (
-          <ElementFormContent
-            key={`${elementId ?? "new"}-${open}`}
-            elementId={elementId}
-            elements={elements}
-            isSaving={isSaving}
-            onSave={handleSave}
-            onClose={() => onOpenChange(false)}
-          />
-        )}
-      </DialogContent>
-    </Dialog>
+          {isEditMode && isLoadingElements ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="size-6 animate-spin" />
+            </div>
+          ) : (
+            <ElementFormContent
+              key={`${elementId ?? "new"}-${open}`}
+              elementId={elementId}
+              elements={elements}
+              isSaving={isSaving}
+              onSave={handleSave}
+              onClose={() => handleOpenChange(false)}
+              onDirtyChange={setIsDirty}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }

--- a/apps/frontend/src/components/world-elements/WorldElementEditDialog.tsx
+++ b/apps/frontend/src/components/world-elements/WorldElementEditDialog.tsx
@@ -4,7 +4,7 @@
  * Modal for creating or editing a single world element.
  */
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Loader2, Plus, X } from "lucide-react";
 import {
   Dialog,
@@ -80,6 +80,8 @@ function validateElement(form: ElementFormState): ElementFormErrors {
 }
 
 interface ElementFormContentProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   elementId: string | undefined;
   elements: WorldElement[];
   isSaving: boolean;
@@ -87,16 +89,14 @@ interface ElementFormContentProps {
     elementId: string | undefined,
     form: ElementFormState
   ) => Promise<void>;
-  onClose: () => void;
-  onDirtyChange?: (dirty: boolean) => void;
 }
 function ElementFormContent({
+  open,
+  onOpenChange,
   elementId,
   elements,
   isSaving,
   onSave,
-  onClose,
-  onDirtyChange,
 }: ElementFormContentProps) {
   const [form, setForm] = useState<ElementFormState>(() => {
     if (!elementId) return INITIAL_FORM;
@@ -133,9 +133,12 @@ function ElementFormContent({
   };
   const { isDirty, resetDirty } = useDirtyForm(initialSnapshot, snapshot);
 
-  useEffect(() => {
-    onDirtyChange?.(isDirty);
-  }, [isDirty, onDirtyChange]);
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
 
   const handleChange = (
     field: keyof ElementFormState,
@@ -175,147 +178,186 @@ function ElementFormContent({
     try {
       await onSave(elementId, form);
       resetDirty();
-      onClose();
+      onOpenChange(false);
     } catch {
       // Error handled by hook toast
     }
   };
 
   return (
-    <div className="space-y-4 mt-4">
-      <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
-        <div className="space-y-1">
-          <Label htmlFor="element-name" className="text-xs">
-            Name *
-          </Label>
-          <Input
-            id="element-name"
-            type="text"
-            placeholder="Castle Blackthorn"
-            value={form.name}
-            onChange={(event) => handleChange("name", event.target.value)}
-            disabled={isSaving}
-            aria-required="true"
-            aria-invalid={!!errors.name}
-            aria-describedby={errors.name ? "element-name-error" : undefined}
-          />
-          <FormErrorMessage id="element-name-error" message={errors.name} />
-        </div>
-
-        <div className="space-y-1">
-          <Label htmlFor="element-type" className="text-xs">
-            Type *
-          </Label>
-          <Select<WorldElementType>
-            id="element-type"
-            options={TYPE_OPTIONS}
-            value={form.type || undefined}
-            onChange={(value) => handleChange("type", value)}
-            placeholder="Select type"
-            disabled={isSaving}
-            aria-required="true"
-            aria-invalid={!!errors.type}
-            aria-describedby={errors.type ? "element-type-error" : undefined}
-          />
-          <FormErrorMessage id="element-type-error" message={errors.type} />
-        </div>
-      </div>
-
-      <div className="space-y-1">
-        <Label htmlFor="element-description" className="text-xs">
-          Description
-        </Label>
-        <Textarea
-          id="element-description"
-          placeholder="Describe this world element..."
-          value={form.description}
-          onChange={(event) => handleChange("description", event.target.value)}
-          disabled={isSaving}
-          rows={3}
-          className="resize-none"
-          aria-invalid={!!errors.description}
-          aria-describedby={
-            errors.description ? "element-description-error" : undefined
-          }
-        />
-        <FormErrorMessage
-          id="element-description-error"
-          message={errors.description}
-        />
-      </div>
-
-      <div className="space-y-1">
-        <Label className="text-xs">Tags</Label>
-        <div className="flex gap-2">
-          <Input
-            type="text"
-            placeholder="Add a tag..."
-            value={newTag}
-            onChange={(event) => setNewTag(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") {
-                event.preventDefault();
-                handleAddTag();
-              }
-            }}
-            disabled={isSaving}
-            className="flex-1"
-          />
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={handleAddTag}
-            disabled={isSaving || !newTag.trim() || form.tags.length >= 20}
-          >
-            <Plus className="size-4" />
-          </Button>
-        </div>
-        {form.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-2">
-            {form.tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-secondary text-secondary-foreground"
-              >
-                {tag}
-                <button
-                  type="button"
-                  onClick={() => handleRemoveTag(tag)}
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-xl w-full">
+          <DialogHeader>
+            <DialogTitle>
+              {elementId ? "Edit World Element" : "Add World Element"}
+            </DialogTitle>
+            <DialogDescription>
+              {elementId
+                ? "Update world element details."
+                : "Create a new entry for your world bible."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 mt-4">
+            <div className="grid grid-cols-2 max-sm:grid-cols-1 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="element-name" className="text-xs">
+                  Name *
+                </Label>
+                <Input
+                  id="element-name"
+                  type="text"
+                  placeholder="Castle Blackthorn"
+                  value={form.name}
+                  onChange={(event) => handleChange("name", event.target.value)}
                   disabled={isSaving}
-                  className="hover:text-destructive transition-colors"
-                  aria-label={`Remove tag ${tag}`}
-                >
-                  <X className="size-3" />
-                </button>
-              </span>
-            ))}
-          </div>
-        )}
-        <p className="text-xs text-muted-foreground">
-          {form.tags.length}/20 tags. Press Enter to add.
-        </p>
-      </div>
+                  aria-required="true"
+                  aria-invalid={!!errors.name}
+                  aria-describedby={
+                    errors.name ? "element-name-error" : undefined
+                  }
+                />
+                <FormErrorMessage
+                  id="element-name-error"
+                  message={errors.name}
+                />
+              </div>
 
-      <div className="flex justify-end gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onClose}
-          disabled={isSaving}
-        >
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          onClick={handleSave}
-          disabled={!isDirty || isSaving}
-        >
-          {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
-          Save
-        </Button>
-      </div>
-    </div>
+              <div className="space-y-1">
+                <Label htmlFor="element-type" className="text-xs">
+                  Type *
+                </Label>
+                <Select<WorldElementType>
+                  id="element-type"
+                  options={TYPE_OPTIONS}
+                  value={form.type || undefined}
+                  onChange={(value) => handleChange("type", value)}
+                  placeholder="Select type"
+                  disabled={isSaving}
+                  aria-required="true"
+                  aria-invalid={!!errors.type}
+                  aria-describedby={
+                    errors.type ? "element-type-error" : undefined
+                  }
+                />
+                <FormErrorMessage
+                  id="element-type-error"
+                  message={errors.type}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <Label htmlFor="element-description" className="text-xs">
+                Description
+              </Label>
+              <Textarea
+                id="element-description"
+                placeholder="Describe this world element..."
+                value={form.description}
+                onChange={(event) =>
+                  handleChange("description", event.target.value)
+                }
+                disabled={isSaving}
+                rows={3}
+                className="resize-none"
+                aria-invalid={!!errors.description}
+                aria-describedby={
+                  errors.description ? "element-description-error" : undefined
+                }
+              />
+              <FormErrorMessage
+                id="element-description-error"
+                message={errors.description}
+              />
+            </div>
+
+            <div className="space-y-1">
+              <Label className="text-xs">Tags</Label>
+              <div className="flex gap-2">
+                <Input
+                  type="text"
+                  placeholder="Add a tag..."
+                  value={newTag}
+                  onChange={(event) => setNewTag(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      handleAddTag();
+                    }
+                  }}
+                  disabled={isSaving}
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAddTag}
+                  disabled={
+                    isSaving || !newTag.trim() || form.tags.length >= 20
+                  }
+                >
+                  <Plus className="size-4" />
+                </Button>
+              </div>
+              {form.tags.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-2">
+                  {form.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-secondary text-secondary-foreground"
+                    >
+                      {tag}
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveTag(tag)}
+                        disabled={isSaving}
+                        className="hover:text-destructive transition-colors"
+                        aria-label={`Remove tag ${tag}`}
+                      >
+                        <X className="size-3" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+              <p className="text-xs text-muted-foreground">
+                {form.tags.length}/20 tags. Press Enter to add.
+              </p>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isSaving}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSave}
+                disabled={!isDirty || isSaving}
+              >
+                {isSaving && <Loader2 className="size-4 animate-spin mr-2" />}
+                Save
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <ConfirmDialog
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+      />
+    </>
   );
 }
 
@@ -337,15 +379,6 @@ export function WorldElementEditDialog({
   const isSaving = isCreatingElement || isUpdatingElement;
   const isEditMode = !!elementId;
 
-  const [isDirty, setIsDirty] = useState(false);
-
-  const {
-    handleOpenChange,
-    confirmDiscard,
-    discardDialogOpen,
-    setDiscardDialogOpen,
-  } = useDirtyDialogWarning(isDirty, onOpenChange);
-
   const handleSave = async (id: string | undefined, form: ElementFormState) => {
     if (id) {
       await updateElement(id, {
@@ -364,47 +397,31 @@ export function WorldElementEditDialog({
     }
   };
 
-  return (
-    <>
-      <Dialog open={open} onOpenChange={handleOpenChange}>
+  if (isEditMode && isLoadingElements) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="max-w-xl w-full">
           <DialogHeader>
-            <DialogTitle>
-              {isEditMode ? "Edit World Element" : "Add World Element"}
-            </DialogTitle>
-            <DialogDescription>
-              {isEditMode
-                ? "Update world element details."
-                : "Create a new entry for your world bible."}
-            </DialogDescription>
+            <DialogTitle>Edit World Element</DialogTitle>
+            <DialogDescription>Update world element details.</DialogDescription>
           </DialogHeader>
-
-          {isEditMode && isLoadingElements ? (
-            <div className="flex justify-center py-8">
-              <Loader2 className="size-6 animate-spin" />
-            </div>
-          ) : (
-            <ElementFormContent
-              key={`${elementId ?? "new"}-${open}`}
-              elementId={elementId}
-              elements={elements}
-              isSaving={isSaving}
-              onSave={handleSave}
-              onClose={() => handleOpenChange(false)}
-              onDirtyChange={setIsDirty}
-            />
-          )}
+          <div className="flex justify-center py-8">
+            <Loader2 className="size-6 animate-spin" />
+          </div>
         </DialogContent>
       </Dialog>
-      <ConfirmDialog
-        open={discardDialogOpen}
-        onOpenChange={setDiscardDialogOpen}
-        onConfirm={confirmDiscard}
-        title="Discard unsaved changes?"
-        description="You have unsaved changes. Are you sure you want to discard them?"
-        confirmLabel="Discard"
-        cancelLabel="Keep editing"
-      />
-    </>
+    );
+  }
+
+  return (
+    <ElementFormContent
+      key={`${elementId ?? "new"}-${open}`}
+      open={open}
+      onOpenChange={onOpenChange}
+      elementId={elementId}
+      elements={elements}
+      isSaving={isSaving}
+      onSave={handleSave}
+    />
   );
 }

--- a/apps/frontend/src/components/world-elements/WorldElementEditDialog.tsx
+++ b/apps/frontend/src/components/world-elements/WorldElementEditDialog.tsx
@@ -125,13 +125,7 @@ function ElementFormContent({
       : INITIAL_FORM;
   });
 
-  const snapshot = {
-    name: form.name,
-    type: form.type,
-    description: form.description,
-    tags: form.tags,
-  };
-  const { isDirty } = useDirtyForm(initialSnapshot, snapshot);
+  const { isDirty } = useDirtyForm(initialSnapshot, form);
 
   const {
     handleOpenChange,

--- a/apps/frontend/src/components/write-mode/LabelEditDialog/LabelEditDialog.tsx
+++ b/apps/frontend/src/components/write-mode/LabelEditDialog/LabelEditDialog.tsx
@@ -4,7 +4,7 @@
  * Modal for editing label metadata, routing, and duo pair configuration.
  */
 
-import { useEffect, useMemo, useReducer, useRef } from "react";
+import { useMemo, useReducer, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -76,7 +76,25 @@ export function LabelEditDialog({
   isSaving,
 }: LabelEditDialogProps) {
   const [form, dispatch] = useReducer(formReducer, INITIAL_FORM_STATE);
-  const initializedForOpenRef = useRef(false);
+  // Gate dirty until the open-time RESET has been applied. Without this,
+  // the first render still has INITIAL_FORM_STATE and would look dirty
+  // (Save enabled / discard on dismiss) before the init commit.
+  // react-doctor-disable-next-line react-doctor/no-derived-useState, react-doctor/rerender-state-only-in-handlers
+  const [hasInitialized, setHasInitialized] = useState(false);
+  if (open && !hasInitialized) {
+    setHasInitialized(true);
+    dispatch({
+      type: "RESET",
+      title: currentTitle,
+      labelName: currentLabelName ?? "",
+      route: currentRoute ?? "",
+      status: currentStatus ?? "DRAFT",
+      visibility: currentVisibility ?? "EXCLUSIVE",
+      duoPairId: currentDuoPairId ?? "",
+    });
+  } else if (!open && hasInitialized) {
+    setHasInitialized(false);
+  }
 
   const comparableSnapshot = useMemo(
     () => ({
@@ -116,7 +134,11 @@ export function LabelEditDialog({
     ]
   );
 
-  const { isDirty } = useDirtyForm(initialSnapshot, comparableSnapshot);
+  const { isDirty: formDirty } = useDirtyForm(
+    initialSnapshot,
+    comparableSnapshot
+  );
+  const isDirty = hasInitialized && formDirty;
 
   const {
     handleOpenChange,
@@ -124,36 +146,6 @@ export function LabelEditDialog({
     discardDialogOpen,
     setDiscardDialogOpen,
   } = useDirtyDialogWarning(isDirty, onOpenChange);
-
-  // Initialize form state when dialog opens
-  useEffect(() => {
-    if (open && !initializedForOpenRef.current) {
-      initializedForOpenRef.current = true;
-      dispatch({
-        type: "RESET",
-        title: currentTitle,
-        labelName: currentLabelName ?? "",
-        route: currentRoute ?? "",
-        status: currentStatus ?? "DRAFT",
-        visibility: currentVisibility ?? "EXCLUSIVE",
-        duoPairId: currentDuoPairId ?? "",
-      });
-    }
-  }, [
-    open,
-    currentTitle,
-    currentLabelName,
-    currentRoute,
-    currentStatus,
-    currentVisibility,
-    currentDuoPairId,
-  ]);
-  // Reset init guard when dialog closes so it re-initializes on next open
-  useEffect(() => {
-    if (!open) {
-      initializedForOpenRef.current = false;
-    }
-  }, [open]);
 
   const handleSave = async () => {
     if (!form.title.trim()) {

--- a/apps/frontend/src/components/write-mode/LabelEditDialog/LabelEditDialog.tsx
+++ b/apps/frontend/src/components/write-mode/LabelEditDialog/LabelEditDialog.tsx
@@ -227,8 +227,12 @@ export function LabelEditDialog({
       return;
     }
 
-    await onSave(changes);
-    onOpenChange(false);
+    try {
+      await onSave(changes);
+      onOpenChange(false);
+    } catch {
+      // Error handled by hook toast
+    }
   };
 
   const handleCancel = () => {

--- a/apps/frontend/src/components/write-mode/LabelEditDialog/LabelEditDialog.tsx
+++ b/apps/frontend/src/components/write-mode/LabelEditDialog/LabelEditDialog.tsx
@@ -4,7 +4,7 @@
  * Modal for editing label metadata, routing, and duo pair configuration.
  */
 
-import { useEffect, useReducer, useRef } from "react";
+import { useEffect, useMemo, useReducer, useRef } from "react";
 import {
   Dialog,
   DialogContent,
@@ -12,6 +12,9 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { useDirtyForm } from "@/hooks/useDirtyForm";
+import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
 import { INITIAL_FORM_STATE, formReducer } from "./LabelEditDialogReducer.js";
 import { LabelEditDialogFields } from "./LabelEditDialogFields.js";
 import { LabelEditDialogFooter } from "./LabelEditDialogFooter.js";
@@ -73,8 +76,54 @@ export function LabelEditDialog({
   isSaving,
 }: LabelEditDialogProps) {
   const [form, dispatch] = useReducer(formReducer, INITIAL_FORM_STATE);
-
   const initializedForOpenRef = useRef(false);
+
+  const comparableSnapshot = useMemo(
+    () => ({
+      title: form.title,
+      labelName: form.labelName,
+      route: form.route,
+      status: form.status,
+      visibility: form.visibility,
+      duoPairId: form.duoPairId,
+    }),
+    [
+      form.title,
+      form.labelName,
+      form.route,
+      form.status,
+      form.visibility,
+      form.duoPairId,
+    ]
+  );
+
+  const initialSnapshot = useMemo(
+    () => ({
+      title: currentTitle,
+      labelName: currentLabelName ?? "",
+      route: currentRoute ?? "",
+      status: currentStatus ?? "DRAFT",
+      visibility: currentVisibility ?? "EXCLUSIVE",
+      duoPairId: currentDuoPairId ?? "",
+    }),
+    [
+      currentTitle,
+      currentLabelName,
+      currentRoute,
+      currentStatus,
+      currentVisibility,
+      currentDuoPairId,
+    ]
+  );
+
+  const { isDirty } = useDirtyForm(initialSnapshot, comparableSnapshot);
+
+  const {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  } = useDirtyDialogWarning(isDirty, onOpenChange);
 
   // Initialize form state when dialog opens
   useEffect(() => {
@@ -99,6 +148,12 @@ export function LabelEditDialog({
     currentVisibility,
     currentDuoPairId,
   ]);
+  // Reset init guard when dialog closes so it re-initializes on next open
+  useEffect(() => {
+    if (!open) {
+      initializedForOpenRef.current = false;
+    }
+  }, [open]);
 
   const handleSave = async () => {
     if (!form.title.trim()) {
@@ -176,54 +231,59 @@ export function LabelEditDialog({
     }
 
     if (Object.keys(changes).length === 0) {
-      initializedForOpenRef.current = false;
       onOpenChange(false);
       return;
     }
 
     await onSave(changes);
-    initializedForOpenRef.current = false;
-  };
-
-  const handleCancel = () => {
-    initializedForOpenRef.current = false;
     onOpenChange(false);
   };
 
+  const handleCancel = () => {
+    handleOpenChange(false);
+  };
+
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(newOpen) => {
-        if (!newOpen) initializedForOpenRef.current = false;
-        onOpenChange(newOpen);
-      }}
-    >
-      <DialogContent className="w-[560px] max-w-[95vw] max-h-[85vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>Edit Label</DialogTitle>
-          <DialogDescription>
-            Update the label metadata and routing configuration.
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="w-[560px] max-w-[95vw] max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Edit Label</DialogTitle>
+            <DialogDescription>
+              Update the label metadata and routing configuration.
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="space-y-4 mt-4">
-          <LabelEditDialogFields
-            form={form}
-            dispatch={dispatch}
-            isSaving={isSaving}
-            currentLabelName={currentLabelName}
-            routeConfigs={routeConfigs}
-            pairGroups={pairGroups}
-            duoEndingEnabled={duoEndingEnabled}
-          />
+          <div className="space-y-4 mt-4">
+            <LabelEditDialogFields
+              form={form}
+              dispatch={dispatch}
+              isSaving={isSaving}
+              currentLabelName={currentLabelName}
+              routeConfigs={routeConfigs}
+              pairGroups={pairGroups}
+              duoEndingEnabled={duoEndingEnabled}
+            />
 
-          <LabelEditDialogFooter
-            isSaving={isSaving}
-            onCancel={handleCancel}
-            onSave={handleSave}
-          />
-        </div>
-      </DialogContent>
-    </Dialog>
+            <LabelEditDialogFooter
+              isSaving={isSaving}
+              saveDisabled={!isDirty}
+              onCancel={handleCancel}
+              onSave={handleSave}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        title="Discard unsaved changes?"
+        description="You have unsaved changes. Are you sure you want to discard them?"
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+        open={discardDialogOpen}
+        onOpenChange={setDiscardDialogOpen}
+        onConfirm={confirmDiscard}
+      />
+    </>
   );
 }

--- a/apps/frontend/src/components/write-mode/LabelEditDialog/LabelEditDialogFooter.tsx
+++ b/apps/frontend/src/components/write-mode/LabelEditDialog/LabelEditDialogFooter.tsx
@@ -9,12 +9,14 @@ import { Button } from "@/components/ui/button";
 
 export interface LabelEditDialogFooterProps {
   isSaving: boolean;
+  saveDisabled: boolean;
   onCancel: () => void;
   onSave: () => void;
 }
 
 export function LabelEditDialogFooter({
   isSaving,
+  saveDisabled,
   onCancel,
   onSave,
 }: LabelEditDialogFooterProps) {
@@ -32,7 +34,7 @@ export function LabelEditDialogFooter({
         type="button"
         variant="default"
         onClick={onSave}
-        disabled={isSaving}
+        disabled={saveDisabled || isSaving}
       >
         {isSaving ? (
           <>

--- a/apps/frontend/src/hooks/__tests__/useDirtyDialogWarning.unit.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useDirtyDialogWarning.unit.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the useDirtyDialogWarning hook.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDirtyDialogWarning } from "../useDirtyDialogWarning";
+
+describe("useDirtyDialogWarning", () => {
+  it("forwards open=true to onOpenChange immediately", () => {
+    const onOpenChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDirtyDialogWarning(false, onOpenChange)
+    );
+
+    act(() => {
+      result.current.handleOpenChange(true);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(result.current.discardDialogOpen).toBe(false);
+  });
+
+  it("closes immediately when not dirty", () => {
+    const onOpenChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDirtyDialogWarning(false, onOpenChange)
+    );
+
+    act(() => {
+      result.current.handleOpenChange(false);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(result.current.discardDialogOpen).toBe(false);
+  });
+
+  it("blocks close and opens discard dialog when dirty", () => {
+    const onOpenChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDirtyDialogWarning(true, onOpenChange)
+    );
+
+    act(() => {
+      result.current.handleOpenChange(false);
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(result.current.discardDialogOpen).toBe(true);
+  });
+
+  it("confirmDiscard closes the parent dialog and hides the prompt", () => {
+    const onOpenChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDirtyDialogWarning(true, onOpenChange)
+    );
+
+    act(() => {
+      result.current.handleOpenChange(false);
+    });
+    expect(result.current.discardDialogOpen).toBe(true);
+
+    act(() => {
+      result.current.confirmDiscard();
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(result.current.discardDialogOpen).toBe(false);
+  });
+
+  it("setDiscardDialogOpen can dismiss the prompt without closing", () => {
+    const onOpenChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDirtyDialogWarning(true, onOpenChange)
+    );
+
+    act(() => {
+      result.current.handleOpenChange(false);
+    });
+    expect(result.current.discardDialogOpen).toBe(true);
+
+    act(() => {
+      result.current.setDiscardDialogOpen(false);
+    });
+
+    expect(result.current.discardDialogOpen).toBe(false);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/__tests__/useDirtyForm.unit.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useDirtyForm.unit.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the useDirtyForm hook.
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDirtyForm } from "../useDirtyForm";
+
+describe("useDirtyForm", () => {
+  it("is not dirty when current values match initial values", () => {
+    const initial = { name: "Alice", age: 30 };
+    const { result } = renderHook(() => useDirtyForm(initial, initial));
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("is dirty when current values diverge from initial values", () => {
+    const initial = { name: "Alice", age: 30 };
+    const current = { name: "Bob", age: 30 };
+    const { result } = renderHook(() => useDirtyForm(initial, current));
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("becomes dirty when current values change via rerender", () => {
+    const initial = { name: "Alice" };
+    const { result, rerender } = renderHook(
+      ({ current }) => useDirtyForm(initial, current),
+      { initialProps: { current: { name: "Alice" } } }
+    );
+
+    expect(result.current.isDirty).toBe(false);
+    rerender({ current: { name: "Bob" } });
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("resetDirty re-baselines to the current values", () => {
+    const initial = { name: "Alice" };
+    const { result, rerender } = renderHook(
+      ({ current }) => useDirtyForm(initial, current),
+      { initialProps: { current: { name: "Alice" } } }
+    );
+
+    rerender({ current: { name: "Bob" } });
+    expect(result.current.isDirty).toBe(true);
+
+    act(() => {
+      result.current.resetDirty();
+    });
+    expect(result.current.isDirty).toBe(false);
+
+    rerender({ current: { name: "Carol" } });
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("re-baselines when initialValues change", () => {
+    const { result, rerender } = renderHook(
+      ({ initial, current }) => useDirtyForm(initial, current),
+      {
+        initialProps: {
+          initial: { name: "Alice" },
+          current: { name: "Alice" },
+        },
+      }
+    );
+
+    expect(result.current.isDirty).toBe(false);
+
+    rerender({
+      initial: { name: "Bob" },
+      current: { name: "Bob" },
+    });
+    expect(result.current.isDirty).toBe(false);
+
+    rerender({
+      initial: { name: "Bob" },
+      current: { name: "Carol" },
+    });
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it("detects nested value changes", () => {
+    const initial = { meta: { tags: ["a"] } };
+    const current = { meta: { tags: ["a", "b"] } };
+    const { result } = renderHook(() => useDirtyForm(initial, current));
+    expect(result.current.isDirty).toBe(true);
+  });
+});

--- a/apps/frontend/src/hooks/__tests__/useDirtyForm.unit.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useDirtyForm.unit.test.ts
@@ -83,4 +83,23 @@ describe("useDirtyForm", () => {
     const { result } = renderHook(() => useDirtyForm(initial, current));
     expect(result.current.isDirty).toBe(true);
   });
+
+  it("checkDirty compares against the current baseline, including after resetDirty", () => {
+    const initial = { name: "Alice" };
+    const { result, rerender } = renderHook(
+      ({ current }) => useDirtyForm(initial, current),
+      { initialProps: { current: { name: "Alice" } } }
+    );
+
+    expect(result.current.checkDirty({ name: "Alice" })).toBe(false);
+    expect(result.current.checkDirty({ name: "Bob" })).toBe(true);
+
+    rerender({ current: { name: "Bob" } });
+    act(() => {
+      result.current.resetDirty();
+    });
+
+    expect(result.current.checkDirty({ name: "Bob" })).toBe(false);
+    expect(result.current.checkDirty({ name: "Carol" })).toBe(true);
+  });
 });

--- a/apps/frontend/src/hooks/useDirtyDialogWarning.ts
+++ b/apps/frontend/src/hooks/useDirtyDialogWarning.ts
@@ -1,0 +1,49 @@
+/**
+ * useDirtyDialogWarning Hook
+ *
+ * Guards dialog dismissal when a form is dirty. Pass `handleOpenChange` to
+ * `<Dialog>` / Cancel / X so Escape, backdrop click, and explicit close all
+ * show a discard confirmation instead of closing immediately.
+ *
+ * After a successful save, call the original `onOpenChange(false)` (or
+ * `resetDirty()` first) — do NOT route the save-success close through
+ * `handleOpenChange`, or the discard prompt will fire while still dirty.
+ */
+
+import { useCallback, useState } from "react";
+
+export function useDirtyDialogWarning(
+  isDirty: boolean,
+  onOpenChange: (open: boolean) => void
+): {
+  handleOpenChange: (open: boolean) => void;
+  confirmDiscard: () => void;
+  discardDialogOpen: boolean;
+  setDiscardDialogOpen: (open: boolean) => void;
+} {
+  const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && isDirty) {
+        setDiscardDialogOpen(true);
+        return;
+      }
+      setDiscardDialogOpen(false);
+      onOpenChange(open);
+    },
+    [isDirty, onOpenChange]
+  );
+
+  const confirmDiscard = useCallback(() => {
+    setDiscardDialogOpen(false);
+    onOpenChange(false);
+  }, [onOpenChange]);
+
+  return {
+    handleOpenChange,
+    confirmDiscard,
+    discardDialogOpen,
+    setDiscardDialogOpen,
+  };
+}

--- a/apps/frontend/src/hooks/useDirtyForm.ts
+++ b/apps/frontend/src/hooks/useDirtyForm.ts
@@ -26,6 +26,8 @@ export function useDirtyForm<T>(
 ): {
   isDirty: boolean;
   resetDirty: () => void;
+  /** Compare arbitrary values against the current baseline (e.g. next form). */
+  checkDirty: (values: T) => boolean;
 } {
   const initialSerialized = serialize(initialValues);
   const [baselineSerialized, setBaselineSerialized] =
@@ -47,5 +49,10 @@ export function useDirtyForm<T>(
     setBaselineSerialized(serialize(currentValues));
   }, [currentValues]);
 
-  return { isDirty, resetDirty };
+  const checkDirty = useCallback(
+    (values: T) => serialize(values) !== baselineSerialized,
+    [baselineSerialized]
+  );
+
+  return { isDirty, resetDirty, checkDirty };
 }

--- a/apps/frontend/src/hooks/useDirtyForm.ts
+++ b/apps/frontend/src/hooks/useDirtyForm.ts
@@ -5,6 +5,11 @@
  * values). Call `resetDirty()` after a successful save to re-baseline so
  * Save can disable again without closing the dialog.
  *
+ * **Close-as-reset pattern**: Dialogs that close after save do NOT need
+ * `resetDirty()` — the next open remounts/re-inits the form, establishing a
+ * fresh baseline. Only stay-open saves (e.g. VisualSystem) call resetDirty()
+ * to keep the save button disabled until the next edit.
+ *
  * Comparison uses JSON.stringify — pass flat/plain form shapes (exclude
  * File objects, error-message fields, and other non-serializable values).
  */

--- a/apps/frontend/src/hooks/useDirtyForm.ts
+++ b/apps/frontend/src/hooks/useDirtyForm.ts
@@ -1,0 +1,46 @@
+/**
+ * useDirtyForm Hook
+ *
+ * Tracks whether form values have diverged from a baseline (initial/saved
+ * values). Call `resetDirty()` after a successful save to re-baseline so
+ * Save can disable again without closing the dialog.
+ *
+ * Comparison uses JSON.stringify — pass flat/plain form shapes (exclude
+ * File objects, error-message fields, and other non-serializable values).
+ */
+
+import { useCallback, useState } from "react";
+
+function serialize<T>(value: T): string {
+  return JSON.stringify(value);
+}
+
+export function useDirtyForm<T>(
+  initialValues: T,
+  currentValues: T
+): {
+  isDirty: boolean;
+  resetDirty: () => void;
+} {
+  const initialSerialized = serialize(initialValues);
+  const [baselineSerialized, setBaselineSerialized] =
+    useState(initialSerialized);
+  const [prevInitialSerialized, setPrevInitialSerialized] =
+    useState(initialSerialized);
+
+  // Re-baseline when the caller supplies a new initial snapshot (e.g. dialog
+  // reopened for a different entity). Adjusting state during render matches
+  // React's "store information from previous renders" pattern.
+  if (prevInitialSerialized !== initialSerialized) {
+    setPrevInitialSerialized(initialSerialized);
+    setBaselineSerialized(initialSerialized);
+  }
+
+  const isDirty = serialize(currentValues) !== baselineSerialized;
+
+  const resetDirty = useCallback(() => {
+    setBaselineSerialized(serialize(currentValues));
+  }, [currentValues]);
+
+  return { isDirty, resetDirty };
+}


### PR DESCRIPTION
## Summary
- Add shared `useDirtyForm` + `useDirtyDialogWarning` hooks and wire dirty tracking, disabled-when-clean Save, and discard `ConfirmDialog` across the #285 form dialogs
- Center `ConfirmDialog` with the same viewport flex overlay as `Dialog`, and prevent native Escape flicker when a dirty guard keeps the dialog open
- Clear react-doctor dirty-sync findings by co-locating dirty ownership with dialog chrome (VisualSystem notifies via handlers + remount session key)

Closes #285

## Type of Change
- [x] Enhancement
- [x] Tests

## Testing
- [x] `pnpm --filter @branchforge/frontend typecheck`
- [x] `pnpm --filter @branchforge/frontend lint` (0 errors; 3 pre-existing warnings)
- [x] `pnpm --filter @branchforge/frontend test:unit` — 74 files / 1025 tests
- [x] `pnpm --filter @branchforge/frontend doctor -- --scope changed` — **100/100**
- [x] New dirty-guard coverage: `ProjectEditDialog.dirty.test.tsx`, PairGroupsDialog discard path, Dialog cancel `preventDefault`

## @oracle
- Initial review: `NEEDS_FIXES` — MF-1 (VisualSystem dirty lifecycle), MF-2 (Escape flicker), SF-1 (component tests), SF-2 (delete+discard stack), SF-3 (`resetDirty` consistency)
- Re-review: **READY** — no remaining must-fix / should-fix
- Deferred nice-to-haves: PairGroups Add-over-dirty-inline-edit (NTH-1), CharacterEdit snapshot memoization (NTH-2)

## Checklist
- [x] Follows existing patterns
- [x] Self-reviewed
- [x] No new lint/type errors
- [x] Unit tests pass locally
- [x] Changeset included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unsaved-changes (dirty form) warnings across multiple editing dialogs, including Save disablement until changes are made.
  * Added consistent “Discard changes?” confirmation with “Keep editing”.
  * Improved dialog centering and responsive sizing for discard prompts.
* **Bug Fixes**
  * Dialog close behavior is now more reliable: Escape/backdrop close shows the discard prompt for dirty forms, while successful saves close cleanly; failed saves keep the dialog open.
* **Tests**
  * Expanded unit and UI coverage for dirty-state detection, discard/confirm flows, Escape handling, and dialog accessibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->