### PR TITLE
feat: add visual statement preview images

### DIFF
--- a/.changeset/visual-preview-images.md
+++ b/.changeset/visual-preview-images.md
@@ -1,0 +1,7 @@
+---
+"@branchforge/backend": minor
+"@branchforge/frontend": minor
+"@branchforge/shared": minor
+---
+
+Added visual statement preview images and hover/click previews in Write and Script modes

--- a/apps/backend/src/db/migrations/0057_slim_vector.sql
+++ b/apps/backend/src/db/migrations/0057_slim_vector.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "project_images" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project_id" uuid NOT NULL,
+	"original_filename" text NOT NULL,
+	"normalized_target" text NOT NULL,
+	"tooltip_filename" text NOT NULL,
+	"modal_filename" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "project_images_project_target_idx" UNIQUE("project_id","normalized_target")
+);
+--> statement-breakpoint
+ALTER TABLE "project_images" ADD CONSTRAINT "project_images_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "project_images_project_id_idx" ON "project_images" USING btree ("project_id");

--- a/apps/backend/src/db/migrations/meta/0057_snapshot.json
+++ b/apps/backend/src/db/migrations/meta/0057_snapshot.json
@@ -1,0 +1,3845 @@
+{
+  "id": "71b9055e-de81-4817-8d3a-cd70a35859d9",
+  "prevId": "fa11bfb5-4001-482d-842f-d54b4490129a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'OWNER'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique_active_idx": {
+          "name": "users_email_unique_active_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_sessions_user_id_idx": {
+          "name": "user_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_expires_at_idx": {
+          "name": "user_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'en'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'periwinkle'"
+        },
+        "daily_writing_goal": {
+          "name": "daily_writing_goal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_word_reset_hour": {
+          "name": "daily_word_reset_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "daily_word_counts": {
+          "name": "daily_word_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "label_word_counts": {
+          "name": "label_word_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_username_idx": {
+          "name": "user_settings_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "daily_word_reset_hour_range": {
+          "name": "daily_word_reset_hour_range",
+          "value": "\"user_settings\".\"daily_word_reset_hour\" >= 0 AND \"user_settings\".\"daily_word_reset_hour\" <= 23"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.admin_settings": {
+      "name": "admin_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_settings_key_idx": {
+          "name": "admin_settings_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_settings_updated_by_users_id_fk": {
+          "name": "admin_settings_updated_by_users_id_fk",
+          "tableFrom": "admin_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_settings_key_unique": {
+          "name": "admin_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_stat_delta": {
+          "name": "max_stat_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "duo_ending_enabled": {
+          "name": "duo_ending_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "project_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'PRIVATE'"
+        },
+        "source": {
+          "name": "source",
+          "type": "file_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_user_id_idx": {
+          "name": "projects_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_users": {
+      "name": "project_users",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_users_user_id_idx": {
+          "name": "project_users_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_users_project_id_projects_id_fk": {
+          "name": "project_users_project_id_projects_id_fk",
+          "tableFrom": "project_users",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_users_user_id_users_id_fk": {
+          "name": "project_users_user_id_users_id_fk",
+          "tableFrom": "project_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_users_project_id_user_id_pk": {
+          "name": "project_users_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_settings": {
+      "name": "project_settings",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "excluded_character_tags": {
+          "name": "excluded_character_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "narrator_character_tags": {
+          "name": "narrator_character_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "auto_link_speakers": {
+          "name": "auto_link_speakers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_settings_updated_at_idx": {
+          "name": "project_settings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_settings_project_id_projects_id_fk": {
+          "name": "project_settings_project_id_projects_id_fk",
+          "tableFrom": "project_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flow_graph_layouts": {
+      "name": "flow_graph_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FLOW'"
+        },
+        "positions": {
+          "name": "positions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flow_graph_layouts_project_user_mode_idx": {
+          "name": "flow_graph_layouts_project_user_mode_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flow_graph_layouts_project_id_projects_id_fk": {
+          "name": "flow_graph_layouts_project_id_projects_id_fk",
+          "tableFrom": "flow_graph_layouts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "flow_graph_layouts_user_id_users_id_fk": {
+          "name": "flow_graph_layouts_user_id_users_id_fk",
+          "tableFrom": "flow_graph_layouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flow_graph_layouts_mode_check": {
+          "name": "flow_graph_layouts_mode_check",
+          "value": "\"flow_graph_layouts\".\"mode\" IN ('FLOW', 'ROUTE', 'FILE')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_images": {
+      "name": "project_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_target": {
+          "name": "normalized_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tooltip_filename": {
+          "name": "tooltip_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modal_filename": {
+          "name": "modal_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_images_project_id_idx": {
+          "name": "project_images_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_images_project_id_projects_id_fk": {
+          "name": "project_images_project_id_projects_id_fk",
+          "tableFrom": "project_images",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_images_project_target_idx": {
+          "name": "project_images_project_target_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "normalized_target"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_files": {
+      "name": "project_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "file_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "project_file_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_content": {
+          "name": "original_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_commit_sha": {
+          "name": "last_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_files_project_id_idx": {
+          "name": "project_files_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_files_project_id_projects_id_fk": {
+          "name": "project_files_project_id_projects_id_fk",
+          "tableFrom": "project_files",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_files_project_source_file_uidx": {
+          "name": "project_files_project_source_file_uidx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "source",
+            "file_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visual_systems": {
+      "name": "visual_systems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "naming_template": {
+          "name": "naming_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{scene}_{counter}_{slug}'"
+        },
+        "group_prefixes": {
+          "name": "group_prefixes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_group_type": {
+          "name": "default_group_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene_padding": {
+          "name": "scene_padding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter_padding": {
+          "name": "counter_padding",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jump_prefix_shared": {
+          "name": "jump_prefix_shared",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placeholder_base_url": {
+          "name": "placeholder_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "visual_systems_project_id_idx": {
+          "name": "visual_systems_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visual_systems_project_id_projects_id_fk": {
+          "name": "visual_systems_project_id_projects_id_fk",
+          "tableFrom": "visual_systems",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "visual_systems_project_id_unique": {
+          "name": "visual_systems_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.route_configs": {
+      "name": "route_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_key": {
+          "name": "route_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jump_prefix": {
+          "name": "jump_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "route_configs_project_id_idx": {
+          "name": "route_configs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "route_configs_project_id_projects_id_fk": {
+          "name": "route_configs_project_id_projects_id_fk",
+          "tableFrom": "route_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "route_configs_project_key_unique": {
+          "name": "route_configs_project_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "route_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_type": {
+          "name": "name_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'literal'"
+        },
+        "renpy_tag": {
+          "name": "renpy_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route_affiliation": {
+          "name": "route_affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_love_interest": {
+          "name": "is_love_interest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_narrator": {
+          "name": "is_narrator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pair_group_id": {
+          "name": "pair_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditional_prefix": {
+          "name": "conditional_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "characters_project_id_idx": {
+          "name": "characters_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "characters_pair_group_id_idx": {
+          "name": "characters_pair_group_id_idx",
+          "columns": [
+            {
+              "expression": "pair_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_project_id_projects_id_fk": {
+          "name": "characters_project_id_projects_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "characters_project_renpy_tag_unique": {
+          "name": "characters_project_renpy_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "renpy_tag"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "characters_name_type_check": {
+          "name": "characters_name_type_check",
+          "value": "\"characters\".\"name_type\" IN ('literal', 'variable', 'interpolated', 'tagged', 'none', 'empty', 'unknown')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pair_groups": {
+      "name": "pair_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_a_id": {
+          "name": "character_a_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_b_id": {
+          "name": "character_b_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duo_ending_label": {
+          "name": "duo_ending_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pair_groups_project_id_idx": {
+          "name": "pair_groups_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pair_groups_character_a_id_idx": {
+          "name": "pair_groups_character_a_id_idx",
+          "columns": [
+            {
+              "expression": "character_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pair_groups_character_b_id_idx": {
+          "name": "pair_groups_character_b_id_idx",
+          "columns": [
+            {
+              "expression": "character_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pair_groups_project_id_projects_id_fk": {
+          "name": "pair_groups_project_id_projects_id_fk",
+          "tableFrom": "pair_groups",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pair_groups_character_a_id_characters_id_fk": {
+          "name": "pair_groups_character_a_id_characters_id_fk",
+          "tableFrom": "pair_groups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pair_groups_character_b_id_characters_id_fk": {
+          "name": "pair_groups_character_b_id_characters_id_fk",
+          "tableFrom": "pair_groups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pair_groups_project_character_pair_idx": {
+          "name": "pair_groups_project_character_pair_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "character_a_id",
+            "character_b_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pair_groups_not_self_pairing": {
+          "name": "pair_groups_not_self_pairing",
+          "value": "character_a_id < character_b_id"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stats": {
+      "name": "stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_value": {
+          "name": "min_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_value": {
+          "name": "max_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stats_project_id_idx": {
+          "name": "stats_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stats_character_id_idx": {
+          "name": "stats_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stats_project_id_projects_id_fk": {
+          "name": "stats_project_id_projects_id_fk",
+          "tableFrom": "stats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stats_character_id_characters_id_fk": {
+          "name": "stats_character_id_characters_id_fk",
+          "tableFrom": "stats",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stats_project_key_idx": {
+          "name": "stats_project_key_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "min_value_lte_max_value": {
+          "name": "min_value_lte_max_value",
+          "value": "\"stats\".\"min_value\" <= \"stats\".\"max_value\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "variables_project_id_idx": {
+          "name": "variables_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variables_project_id_projects_id_fk": {
+          "name": "variables_project_id_projects_id_fk",
+          "tableFrom": "variables",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "variables_project_key_idx": {
+          "name": "variables_project_key_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_type": {
+          "name": "group_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_value": {
+          "name": "group_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_number": {
+          "name": "label_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_order": {
+          "name": "sequence_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "label_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'EXCLUSIVE'"
+        },
+        "duo_pair_id": {
+          "name": "duo_pair_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "label_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'DRAFT'"
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "incoming_jumps": {
+          "name": "incoming_jumps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cross_route_context": {
+          "name": "cross_route_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_notes": {
+          "name": "reader_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_file_id": {
+          "name": "project_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_position": {
+          "name": "label_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_hash": {
+          "name": "last_synced_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_exported_at": {
+          "name": "last_exported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_imported_at": {
+          "name": "last_imported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "export_commit_sha": {
+          "name": "export_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_commit_sha": {
+          "name": "import_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labels_duo_pair_id_idx": {
+          "name": "labels_duo_pair_id_idx",
+          "columns": [
+            {
+              "expression": "duo_pair_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_file_id_idx": {
+          "name": "labels_project_file_id_idx",
+          "columns": [
+            {
+              "expression": "project_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_file_position_idx": {
+          "name": "labels_project_file_position_idx",
+          "columns": [
+            {
+              "expression": "project_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_route_idx": {
+          "name": "labels_project_route_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "route",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_status_idx": {
+          "name": "labels_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_sequence_idx": {
+          "name": "labels_project_sequence_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_label_number_idx": {
+          "name": "labels_project_label_number_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_sync_status_idx": {
+          "name": "labels_sync_status_idx",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_deleted_at_idx": {
+          "name": "labels_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_incoming_jumps_gin_idx": {
+          "name": "labels_incoming_jumps_gin_idx",
+          "columns": [
+            {
+              "expression": "incoming_jumps",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "labels_created_by_idx": {
+          "name": "labels_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_updated_by_idx": {
+          "name": "labels_updated_by_idx",
+          "columns": [
+            {
+              "expression": "updated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_project_file_label_name_unique_idx": {
+          "name": "labels_project_file_label_name_unique_idx",
+          "columns": [
+            {
+              "expression": "project_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"label_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"labels\".\"deleted_at\" IS NULL AND \"labels\".\"label_name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labels_project_id_projects_id_fk": {
+          "name": "labels_project_id_projects_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "labels_duo_pair_id_pair_groups_id_fk": {
+          "name": "labels_duo_pair_id_pair_groups_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "pair_groups",
+          "columnsFrom": [
+            "duo_pair_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "labels_project_file_id_project_files_id_fk": {
+          "name": "labels_project_file_id_project_files_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "project_files",
+          "columnsFrom": [
+            "project_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "labels_created_by_users_id_fk": {
+          "name": "labels_created_by_users_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "labels_updated_by_users_id_fk": {
+          "name": "labels_updated_by_users_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_lines": {
+      "name": "label_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "content_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker_id": {
+          "name": "speaker_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visual_type": {
+          "name": "visual_type",
+          "type": "visual_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GENERATED'"
+        },
+        "visual_slug_override": {
+          "name": "visual_slug_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_visual_name": {
+          "name": "custom_visual_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "menu_options": {
+          "name": "menu_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visual_statements": {
+          "name": "visual_statements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_placeholder_color": {
+          "name": "demo_placeholder_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_notes": {
+          "name": "demo_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_file_id": {
+          "name": "project_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_position": {
+          "name": "line_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_hash": {
+          "name": "last_synced_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_dirty": {
+          "name": "is_dirty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rpy_line_number": {
+          "name": "rpy_line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rpy_indent_level": {
+          "name": "rpy_indent_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "label_lines_speaker_id_idx": {
+          "name": "label_lines_speaker_id_idx",
+          "columns": [
+            {
+              "expression": "speaker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_lines_label_speaker_idx": {
+          "name": "label_lines_label_speaker_idx",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "speaker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_lines_label_sequence_idx": {
+          "name": "label_lines_label_sequence_idx",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_lines_project_file_id_idx": {
+          "name": "label_lines_project_file_id_idx",
+          "columns": [
+            {
+              "expression": "project_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_lines_is_dirty_idx": {
+          "name": "label_lines_is_dirty_idx",
+          "columns": [
+            {
+              "expression": "is_dirty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"label_lines\".\"is_dirty\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_lines_deleted_at_idx": {
+          "name": "label_lines_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"label_lines\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "label_lines_label_id_labels_id_fk": {
+          "name": "label_lines_label_id_labels_id_fk",
+          "tableFrom": "label_lines",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_lines_speaker_id_characters_id_fk": {
+          "name": "label_lines_speaker_id_characters_id_fk",
+          "tableFrom": "label_lines",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "speaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "label_lines_project_file_id_project_files_id_fk": {
+          "name": "label_lines_project_file_id_project_files_id_fk",
+          "tableFrom": "label_lines",
+          "tableTo": "project_files",
+          "columnsFrom": [
+            "project_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.world_elements": {
+      "name": "world_elements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "element_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "world_elements_project_id_idx": {
+          "name": "world_elements_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "world_elements_project_id_projects_id_fk": {
+          "name": "world_elements_project_id_projects_id_fk",
+          "tableFrom": "world_elements",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_suggestions": {
+      "name": "ai_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "suggestion_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_context": {
+          "name": "prompt_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name_anonymized": {
+          "name": "project_name_anonymized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_suggestions": {
+          "name": "parsed_suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "suggestion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'PENDING'"
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_suggestions_project_id_idx": {
+          "name": "ai_suggestions_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_suggestions_label_id_idx": {
+          "name": "ai_suggestions_label_id_idx",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_suggestions_character_id_idx": {
+          "name": "ai_suggestions_character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_suggestions_project_id_projects_id_fk": {
+          "name": "ai_suggestions_project_id_projects_id_fk",
+          "tableFrom": "ai_suggestions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_suggestions_label_id_labels_id_fk": {
+          "name": "ai_suggestions_label_id_labels_id_fk",
+          "tableFrom": "ai_suggestions",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_suggestions_character_id_characters_id_fk": {
+          "name": "ai_suggestions_character_id_characters_id_fk",
+          "tableFrom": "ai_suggestions",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exports": {
+      "name": "exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visual_system_snapshot": {
+          "name": "visual_system_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "exports_project_id_idx": {
+          "name": "exports_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exports_project_id_projects_id_fk": {
+          "name": "exports_project_id_projects_id_fk",
+          "tableFrom": "exports",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.import_logs": {
+      "name": "import_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_created": {
+          "name": "labels_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "labels_skipped": {
+          "name": "labels_skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "import_logs_project_id_idx": {
+          "name": "import_logs_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "import_logs_project_id_projects_id_fk": {
+          "name": "import_logs_project_id_projects_id_fk",
+          "tableFrom": "import_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gitlab_integrations": {
+      "name": "gitlab_integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitlab_url": {
+          "name": "gitlab_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'https://gitlab.com'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gitlab_integrations_user_id_users_id_fk": {
+          "name": "gitlab_integrations_user_id_users_id_fk",
+          "tableFrom": "gitlab_integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gitlab_integrations_user_id_unique": {
+          "name": "gitlab_integrations_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_file_sync_state": {
+      "name": "project_file_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_file_id": {
+          "name": "project_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rpy_label_count": {
+          "name": "rpy_label_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "db_label_count": {
+          "name": "db_label_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_file_sync_state_project_file_id_idx": {
+          "name": "project_file_sync_state_project_file_id_idx",
+          "columns": [
+            {
+              "expression": "project_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_file_sync_state_status_idx": {
+          "name": "project_file_sync_state_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_file_sync_state_in_progress_unique_idx": {
+          "name": "project_file_sync_state_in_progress_unique_idx",
+          "columns": [
+            {
+              "expression": "project_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project_file_sync_state\".\"status\" = 'MODIFIED_LOCAL' AND \"project_file_sync_state\".\"completed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_file_sync_state_project_file_id_project_files_id_fk": {
+          "name": "project_file_sync_state_project_file_id_project_files_id_fk",
+          "tableFrom": "project_file_sync_state",
+          "tableTo": "project_files",
+          "columnsFrom": [
+            "project_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gitlab_repositories": {
+      "name": "gitlab_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitlab_project_id": {
+          "name": "gitlab_project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name": {
+          "name": "repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitlab_url": {
+          "name": "gitlab_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'https://gitlab.com'"
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'main'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gitlab_repositories_project_id_projects_id_fk": {
+          "name": "gitlab_repositories_project_id_projects_id_fk",
+          "tableFrom": "gitlab_repositories",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gitlab_repositories_project_id_unique": {
+          "name": "gitlab_repositories_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        },
+        "gitlab_repositories_gitlab_project_id_unique": {
+          "name": "gitlab_repositories_gitlab_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "gitlab_project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gitlab_sync_operations": {
+      "name": "gitlab_sync_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "sync_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_count": {
+          "name": "conflict_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gitlab_sync_operations_project_id_idx": {
+          "name": "gitlab_sync_operations_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gitlab_sync_operations_status_idx": {
+          "name": "gitlab_sync_operations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gitlab_sync_operations_project_id_projects_id_fk": {
+          "name": "gitlab_sync_operations_project_id_projects_id_fk",
+          "tableFrom": "gitlab_sync_operations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_sessions": {
+      "name": "demo_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_label_line_id": {
+          "name": "current_label_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_flags": {
+          "name": "active_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active_stats": {
+          "name": "active_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "route_taken": {
+          "name": "route_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_sessions_project_id_idx": {
+          "name": "demo_sessions_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_sessions_user_id_idx": {
+          "name": "demo_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_sessions_current_label_line_id_idx": {
+          "name": "demo_sessions_current_label_line_id_idx",
+          "columns": [
+            {
+              "expression": "current_label_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "demo_sessions_project_id_projects_id_fk": {
+          "name": "demo_sessions_project_id_projects_id_fk",
+          "tableFrom": "demo_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "demo_sessions_user_id_users_id_fk": {
+          "name": "demo_sessions_user_id_users_id_fk",
+          "tableFrom": "demo_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "demo_sessions_current_label_line_id_label_lines_id_fk": {
+          "name": "demo_sessions_current_label_line_id_label_lines_id_fk",
+          "tableFrom": "demo_sessions",
+          "tableTo": "label_lines",
+          "columnsFrom": [
+            "current_label_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "OWNER",
+        "READER",
+        "TESTER"
+      ]
+    },
+    "public.project_visibility": {
+      "name": "project_visibility",
+      "schema": "public",
+      "values": [
+        "PUBLIC",
+        "PRIVATE",
+        "TEAM"
+      ]
+    },
+    "public.label_status": {
+      "name": "label_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "REVIEW",
+        "FINAL"
+      ]
+    },
+    "public.content_type": {
+      "name": "content_type",
+      "schema": "public",
+      "values": [
+        "NARRATION",
+        "DIALOGUE",
+        "CHOICE",
+        "MENU",
+        "JUMP",
+        "VISUAL"
+      ]
+    },
+    "public.visual_type": {
+      "name": "visual_type",
+      "schema": "public",
+      "values": [
+        "GENERATED",
+        "BLACK",
+        "CUSTOM"
+      ]
+    },
+    "public.element_type": {
+      "name": "element_type",
+      "schema": "public",
+      "values": [
+        "LOCATION",
+        "ITEM",
+        "CONCEPT",
+        "EVENT"
+      ]
+    },
+    "public.suggestion_type": {
+      "name": "suggestion_type",
+      "schema": "public",
+      "values": [
+        "CONSISTENCY",
+        "FLAG_SUGGEST",
+        "METER_SUGGEST",
+        "DIALOGUE_VARIANT"
+      ]
+    },
+    "public.suggestion_status": {
+      "name": "suggestion_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REJECTED"
+      ]
+    },
+    "public.label_visibility": {
+      "name": "label_visibility",
+      "schema": "public",
+      "values": [
+        "EXCLUSIVE",
+        "SHARED",
+        "DUO_PAIR"
+      ]
+    },
+    "public.sync_operation": {
+      "name": "sync_operation",
+      "schema": "public",
+      "values": [
+        "EXPORT",
+        "IMPORT"
+      ]
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "public",
+      "values": [
+        "SYNCED",
+        "MODIFIED_LOCAL",
+        "CONFLICT"
+      ]
+    },
+    "public.sync_operation_status": {
+      "name": "sync_operation_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "IN_PROGRESS",
+        "COMPLETED",
+        "FAILED"
+      ]
+    },
+    "public.project_file_type": {
+      "name": "project_file_type",
+      "schema": "public",
+      "values": [
+        "STORY",
+        "SETTINGS"
+      ]
+    },
+    "public.file_source": {
+      "name": "file_source",
+      "schema": "public",
+      "values": [
+        "GITLAB",
+        "ZIP"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/src/db/migrations/meta/_journal.json
+++ b/apps/backend/src/db/migrations/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1785082685438,
       "tag": "0056_known_mongu",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1785092076173,
+      "tag": "0057_slim_vector",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema/index.ts
+++ b/apps/backend/src/db/schema/index.ts
@@ -27,6 +27,7 @@ export * from "./tables/admin-settings.js";
 export * from "./tables/projects.js";
 export * from "./tables/project-settings.js";
 export * from "./tables/flow-graph-layouts.js";
+export * from "./tables/project-images.js";
 
 // Project Files (unified for all sources)
 export * from "./tables/project-files.js";

--- a/apps/backend/src/db/schema/tables/project-images.ts
+++ b/apps/backend/src/db/schema/tables/project-images.ts
@@ -1,0 +1,40 @@
+/**
+ * Project Images Table
+ *
+ * Visual preview images for Ren'Py scene/show/hide statements.
+ */
+
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  index,
+  unique,
+} from "drizzle-orm/pg-core";
+import { projects } from "./projects.js";
+
+export const projectImages = pgTable(
+  "project_images",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    projectId: uuid("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    originalFilename: text("original_filename").notNull(),
+    normalizedTarget: text("normalized_target").notNull(),
+    tooltipFilename: text("tooltip_filename").notNull(),
+    modalFilename: text("modal_filename").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("project_images_project_id_idx").on(table.projectId),
+    unique("project_images_project_target_idx").on(
+      table.projectId,
+      table.normalizedTarget
+    ),
+  ]
+);
+
+export type ProjectImageRow = typeof projectImages.$inferSelect;
+export type NewProjectImageRow = typeof projectImages.$inferInsert;

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -27,6 +27,7 @@ import { exportsRoutes } from "./routes/exports.routes.js";
 import { visualSystemsRoutes } from "./routes/visual-systems.routes.js";
 import { worldElementsRoutes } from "./routes/world-elements.routes.js";
 import { pairGroupsRoutes } from "./routes/pair-groups.routes.js";
+import { projectImagesRoutes } from "./routes/project-images.routes.js";
 import { createDrizzleSessionStore } from "./services/session-store.service.js";
 import { setupShutdownHandlers } from "./lib/shutdown.js";
 import { cleanupStaleSyncOperations } from "./services/gitlab/index.js";
@@ -36,6 +37,7 @@ import { SESSION_COOKIE_NAME } from "./lib/session.js";
 import { getBasePath, getSessionMaxAge } from "./lib/config.js";
 import {
   ensureAvatarDir,
+  ensureProjectImageDir,
   UPLOADS_DIR,
   getUploadsDirPath,
 } from "./lib/storage.js";
@@ -75,6 +77,7 @@ const basePath = getBasePath();
 
 // Ensure avatar directory exists on startup BEFORE registering static file serving
 await ensureAvatarDir();
+await ensureProjectImageDir();
 
 // Register static file serving for uploads (under base path for consistency)
 await server.register(fastifyStatic, {
@@ -168,6 +171,7 @@ await server.register(exportsRoutes, { prefix: basePath });
 await server.register(visualSystemsRoutes, { prefix: basePath });
 await server.register(worldElementsRoutes, { prefix: basePath });
 await server.register(pairGroupsRoutes, { prefix: basePath });
+await server.register(projectImagesRoutes, { prefix: basePath });
 
 // Register a global preValidation hook that enforces double-submit
 // CSRF protection on every state-changing request. The hook itself

--- a/apps/backend/src/lib/__tests__/storage.unit.test.ts
+++ b/apps/backend/src/lib/__tests__/storage.unit.test.ts
@@ -4,7 +4,7 @@ import {
   getAvatarPath,
   getAvatarFullPath,
   AvatarFilenameError,
-} from "../storage";
+} from "../storage.js";
 
 describe("validateAvatarFilename", () => {
   const validFilenames = [
@@ -144,7 +144,7 @@ import {
   getProjectImagePath,
   getProjectImageFullPath,
   ProjectImageFilenameError,
-} from "../storage";
+} from "../storage.js";
 
 const PROJECT_ID = "550e8400-e29b-41d4-a716-446655440000";
 

--- a/apps/backend/src/lib/__tests__/storage.unit.test.ts
+++ b/apps/backend/src/lib/__tests__/storage.unit.test.ts
@@ -137,3 +137,67 @@ describe("getAvatarFullPath", () => {
     expect(uploadsDir).toMatch(/uploads\/avatars\/$/);
   });
 });
+
+import {
+  validateProjectImageFilename,
+  validateProjectImageProjectId,
+  getProjectImagePath,
+  getProjectImageFullPath,
+  ProjectImageFilenameError,
+} from "../storage";
+
+const PROJECT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("validateProjectImageFilename", () => {
+  it("accepts safe filenames", () => {
+    expect(validateProjectImageFilename("abc_tooltip.webp")).toBe(
+      "abc_tooltip.webp"
+    );
+  });
+
+  it("rejects path traversal", () => {
+    expect(() => validateProjectImageFilename("../secret.png")).toThrow(
+      ProjectImageFilenameError
+    );
+  });
+});
+
+describe("validateProjectImageProjectId", () => {
+  it("accepts and lowercases UUID project IDs", () => {
+    expect(validateProjectImageProjectId(PROJECT_ID.toUpperCase())).toBe(
+      PROJECT_ID
+    );
+  });
+
+  it("rejects non-UUID project IDs", () => {
+    expect(() => validateProjectImageProjectId("../etc")).toThrow(
+      ProjectImageFilenameError
+    );
+    expect(() => validateProjectImageProjectId("not-a-uuid")).toThrow(
+      ProjectImageFilenameError
+    );
+  });
+});
+
+describe("getProjectImagePath", () => {
+  it("builds project image URL under uploads/project-images/<projectId>", () => {
+    expect(getProjectImagePath(PROJECT_ID, "file.webp", "/api/")).toBe(
+      `/api/uploads/project-images/${PROJECT_ID}/file.webp`
+    );
+  });
+});
+
+describe("getProjectImageFullPath", () => {
+  it("returns absolute path under project subdirectory", () => {
+    const result = getProjectImageFullPath(PROJECT_ID, "file.webp");
+    expect(result).toMatch(
+      new RegExp(`uploads/project-images/${PROJECT_ID}/file\\.webp$`)
+    );
+  });
+
+  it("rejects invalid project IDs", () => {
+    expect(() => getProjectImageFullPath("../etc", "file.webp")).toThrow(
+      ProjectImageFilenameError
+    );
+  });
+});

--- a/apps/backend/src/lib/storage.ts
+++ b/apps/backend/src/lib/storage.ts
@@ -200,18 +200,60 @@ export function validateProjectImageFilename(filename: string): string {
 }
 
 /**
+ * Absolute path to the untainted project-images uploads root.
+ */
+export function getProjectImageRootDirPath(): string {
+  return path.join(getUploadsDirPath(), PROJECT_IMAGE_SUBDIR);
+}
+
+/**
+ * CodeQL-recognized containment check (path.relative + ".." prefix guard).
+ * Returns the resolved absolute path when it stays under the project-images root.
+ *
+ * @see https://codeql.github.com/codeql-query-help/javascript/js-path-injection/
+ */
+export function resolvePathInsideProjectImageRoot(
+  ...pathSegments: string[]
+): string {
+  const rootDir = getProjectImageRootDirPath();
+  const resolvedPath = path.resolve(rootDir, ...pathSegments);
+  const relative = path.relative(rootDir, resolvedPath);
+  if (
+    relative.startsWith(".." + path.sep) ||
+    relative === ".." ||
+    path.isAbsolute(relative)
+  ) {
+    throw new ProjectImageFilenameError(
+      "Resolved path escapes the uploads directory"
+    );
+  }
+  return resolvedPath;
+}
+
+/**
  * Ensure the project-images root directory exists.
  * When `projectId` is provided, also ensure that project's subdirectory exists.
  */
 export async function ensureProjectImageDir(projectId?: string): Promise<void> {
-  const rootDir = path.join(getUploadsDirPath(), PROJECT_IMAGE_SUBDIR);
+  const rootDir = getProjectImageRootDirPath();
+  await fs.mkdir(rootDir, { recursive: true });
   if (projectId === undefined) {
-    await fs.mkdir(rootDir, { recursive: true });
     return;
   }
 
   const sanitizedProjectId = validateProjectImageProjectId(projectId);
-  await fs.mkdir(path.join(rootDir, sanitizedProjectId), { recursive: true });
+  const projectDirPath = path.resolve(rootDir, sanitizedProjectId);
+  const relative = path.relative(rootDir, projectDirPath);
+  if (
+    relative.startsWith(".." + path.sep) ||
+    relative === ".." ||
+    path.isAbsolute(relative)
+  ) {
+    throw new ProjectImageFilenameError(
+      "Resolved path escapes the uploads directory"
+    );
+  }
+  await fs.mkdir(projectDirPath, { recursive: true });
 }
 
 export function generateProjectImageFilename(
@@ -250,28 +292,7 @@ export function getProjectImageFullPath(
 ): string {
   const sanitizedProjectId = validateProjectImageProjectId(projectId);
   const sanitized = validateProjectImageFilename(filename);
-
-  const projectDirPath = path.join(
-    getUploadsDirPath(),
-    PROJECT_IMAGE_SUBDIR,
-    sanitizedProjectId
-  );
-  const fullPath = path.resolve(projectDirPath, sanitized);
-
-  const normalizedProjectDir = projectDirPath.endsWith(path.sep)
-    ? projectDirPath
-    : projectDirPath + path.sep;
-
-  if (
-    fullPath !== projectDirPath &&
-    !fullPath.startsWith(normalizedProjectDir)
-  ) {
-    throw new ProjectImageFilenameError(
-      "Resolved path escapes the uploads directory"
-    );
-  }
-
-  return fullPath;
+  return resolvePathInsideProjectImageRoot(sanitizedProjectId, sanitized);
 }
 
 /**

--- a/apps/backend/src/lib/storage.ts
+++ b/apps/backend/src/lib/storage.ts
@@ -12,8 +12,10 @@ import { randomUUID } from "node:crypto";
 
 export const UPLOADS_DIR = "uploads";
 export const AVATAR_SUBDIR = "avatars";
+export const PROJECT_IMAGE_SUBDIR = "project-images";
 
 export const AVATAR_UPLOAD_DIR = `${UPLOADS_DIR}/${AVATAR_SUBDIR}`;
+export const PROJECT_IMAGE_UPLOAD_DIR = `${UPLOADS_DIR}/${PROJECT_IMAGE_SUBDIR}`;
 export const AVATAR_MAX_WIDTH = 200;
 export const AVATAR_WEBP_QUALITY = 85;
 
@@ -123,6 +125,148 @@ export function getAvatarFullPath(filename: string): string {
     !fullPath.startsWith(normalizedUploadsPath)
   ) {
     throw new AvatarFilenameError(
+      "Resolved path escapes the uploads directory"
+    );
+  }
+
+  return fullPath;
+}
+
+/**
+ * Project image filename validation error
+ */
+export class ProjectImageFilenameError extends Error {
+  constructor(message: string) {
+    super(`Invalid project image filename: ${message}`);
+    this.name = "ProjectImageFilenameError";
+  }
+}
+
+const PROJECT_ID_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Validate a project UUID used as an on-disk subdirectory under project-images/.
+ */
+export function validateProjectImageProjectId(projectId: string): string {
+  if (!projectId || typeof projectId !== "string") {
+    throw new ProjectImageFilenameError(
+      "Project ID must be a non-empty string"
+    );
+  }
+
+  if (!PROJECT_ID_UUID_PATTERN.test(projectId)) {
+    throw new ProjectImageFilenameError("Project ID must be a valid UUID");
+  }
+
+  return projectId.toLowerCase();
+}
+
+/**
+ * Validate and sanitize a project image filename to prevent path traversal attacks.
+ */
+export function validateProjectImageFilename(filename: string): string {
+  if (!filename || typeof filename !== "string") {
+    throw new ProjectImageFilenameError("Filename must be a non-empty string");
+  }
+
+  const MAX_FILENAME_LENGTH = 255;
+  if (filename.length > MAX_FILENAME_LENGTH) {
+    throw new ProjectImageFilenameError(
+      `Filename cannot exceed ${MAX_FILENAME_LENGTH} characters`
+    );
+  }
+
+  const sanitized = path.basename(filename);
+
+  if (filename !== sanitized) {
+    throw new ProjectImageFilenameError(
+      "Filename cannot contain path separators"
+    );
+  }
+
+  const validPattern = /^[a-zA-Z0-9._-]+$/;
+  if (!validPattern.test(sanitized)) {
+    throw new ProjectImageFilenameError(
+      "Filename contains invalid characters. Only alphanumeric, dot, dash, and underscore are allowed"
+    );
+  }
+
+  if (sanitized.startsWith(".")) {
+    throw new ProjectImageFilenameError("Filename cannot start with a dot");
+  }
+
+  return sanitized;
+}
+
+/**
+ * Ensure the project-images root directory exists.
+ * When `projectId` is provided, also ensure that project's subdirectory exists.
+ */
+export async function ensureProjectImageDir(projectId?: string): Promise<void> {
+  const rootDir = path.join(getUploadsDirPath(), PROJECT_IMAGE_SUBDIR);
+  if (projectId === undefined) {
+    await fs.mkdir(rootDir, { recursive: true });
+    return;
+  }
+
+  const sanitizedProjectId = validateProjectImageProjectId(projectId);
+  await fs.mkdir(path.join(rootDir, sanitizedProjectId), { recursive: true });
+}
+
+export function generateProjectImageFilename(
+  variant: "tooltip" | "modal",
+  extension: string
+): string {
+  const ext = extension.startsWith(".") ? extension : `.${extension}`;
+  return `${randomUUID()}_${variant}${ext}`;
+}
+
+/**
+ * Get the project image URL path for client access.
+ * Shape: `{basePath}/uploads/project-images/<projectId>/<filename>`
+ */
+export function getProjectImagePath(
+  projectId: string,
+  filename: string,
+  basePath = "/"
+): string {
+  const sanitizedProjectId = validateProjectImageProjectId(projectId);
+  const sanitized = validateProjectImageFilename(filename);
+
+  const cleanBasePath = basePath.endsWith("/")
+    ? basePath.slice(0, -1)
+    : basePath;
+  return `${cleanBasePath}/${PROJECT_IMAGE_UPLOAD_DIR}/${sanitizedProjectId}/${sanitized}`;
+}
+
+/**
+ * Get the absolute filesystem path for a project image file.
+ * Shape: `.../uploads/project-images/<projectId>/<filename>`
+ */
+export function getProjectImageFullPath(
+  projectId: string,
+  filename: string
+): string {
+  const sanitizedProjectId = validateProjectImageProjectId(projectId);
+  const sanitized = validateProjectImageFilename(filename);
+
+  const projectDirPath = path.join(
+    getUploadsDirPath(),
+    PROJECT_IMAGE_SUBDIR,
+    sanitizedProjectId
+  );
+  const fullPath = path.resolve(projectDirPath, sanitized);
+
+  const normalizedProjectDir = projectDirPath.endsWith(path.sep)
+    ? projectDirPath
+    : projectDirPath + path.sep;
+
+  if (
+    fullPath !== projectDirPath &&
+    !fullPath.startsWith(normalizedProjectDir)
+  ) {
+    throw new ProjectImageFilenameError(
       "Resolved path escapes the uploads directory"
     );
   }

--- a/apps/backend/src/lib/validation.ts
+++ b/apps/backend/src/lib/validation.ts
@@ -18,6 +18,7 @@ export * from "./validation/stats.js";
 export * from "./validation/pair-groups.js";
 export * from "./validation/characters.js";
 export * from "./validation/world-elements.js";
+export * from "./validation/project-images.js";
 export * from "./validation/gitlab.js";
 export * from "./validation/export-import.js";
 export * from "./validation/user-settings.js";

--- a/apps/backend/src/lib/validation/project-images.ts
+++ b/apps/backend/src/lib/validation/project-images.ts
@@ -1,0 +1,15 @@
+/**
+ * Project Image Validation Schemas
+ */
+
+import { z } from "zod";
+import { uuidSchema } from "./common.js";
+
+/**
+ * Project image ID params validation
+ */
+export const projectImageIdParamsSchema = z.object({
+  imageId: uuidSchema,
+});
+
+export type ProjectImageIdParams = z.infer<typeof projectImageIdParamsSchema>;

--- a/apps/backend/src/lib/validation/project-images.ts
+++ b/apps/backend/src/lib/validation/project-images.ts
@@ -13,3 +13,12 @@ export const projectImageIdParamsSchema = z.object({
 });
 
 export type ProjectImageIdParams = z.infer<typeof projectImageIdParamsSchema>;
+
+/**
+ * Multipart plain fields for project image upload/replace.
+ * originalFilename is required for upload; normalizedTarget is optional.
+ */
+export const projectImagePlainFieldsSchema = z.object({
+  originalFilename: z.string().trim().min(1, "originalFilename is required"),
+  normalizedTarget: z.string().trim().optional(),
+});

--- a/apps/backend/src/routes/__tests__/project-images.routes.unit.test.ts
+++ b/apps/backend/src/routes/__tests__/project-images.routes.unit.test.ts
@@ -138,6 +138,64 @@ describe("ProjectImagesRoutes", () => {
     );
   });
 
+  it("POST /projects/:projectId/images returns 400 when file exceeds size limit", async () => {
+    const largeBuffer = new Uint8Array(6 * 1024 * 1024); // 6MB > 5MB limit
+    const formData = new FormData();
+    formData.append("originalFilename", "test.png");
+    formData.append(
+      "tooltip",
+      new Blob([largeBuffer], { type: "image/png" }),
+      "tooltip.png"
+    );
+    formData.append(
+      "modal",
+      new Blob([minimalPng], { type: "image/png" }),
+      "modal.png"
+    );
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: `/projects/${PROJECT_ID}/images`,
+      payload: formData as any,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: "ValidationError",
+    });
+  });
+
+  it("POST /projects/:projectId/images returns 400 when too many files", async () => {
+    const formData = new FormData();
+    formData.append("originalFilename", "test.png");
+    formData.append(
+      "tooltip",
+      new Blob([minimalPng], { type: "image/png" }),
+      "tooltip.png"
+    );
+    formData.append(
+      "modal",
+      new Blob([minimalPng], { type: "image/png" }),
+      "modal.png"
+    );
+    formData.append(
+      "extra",
+      new Blob([minimalPng], { type: "image/png" }),
+      "extra.png"
+    );
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: `/projects/${PROJECT_ID}/images`,
+      payload: formData as any,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: "ValidationError",
+    });
+  });
+
   it("PUT /project-images/:imageId replaces image", async () => {
     const image = {
       id: IMAGE_ID,

--- a/apps/backend/src/routes/__tests__/project-images.routes.unit.test.ts
+++ b/apps/backend/src/routes/__tests__/project-images.routes.unit.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Project Images Routes Unit Tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Fastify from "fastify";
+import multipart from "@fastify/multipart";
+import { projectImagesRoutes } from "../project-images.routes.js";
+import * as projectImagesService from "../../services/project-images.service.js";
+import {
+  globalErrorHandler,
+  NotFoundError,
+} from "../../middleware/error-handler.middleware.js";
+
+const PROJECT_ID = "550e8400-e29b-41d4-a716-446655440000";
+const IMAGE_ID = "770e8400-e29b-41d4-a716-446655440002";
+
+vi.mock("../../services/project-images.service.js", () => ({
+  listProjectImages: vi.fn(),
+  uploadProjectImage: vi.fn(),
+  replaceProjectImage: vi.fn(),
+  deleteProjectImage: vi.fn(),
+}));
+
+vi.mock("../../middleware/auth.middleware.js", () => ({
+  authenticate: async (request: any) => {
+    request.user = {
+      id: "user-123",
+      email: "test@example.com",
+      role: "OWNER" as const,
+    };
+  },
+}));
+
+const minimalPng = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06,
+  0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44,
+  0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d,
+  0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42,
+  0x60, 0x82,
+]);
+
+describe("ProjectImagesRoutes", () => {
+  let fastify: ReturnType<typeof Fastify>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    fastify = Fastify();
+    // Match production default (files: 1). The route must override to 2
+    // because each upload sends tooltip + modal parts.
+    await fastify.register(multipart, {
+      limits: {
+        fileSize: 5 * 1024 * 1024,
+        files: 1,
+      },
+    });
+    await projectImagesRoutes(fastify);
+    fastify.setErrorHandler(globalErrorHandler);
+    await fastify.ready();
+  });
+
+  afterEach(async () => {
+    if (fastify) {
+      await fastify.close();
+    }
+  });
+
+  it("GET /projects/:projectId/images returns images", async () => {
+    const image = {
+      id: IMAGE_ID,
+      projectId: PROJECT_ID,
+      originalFilename: "eileen_happy.png",
+      normalizedTarget: "eileen_happy",
+      tooltipUrl: `/api/uploads/project-images/${PROJECT_ID}/t.webp`,
+      modalUrl: `/api/uploads/project-images/${PROJECT_ID}/m.webp`,
+      createdAt: "2024-06-01T12:00:00.000Z",
+    };
+    vi.mocked(projectImagesService.listProjectImages).mockResolvedValue([
+      image,
+    ]);
+
+    const response = await fastify.inject({
+      method: "GET",
+      url: `/projects/${PROJECT_ID}/images`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ images: [image] });
+    expect(projectImagesService.listProjectImages).toHaveBeenCalledWith(
+      PROJECT_ID,
+      "user-123"
+    );
+  });
+
+  it("POST /projects/:projectId/images uploads image", async () => {
+    const image = {
+      id: IMAGE_ID,
+      projectId: PROJECT_ID,
+      originalFilename: "eileen_happy.png",
+      normalizedTarget: "eileen_happy",
+      tooltipUrl: `/api/uploads/project-images/${PROJECT_ID}/t.webp`,
+      modalUrl: `/api/uploads/project-images/${PROJECT_ID}/m.webp`,
+      createdAt: "2024-06-01T12:00:00.000Z",
+    };
+    vi.mocked(projectImagesService.uploadProjectImage).mockResolvedValue(image);
+
+    const formData = new FormData();
+    formData.append("originalFilename", "eileen_happy.png");
+    formData.append(
+      "tooltip",
+      new Blob([minimalPng], { type: "image/png" }),
+      "tooltip.png"
+    );
+    formData.append(
+      "modal",
+      new Blob([minimalPng], { type: "image/png" }),
+      "modal.png"
+    );
+
+    const response = await fastify.inject({
+      method: "POST",
+      url: `/projects/${PROJECT_ID}/images`,
+      payload: formData as any,
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toEqual({ image });
+    expect(projectImagesService.uploadProjectImage).toHaveBeenCalledWith(
+      PROJECT_ID,
+      "user-123",
+      expect.objectContaining({
+        originalFilename: "eileen_happy.png",
+        tooltip: expect.objectContaining({ mimeType: "image/png" }),
+        modal: expect.objectContaining({ mimeType: "image/png" }),
+      })
+    );
+  });
+
+  it("PUT /project-images/:imageId replaces image", async () => {
+    const image = {
+      id: IMAGE_ID,
+      projectId: PROJECT_ID,
+      originalFilename: "eileen_happy.png",
+      normalizedTarget: "eileen_happy",
+      tooltipUrl: `/api/uploads/project-images/${PROJECT_ID}/t.webp`,
+      modalUrl: `/api/uploads/project-images/${PROJECT_ID}/m.webp`,
+      createdAt: "2024-06-01T12:00:00.000Z",
+    };
+    vi.mocked(projectImagesService.replaceProjectImage).mockResolvedValue(
+      image
+    );
+
+    const formData = new FormData();
+    formData.append("originalFilename", "eileen_happy.png");
+    formData.append(
+      "tooltip",
+      new Blob([minimalPng], { type: "image/png" }),
+      "tooltip.png"
+    );
+    formData.append(
+      "modal",
+      new Blob([minimalPng], { type: "image/png" }),
+      "modal.png"
+    );
+
+    const response = await fastify.inject({
+      method: "PUT",
+      url: `/project-images/${IMAGE_ID}`,
+      payload: formData as any,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ image });
+    expect(projectImagesService.replaceProjectImage).toHaveBeenCalledWith(
+      IMAGE_ID,
+      "user-123",
+      expect.objectContaining({
+        originalFilename: "eileen_happy.png",
+        tooltip: expect.objectContaining({ mimeType: "image/png" }),
+        modal: expect.objectContaining({ mimeType: "image/png" }),
+      })
+    );
+  });
+
+  it("DELETE /project-images/:imageId deletes image", async () => {
+    vi.mocked(projectImagesService.deleteProjectImage).mockResolvedValue();
+
+    const response = await fastify.inject({
+      method: "DELETE",
+      url: `/project-images/${IMAGE_ID}`,
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(projectImagesService.deleteProjectImage).toHaveBeenCalledWith(
+      IMAGE_ID,
+      "user-123"
+    );
+  });
+
+  it("DELETE /project-images/:imageId maps NotFoundError", async () => {
+    vi.mocked(projectImagesService.deleteProjectImage).mockRejectedValue(
+      new NotFoundError("Project image")
+    );
+
+    const response = await fastify.inject({
+      method: "DELETE",
+      url: `/project-images/${IMAGE_ID}`,
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+});

--- a/apps/backend/src/routes/project-images.routes.ts
+++ b/apps/backend/src/routes/project-images.routes.ts
@@ -6,10 +6,13 @@
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import type { MultipartFile } from "@fastify/multipart";
+import sharp from "sharp";
 import { authenticate } from "../middleware/auth.middleware.js";
 import { validateParams } from "../middleware/validation.middleware.js";
 import { ValidationError } from "../middleware/error-handler.middleware.js";
 import {
+  validateData,
+  projectImagePlainFieldsSchema,
   projectIdParamsSchema,
   projectImageIdParamsSchema,
   type ProjectIdParams,
@@ -126,7 +129,39 @@ async function readMultipartFile(
     );
   }
 
-  return { buffer, mimeType: part.mimetype };
+  // Detect actual MIME type via sharp metadata
+  let detectedFormat: string | undefined;
+  try {
+    const metadata = await sharp(buffer).metadata();
+    detectedFormat = metadata.format;
+  } catch {
+    throw new ValidationError("Invalid or corrupt image file");
+  }
+
+  const formatToMime: Record<string, string> = {
+    png: "image/png",
+    jpeg: "image/jpeg",
+    webp: "image/webp",
+  };
+
+  const detectedMime = detectedFormat
+    ? formatToMime[detectedFormat]
+    : undefined;
+  if (!detectedMime) {
+    throw new ValidationError("Invalid or corrupt image file");
+  }
+
+  // Normalize claimed MIME and compare to detected
+  const claimedMime = part.mimetype
+    .toLowerCase()
+    .replace("image/jpg", "image/jpeg");
+  if (claimedMime !== detectedMime) {
+    throw new ValidationError(
+      "Uploaded file type does not match expected type"
+    );
+  }
+
+  return { buffer, mimeType: detectedMime };
 }
 
 async function parseProjectImageUpload(
@@ -188,9 +223,8 @@ async function uploadProjectImageHandler(
   const { projectId } = request.params;
   const parsed = await parseProjectImageUpload(request);
 
-  if (!parsed.originalFilename?.trim()) {
-    throw new ValidationError("originalFilename is required");
-  }
+  validateData(parsed, projectImagePlainFieldsSchema, "Invalid upload fields");
+
   if (!parsed.tooltip) {
     throw new ValidationError("tooltip file is required");
   }
@@ -199,7 +233,7 @@ async function uploadProjectImageHandler(
   }
 
   const image = await uploadProjectImage(projectId, request.user!.id, {
-    originalFilename: parsed.originalFilename,
+    originalFilename: parsed.originalFilename!,
     normalizedTarget: parsed.normalizedTarget,
     tooltip: parsed.tooltip,
     modal: parsed.modal,
@@ -215,6 +249,12 @@ async function replaceProjectImageHandler(
 ): Promise<void> {
   const { imageId } = request.params;
   const parsed = await parseProjectImageUpload(request);
+
+  validateData(
+    parsed,
+    projectImagePlainFieldsSchema.partial(),
+    "Invalid upload fields"
+  );
 
   if (!parsed.tooltip) {
     throw new ValidationError("tooltip file is required");

--- a/apps/backend/src/routes/project-images.routes.ts
+++ b/apps/backend/src/routes/project-images.routes.ts
@@ -1,0 +1,283 @@
+/**
+ * Project Images Routes
+ *
+ * Thin HTTP wrappers for visual preview image CRUD.
+ */
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import type { MultipartFile } from "@fastify/multipart";
+import { authenticate } from "../middleware/auth.middleware.js";
+import { validateParams } from "../middleware/validation.middleware.js";
+import { ValidationError } from "../middleware/error-handler.middleware.js";
+import {
+  projectIdParamsSchema,
+  projectImageIdParamsSchema,
+  type ProjectIdParams,
+  type ProjectImageIdParams,
+} from "../lib/validation.js";
+import {
+  PROJECT_IMAGE_MAX_SIZE,
+  PROJECT_IMAGE_MAX_SIZE_MB,
+  type ProjectImage,
+} from "@branchforge/shared";
+import {
+  deleteProjectImage,
+  listProjectImages,
+  replaceProjectImage,
+  uploadProjectImage,
+} from "../services/project-images.service.js";
+
+interface ListProjectImagesResponse {
+  images: ProjectImage[];
+}
+
+interface UploadProjectImageResponse {
+  image: ProjectImage;
+}
+
+interface ParsedUpload {
+  originalFilename?: string;
+  normalizedTarget?: string;
+  tooltip?: { buffer: Buffer; mimeType: string };
+  modal?: { buffer: Buffer; mimeType: string };
+}
+
+function getErrorCode(error: unknown): string {
+  if (!(error instanceof Error) || !("code" in error)) {
+    return "";
+  }
+  return String((error as { code?: unknown }).code ?? "");
+}
+
+function isMultipartFileTooLargeError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const code = getErrorCode(error);
+  if (code === "FST_REQ_FILE_TOO_LARGE" || code === "LIMIT_FILE_SIZE") {
+    return true;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("file too large") ||
+    message.includes("limit file size") ||
+    message.includes("filesize limit")
+  );
+}
+
+function isMultipartFilesLimitError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const code = getErrorCode(error);
+  if (
+    code === "FST_FILES_LIMIT" ||
+    code === "FST_PARTS_LIMIT" ||
+    code === "LIMIT_FILE_COUNT" ||
+    code === "LIMIT_PART_COUNT"
+  ) {
+    return true;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("reach files limit") ||
+    message.includes("files limit") ||
+    message.includes("parts limit")
+  );
+}
+
+function mapMultipartValidationError(error: unknown): never {
+  if (isMultipartFileTooLargeError(error)) {
+    throw new ValidationError(
+      `File must be smaller than ${PROJECT_IMAGE_MAX_SIZE_MB}MB`
+    );
+  }
+  if (isMultipartFilesLimitError(error)) {
+    throw new ValidationError(
+      "Upload includes too many files. Expected tooltip and modal only."
+    );
+  }
+  throw error;
+}
+
+async function readMultipartFile(
+  part: MultipartFile
+): Promise<{ buffer: Buffer; mimeType: string }> {
+  let buffer: Buffer;
+  try {
+    buffer = await part.toBuffer();
+  } catch (error) {
+    mapMultipartValidationError(error);
+  }
+
+  if (part.file.truncated) {
+    throw new ValidationError(
+      `File must be smaller than ${PROJECT_IMAGE_MAX_SIZE_MB}MB`
+    );
+  }
+
+  if (buffer.length > PROJECT_IMAGE_MAX_SIZE) {
+    throw new ValidationError(
+      `File must be smaller than ${PROJECT_IMAGE_MAX_SIZE_MB}MB`
+    );
+  }
+
+  return { buffer, mimeType: part.mimetype };
+}
+
+async function parseProjectImageUpload(
+  request: FastifyRequest
+): Promise<ParsedUpload> {
+  const result: ParsedUpload = {};
+
+  try {
+    // Global multipart plugin defaults to files: 1 (avatar/ZIP). This endpoint
+    // always sends two files (tooltip + modal), so override per-request.
+    const parts = request.parts({
+      limits: {
+        fileSize: PROJECT_IMAGE_MAX_SIZE,
+        files: 2,
+      },
+    });
+
+    for await (const part of parts) {
+      if (part.type === "file") {
+        const filePart = await readMultipartFile(part);
+        if (part.fieldname === "tooltip") {
+          result.tooltip = filePart;
+        } else if (part.fieldname === "modal") {
+          result.modal = filePart;
+        }
+      } else if (part.type === "field") {
+        const value =
+          typeof part.value === "string"
+            ? part.value
+            : String(part.value ?? "");
+        if (part.fieldname === "originalFilename") {
+          result.originalFilename = value;
+        } else if (part.fieldname === "normalizedTarget") {
+          result.normalizedTarget = value;
+        }
+      }
+    }
+  } catch (error) {
+    mapMultipartValidationError(error);
+  }
+
+  return result;
+}
+
+async function listProjectImagesHandler(
+  request: FastifyRequest<{ Params: ProjectIdParams }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { projectId } = request.params;
+  const images = await listProjectImages(projectId, request.user!.id);
+  const response: ListProjectImagesResponse = { images };
+  reply.status(200).send(response);
+}
+
+async function uploadProjectImageHandler(
+  request: FastifyRequest<{ Params: ProjectIdParams }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { projectId } = request.params;
+  const parsed = await parseProjectImageUpload(request);
+
+  if (!parsed.originalFilename?.trim()) {
+    throw new ValidationError("originalFilename is required");
+  }
+  if (!parsed.tooltip) {
+    throw new ValidationError("tooltip file is required");
+  }
+  if (!parsed.modal) {
+    throw new ValidationError("modal file is required");
+  }
+
+  const image = await uploadProjectImage(projectId, request.user!.id, {
+    originalFilename: parsed.originalFilename,
+    normalizedTarget: parsed.normalizedTarget,
+    tooltip: parsed.tooltip,
+    modal: parsed.modal,
+  });
+
+  const response: UploadProjectImageResponse = { image };
+  reply.status(201).send(response);
+}
+
+async function replaceProjectImageHandler(
+  request: FastifyRequest<{ Params: ProjectImageIdParams }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { imageId } = request.params;
+  const parsed = await parseProjectImageUpload(request);
+
+  if (!parsed.tooltip) {
+    throw new ValidationError("tooltip file is required");
+  }
+  if (!parsed.modal) {
+    throw new ValidationError("modal file is required");
+  }
+
+  const image = await replaceProjectImage(imageId, request.user!.id, {
+    originalFilename: parsed.originalFilename,
+    tooltip: parsed.tooltip,
+    modal: parsed.modal,
+  });
+
+  const response: UploadProjectImageResponse = { image };
+  reply.status(200).send(response);
+}
+
+async function deleteProjectImageHandler(
+  request: FastifyRequest<{ Params: ProjectImageIdParams }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { imageId } = request.params;
+  await deleteProjectImage(imageId, request.user!.id);
+  reply.status(204).send();
+}
+
+export async function projectImagesRoutes(
+  fastify: FastifyInstance
+): Promise<void> {
+  fastify.get<{ Params: ProjectIdParams }>(
+    "/projects/:projectId/images",
+    {
+      onRequest: authenticate,
+      preValidation: validateParams(projectIdParamsSchema),
+    },
+    listProjectImagesHandler
+  );
+
+  fastify.post<{ Params: ProjectIdParams }>(
+    "/projects/:projectId/images",
+    {
+      onRequest: authenticate,
+      preValidation: validateParams(projectIdParamsSchema),
+    },
+    uploadProjectImageHandler
+  );
+
+  fastify.put<{ Params: ProjectImageIdParams }>(
+    "/project-images/:imageId",
+    {
+      onRequest: authenticate,
+      preValidation: validateParams(projectImageIdParamsSchema),
+    },
+    replaceProjectImageHandler
+  );
+
+  fastify.delete<{ Params: ProjectImageIdParams }>(
+    "/project-images/:imageId",
+    {
+      onRequest: authenticate,
+      preValidation: validateParams(projectImageIdParamsSchema),
+    },
+    deleteProjectImageHandler
+  );
+}

--- a/apps/backend/src/services/__tests__/project-images.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/project-images.service.unit.test.ts
@@ -30,8 +30,19 @@ vi.mock("../authz.service.js", () => ({
   requireProjectOwnership: vi.fn(() => Promise.resolve()),
 }));
 
-function chain(resolveValue: unknown): any {
-  const fn = ((..._args: unknown[]) => chain(resolveValue)) as any;
+interface Chain {
+  then<TResult1 = unknown, TResult2 = never>(
+    onfulfilled?: ((value: unknown) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2>;
+  catch<TResult = never>(
+    onrejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null
+  ): Promise<unknown>;
+  [key: string]: (...args: unknown[]) => Chain;
+}
+
+function chain(resolveValue: unknown): Chain {
+  const fn = ((..._args: unknown[]) => chain(resolveValue)) as unknown as Chain;
   return new Proxy(fn, {
     get(_target, prop) {
       if (prop === "then") {

--- a/apps/backend/src/services/__tests__/project-images.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/project-images.service.unit.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Project Images Service Unit Tests
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { promises as fs } from "node:fs";
+
+vi.mock("node:fs", () => ({
+  promises: {
+    writeFile: vi.fn(() => Promise.resolve()),
+    unlink: vi.fn(() => Promise.resolve()),
+  },
+}));
+import {
+  deleteProjectImage,
+  listProjectImages,
+  replaceProjectImage,
+  uploadProjectImage,
+} from "../project-images.service.js";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "../../middleware/error-handler.middleware.js";
+import { requireProjectOwnership } from "../authz.service.js";
+
+vi.mock("../authz.service.js", () => ({
+  requireProjectAccess: vi.fn(() => Promise.resolve()),
+  requireProjectOwnership: vi.fn(() => Promise.resolve()),
+}));
+
+function chain(resolveValue: unknown): any {
+  const fn = ((..._args: unknown[]) => chain(resolveValue)) as any;
+  return new Proxy(fn, {
+    get(_target, prop) {
+      if (prop === "then") {
+        return (
+          resolve: (v: unknown) => void,
+          reject?: (e: unknown) => void
+        ) => {
+          if (resolveValue instanceof Error) {
+            reject?.(resolveValue);
+          } else {
+            resolve?.(resolveValue);
+          }
+        };
+      }
+      if (prop === "catch") {
+        return (reject?: (e: unknown) => void) => {
+          if (resolveValue instanceof Error) {
+            reject?.(resolveValue);
+          }
+          return undefined;
+        };
+      }
+      return chain(resolveValue);
+    },
+  });
+}
+
+const dbSelect = vi.fn();
+const dbInsert = vi.fn();
+const dbUpdate = vi.fn();
+const dbDelete = vi.fn();
+
+vi.mock("../../db/index.js", () => ({
+  getDb: vi.fn(() => ({
+    select: dbSelect,
+    insert: dbInsert,
+    update: dbUpdate,
+    delete: dbDelete,
+  })),
+}));
+
+vi.mock("../../lib/config.js", () => ({
+  getBasePath: vi.fn(() => "/api/"),
+}));
+
+vi.mock("../../lib/storage.js", () => ({
+  ensureProjectImageDir: vi.fn(() => Promise.resolve()),
+  generateProjectImageFilename: vi.fn(
+    (variant: string) => `${variant}-file.webp`
+  ),
+  getProjectImageFullPath: vi.fn(
+    (projectId: string, filename: string) =>
+      `/tmp/project-images/${projectId}/${filename}`
+  ),
+  getProjectImagePath: vi.fn(
+    (projectId: string, filename: string, basePath: string) =>
+      `${basePath}uploads/project-images/${projectId}/${filename}`
+  ),
+}));
+
+const projectId = "550e8400-e29b-41d4-a716-446655440000";
+const userId = "660e8400-e29b-41d4-a716-446655440001";
+const imageId = "770e8400-e29b-41d4-a716-446655440002";
+const otherUserId = "880e8400-e29b-41d4-a716-446655440003";
+
+const minimalPng = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06,
+  0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44,
+  0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d,
+  0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42,
+  0x60, 0x82,
+]);
+
+const existingRow = {
+  id: imageId,
+  projectId,
+  originalFilename: "eileen_happy.png",
+  normalizedTarget: "eileen_happy",
+  tooltipFilename: "old-tooltip.webp",
+  modalFilename: "old-modal.webp",
+  createdAt: new Date("2024-06-01T12:00:00.000Z"),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbSelect.mockReturnValue(chain([]));
+  dbInsert.mockReturnValue(chain([]));
+  dbUpdate.mockReturnValue(chain([]));
+  dbDelete.mockReturnValue(chain([]));
+  vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+  vi.mocked(fs.unlink).mockResolvedValue(undefined);
+  vi.mocked(requireProjectOwnership).mockResolvedValue(undefined);
+});
+
+describe("listProjectImages", () => {
+  it("returns mapped project images", async () => {
+    const createdAt = new Date("2024-06-01T12:00:00.000Z");
+    dbSelect.mockReturnValueOnce(
+      chain([
+        {
+          id: imageId,
+          projectId,
+          originalFilename: "eileen_happy.png",
+          normalizedTarget: "eileen_happy",
+          tooltipFilename: "tooltip-file.webp",
+          modalFilename: "modal-file.webp",
+          createdAt,
+        },
+      ])
+    );
+
+    const images = await listProjectImages(projectId, userId);
+
+    expect(images).toEqual([
+      {
+        id: imageId,
+        projectId,
+        originalFilename: "eileen_happy.png",
+        normalizedTarget: "eileen_happy",
+        tooltipUrl: `/api/uploads/project-images/${projectId}/tooltip-file.webp`,
+        modalUrl: `/api/uploads/project-images/${projectId}/modal-file.webp`,
+        createdAt: createdAt.toISOString(),
+      },
+    ]);
+  });
+});
+
+describe("uploadProjectImage", () => {
+  it("throws ConflictError on duplicate normalized target", async () => {
+    const dupError = new Error("duplicate key value") as Error & {
+      code: string;
+    };
+    dupError.code = "23505";
+    dbInsert.mockReturnValueOnce(chain(dupError));
+
+    await expect(
+      uploadProjectImage(projectId, userId, {
+        originalFilename: "eileen_happy.png",
+        tooltip: { buffer: minimalPng, mimeType: "image/png" },
+        modal: { buffer: minimalPng, mimeType: "image/png" },
+      })
+    ).rejects.toThrow(ConflictError);
+
+    expect(fs.unlink).toHaveBeenCalled();
+  });
+
+  it("rejects oversized originalFilename", async () => {
+    await expect(
+      uploadProjectImage(projectId, userId, {
+        originalFilename: `${"a".repeat(256)}.png`,
+        tooltip: { buffer: minimalPng, mimeType: "image/png" },
+        modal: { buffer: minimalPng, mimeType: "image/png" },
+      })
+    ).rejects.toThrow(ValidationError);
+
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("replaceProjectImage", () => {
+  it("updates files then unlinks previous files", async () => {
+    const updated = {
+      ...existingRow,
+      tooltipFilename: "tooltip-file.webp",
+      modalFilename: "modal-file.webp",
+    };
+    dbSelect.mockReturnValueOnce(chain([existingRow]));
+    dbUpdate.mockReturnValueOnce(chain([updated]));
+
+    const image = await replaceProjectImage(imageId, userId, {
+      originalFilename: "eileen_happy.png",
+      tooltip: { buffer: minimalPng, mimeType: "image/png" },
+      modal: { buffer: minimalPng, mimeType: "image/png" },
+    });
+
+    expect(requireProjectOwnership).toHaveBeenCalledWith(projectId, userId);
+    expect(fs.writeFile).toHaveBeenCalled();
+    expect(dbUpdate).toHaveBeenCalled();
+    expect(fs.unlink).toHaveBeenCalledWith(
+      `/tmp/project-images/${projectId}/old-tooltip.webp`
+    );
+    expect(fs.unlink).toHaveBeenCalledWith(
+      `/tmp/project-images/${projectId}/old-modal.webp`
+    );
+    expect(image.tooltipUrl).toContain("tooltip-file.webp");
+  });
+
+  it("throws NotFoundError when image is missing", async () => {
+    dbSelect.mockReturnValueOnce(chain([]));
+
+    await expect(
+      replaceProjectImage(imageId, userId, {
+        tooltip: { buffer: minimalPng, mimeType: "image/png" },
+        modal: { buffer: minimalPng, mimeType: "image/png" },
+      })
+    ).rejects.toThrow(NotFoundError);
+  });
+});
+
+describe("deleteProjectImage", () => {
+  it("deletes the DB row before unlinking files", async () => {
+    const callOrder: string[] = [];
+    dbSelect.mockReturnValueOnce(
+      chain([
+        {
+          id: imageId,
+          projectId,
+          tooltipFilename: "old-tooltip.webp",
+          modalFilename: "old-modal.webp",
+          ownerId: userId,
+        },
+      ])
+    );
+    dbDelete.mockImplementation(() => {
+      callOrder.push("delete");
+      return chain([
+        {
+          id: imageId,
+          projectId,
+          tooltipFilename: "old-tooltip.webp",
+          modalFilename: "old-modal.webp",
+        },
+      ]);
+    });
+    vi.mocked(fs.unlink).mockImplementation(async () => {
+      callOrder.push("unlink");
+    });
+
+    await deleteProjectImage(imageId, userId);
+
+    expect(callOrder[0]).toBe("delete");
+    expect(callOrder.slice(1)).toEqual(["unlink", "unlink"]);
+  });
+
+  it("throws NotFoundError when image is missing", async () => {
+    dbSelect.mockReturnValueOnce(chain([]));
+
+    await expect(deleteProjectImage(imageId, userId)).rejects.toThrow(
+      NotFoundError
+    );
+    expect(dbDelete).not.toHaveBeenCalled();
+    expect(fs.unlink).not.toHaveBeenCalled();
+  });
+
+  it("throws ForbiddenError when user is not the owner", async () => {
+    dbSelect.mockReturnValueOnce(
+      chain([
+        {
+          id: imageId,
+          projectId,
+          tooltipFilename: "old-tooltip.webp",
+          modalFilename: "old-modal.webp",
+          ownerId: otherUserId,
+        },
+      ])
+    );
+
+    await expect(deleteProjectImage(imageId, userId)).rejects.toThrow(
+      ForbiddenError
+    );
+    expect(dbDelete).not.toHaveBeenCalled();
+    expect(fs.unlink).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/services/__tests__/project-images.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/project-images.service.unit.test.ts
@@ -82,6 +82,7 @@ vi.mock("../../lib/storage.js", () => ({
   generateProjectImageFilename: vi.fn(
     (variant: string) => `${variant}-file.webp`
   ),
+  getProjectImageRootDirPath: vi.fn(() => "/tmp/project-images"),
   getProjectImageFullPath: vi.fn(
     (projectId: string, filename: string) =>
       `/tmp/project-images/${projectId}/${filename}`
@@ -89,6 +90,9 @@ vi.mock("../../lib/storage.js", () => ({
   getProjectImagePath: vi.fn(
     (projectId: string, filename: string, basePath: string) =>
       `${basePath}uploads/project-images/${projectId}/${filename}`
+  ),
+  resolvePathInsideProjectImageRoot: vi.fn(
+    (...segments: string[]) => `/tmp/project-images/${segments.join("/")}`
   ),
 }));
 

--- a/apps/backend/src/services/__tests__/project-images.service.unit.test.ts
+++ b/apps/backend/src/services/__tests__/project-images.service.unit.test.ts
@@ -205,6 +205,28 @@ describe("uploadProjectImage", () => {
 
     expect(fs.writeFile).not.toHaveBeenCalled();
   });
+
+  it("unlinks both files when one parallel write fails", async () => {
+    vi.mocked(fs.writeFile)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(
+      uploadProjectImage(projectId, userId, {
+        originalFilename: "eileen_happy.png",
+        tooltip: { buffer: minimalPng, mimeType: "image/png" },
+        modal: { buffer: minimalPng, mimeType: "image/png" },
+      })
+    ).rejects.toThrow("disk full");
+
+    expect(dbInsert).not.toHaveBeenCalled();
+    expect(fs.unlink).toHaveBeenCalledWith(
+      `/tmp/project-images/${projectId}/tooltip-file.webp`
+    );
+    expect(fs.unlink).toHaveBeenCalledWith(
+      `/tmp/project-images/${projectId}/modal-file.webp`
+    );
+  });
 });
 
 describe("replaceProjectImage", () => {

--- a/apps/backend/src/services/project-images.service.ts
+++ b/apps/backend/src/services/project-images.service.ts
@@ -106,6 +106,42 @@ async function unlinkProjectImageFile(
   }
 }
 
+/**
+ * Write tooltip and modal image files with path containment checks.
+ * Both writes run in parallel via Promise.all.
+ */
+async function writeImageFiles(
+  projectId: string,
+  tooltipBuffer: Buffer,
+  tooltipFilename: string,
+  modalBuffer: Buffer,
+  modalFilename: string
+): Promise<void> {
+  const tooltipPath = getProjectImageFullPath(projectId, tooltipFilename);
+  const modalPath = getProjectImageFullPath(projectId, modalFilename);
+
+  {
+    const rootDir = getProjectImageRootDirPath();
+    const tooltipRelative = path.relative(rootDir, tooltipPath);
+    const modalRelative = path.relative(rootDir, modalPath);
+    if (
+      tooltipRelative.startsWith(".." + path.sep) ||
+      tooltipRelative === ".." ||
+      path.isAbsolute(tooltipRelative) ||
+      modalRelative.startsWith(".." + path.sep) ||
+      modalRelative === ".." ||
+      path.isAbsolute(modalRelative)
+    ) {
+      throw new ValidationError("Invalid project image path");
+    }
+  }
+
+  await Promise.all([
+    fs.writeFile(tooltipPath, tooltipBuffer),
+    fs.writeFile(modalPath, modalBuffer),
+  ]);
+}
+
 function validateOriginalFilename(raw: string): string {
   const originalFilename = raw.trim();
   if (!originalFilename) {
@@ -186,27 +222,13 @@ export async function uploadProjectImage(
   const modalFilename = generateProjectImageFilename("modal", modalExt);
 
   await ensureProjectImageDir(projectId);
-
-  const tooltipPath = getProjectImageFullPath(projectId, tooltipFilename);
-  const modalPath = getProjectImageFullPath(projectId, modalFilename);
-  {
-    const rootDir = getProjectImageRootDirPath();
-    const tooltipRelative = path.relative(rootDir, tooltipPath);
-    const modalRelative = path.relative(rootDir, modalPath);
-    if (
-      tooltipRelative.startsWith(".." + path.sep) ||
-      tooltipRelative === ".." ||
-      path.isAbsolute(tooltipRelative) ||
-      modalRelative.startsWith(".." + path.sep) ||
-      modalRelative === ".." ||
-      path.isAbsolute(modalRelative)
-    ) {
-      throw new ValidationError("Invalid project image path");
-    }
-  }
-
-  await fs.writeFile(tooltipPath, input.tooltip.buffer);
-  await fs.writeFile(modalPath, input.modal.buffer);
+  await writeImageFiles(
+    projectId,
+    input.tooltip.buffer,
+    tooltipFilename,
+    input.modal.buffer,
+    modalFilename
+  );
 
   try {
     const [created] = await getDb()
@@ -282,30 +304,13 @@ export async function replaceProjectImage(
   const modalFilename = generateProjectImageFilename("modal", modalExt);
 
   await ensureProjectImageDir(existing.projectId);
-
-  const tooltipPath = getProjectImageFullPath(
+  await writeImageFiles(
     existing.projectId,
-    tooltipFilename
+    input.tooltip.buffer,
+    tooltipFilename,
+    input.modal.buffer,
+    modalFilename
   );
-  const modalPath = getProjectImageFullPath(existing.projectId, modalFilename);
-  {
-    const rootDir = getProjectImageRootDirPath();
-    const tooltipRelative = path.relative(rootDir, tooltipPath);
-    const modalRelative = path.relative(rootDir, modalPath);
-    if (
-      tooltipRelative.startsWith(".." + path.sep) ||
-      tooltipRelative === ".." ||
-      path.isAbsolute(tooltipRelative) ||
-      modalRelative.startsWith(".." + path.sep) ||
-      modalRelative === ".." ||
-      path.isAbsolute(modalRelative)
-    ) {
-      throw new ValidationError("Invalid project image path");
-    }
-  }
-
-  await fs.writeFile(tooltipPath, input.tooltip.buffer);
-  await fs.writeFile(modalPath, input.modal.buffer);
 
   try {
     const [updated] = await db

--- a/apps/backend/src/services/project-images.service.ts
+++ b/apps/backend/src/services/project-images.service.ts
@@ -1,0 +1,342 @@
+/**
+ * Project Images Service
+ *
+ * CRUD for visual preview images linked to Ren'Py statement targets.
+ */
+
+import { promises as fs } from "node:fs";
+import { eq, asc } from "drizzle-orm";
+import { getDb } from "../db/index.js";
+import { projectImages, projects } from "../db/schema/index.js";
+import type { ProjectImageRow } from "../db/schema/index.js";
+import {
+  requireProjectAccess,
+  requireProjectOwnership,
+} from "./authz.service.js";
+import {
+  ensureProjectImageDir,
+  generateProjectImageFilename,
+  getProjectImageFullPath,
+  getProjectImagePath,
+} from "../lib/storage.js";
+import { getBasePath } from "../lib/config.js";
+import { isUniqueConstraintViolation } from "../lib/db.js";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "../middleware/error-handler.middleware.js";
+import {
+  isValidProjectImageMimeType,
+  normalizeImageTarget,
+  PROJECT_IMAGE_ORIGINAL_FILENAME_MAX,
+  type ProjectImage,
+} from "@branchforge/shared";
+import { logWarn, LogEventType } from "../lib/logger.js";
+
+export interface UploadProjectImageInput {
+  originalFilename: string;
+  normalizedTarget?: string;
+  tooltip: { buffer: Buffer; mimeType: string };
+  modal: { buffer: Buffer; mimeType: string };
+}
+
+export interface ReplaceProjectImageInput {
+  originalFilename?: string;
+  tooltip: { buffer: Buffer; mimeType: string };
+  modal: { buffer: Buffer; mimeType: string };
+}
+
+function extensionForMimeType(mimeType: string): string {
+  const mime = mimeType.toLowerCase();
+  if (mime === "image/webp") return "webp";
+  if (mime === "image/png") return "png";
+  if (mime === "image/jpeg" || mime === "image/jpg") return "jpg";
+  return "webp";
+}
+
+function mapToProjectImage(row: ProjectImageRow): ProjectImage {
+  const basePath = getBasePath();
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    originalFilename: row.originalFilename,
+    normalizedTarget: row.normalizedTarget,
+    tooltipUrl: getProjectImagePath(
+      row.projectId,
+      row.tooltipFilename,
+      basePath
+    ),
+    modalUrl: getProjectImagePath(row.projectId, row.modalFilename, basePath),
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+async function unlinkProjectImageFile(
+  projectId: string,
+  filename: string
+): Promise<void> {
+  try {
+    await fs.unlink(getProjectImageFullPath(projectId, filename));
+  } catch (error) {
+    if (
+      !(error instanceof Error && "code" in error) ||
+      (error as NodeJS.ErrnoException).code !== "ENOENT"
+    ) {
+      logWarn(LogEventType.SERVICE_ERROR, {
+        message: `Failed to delete project image file: ${filename}`,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+function validateOriginalFilename(raw: string): string {
+  const originalFilename = raw.trim();
+  if (!originalFilename) {
+    throw new ValidationError("originalFilename is required");
+  }
+  if (originalFilename.length > PROJECT_IMAGE_ORIGINAL_FILENAME_MAX) {
+    throw new ValidationError(
+      `originalFilename must be ${PROJECT_IMAGE_ORIGINAL_FILENAME_MAX} characters or fewer`
+    );
+  }
+  return originalFilename;
+}
+
+function assertValidImageParts(input: {
+  tooltip: { mimeType: string };
+  modal: { mimeType: string };
+}): void {
+  if (!isValidProjectImageMimeType(input.tooltip.mimeType)) {
+    throw new ValidationError("Invalid tooltip image type");
+  }
+  if (!isValidProjectImageMimeType(input.modal.mimeType)) {
+    throw new ValidationError("Invalid modal image type");
+  }
+}
+
+/**
+ * List all project images for a project.
+ */
+export async function listProjectImages(
+  projectId: string,
+  userId: string
+): Promise<ProjectImage[]> {
+  await requireProjectAccess(projectId, userId);
+
+  const rows = await getDb()
+    .select()
+    .from(projectImages)
+    .where(eq(projectImages.projectId, projectId))
+    .orderBy(asc(projectImages.createdAt));
+
+  return rows.map(mapToProjectImage);
+}
+
+/**
+ * Upload tooltip + modal preview images for a normalized target.
+ */
+export async function uploadProjectImage(
+  projectId: string,
+  userId: string,
+  input: UploadProjectImageInput
+): Promise<ProjectImage> {
+  await requireProjectOwnership(projectId, userId);
+
+  const originalFilename = validateOriginalFilename(input.originalFilename);
+
+  const derivedTarget = normalizeImageTarget(originalFilename);
+  if (!derivedTarget) {
+    throw new ValidationError(
+      "Could not derive a valid normalized target from originalFilename"
+    );
+  }
+
+  if (
+    input.normalizedTarget !== undefined &&
+    input.normalizedTarget.trim() !== "" &&
+    normalizeImageTarget(input.normalizedTarget) !== derivedTarget
+  ) {
+    throw new ValidationError(
+      "normalizedTarget does not match originalFilename"
+    );
+  }
+
+  assertValidImageParts(input);
+
+  const tooltipExt = extensionForMimeType(input.tooltip.mimeType);
+  const modalExt = extensionForMimeType(input.modal.mimeType);
+  const tooltipFilename = generateProjectImageFilename("tooltip", tooltipExt);
+  const modalFilename = generateProjectImageFilename("modal", modalExt);
+
+  await ensureProjectImageDir(projectId);
+
+  const tooltipPath = getProjectImageFullPath(projectId, tooltipFilename);
+  const modalPath = getProjectImageFullPath(projectId, modalFilename);
+
+  await fs.writeFile(tooltipPath, input.tooltip.buffer);
+  await fs.writeFile(modalPath, input.modal.buffer);
+
+  try {
+    const [created] = await getDb()
+      .insert(projectImages)
+      .values({
+        projectId,
+        originalFilename,
+        normalizedTarget: derivedTarget,
+        tooltipFilename,
+        modalFilename,
+      })
+      .returning();
+
+    if (!created) {
+      throw new ValidationError("Failed to create project image");
+    }
+
+    return mapToProjectImage(created);
+  } catch (error) {
+    await unlinkProjectImageFile(projectId, tooltipFilename);
+    await unlinkProjectImageFile(projectId, modalFilename);
+
+    if (isUniqueConstraintViolation(error)) {
+      throw new ConflictError(
+        "A project image with this normalized target already exists"
+      );
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * Replace tooltip + modal files for an existing project image.
+ *
+ * Writes new files first, updates the DB row, then unlinks the previous files
+ * so a failed upload never leaves the target without an image.
+ */
+export async function replaceProjectImage(
+  imageId: string,
+  userId: string,
+  input: ReplaceProjectImageInput
+): Promise<ProjectImage> {
+  const db = getDb();
+
+  const [existing] = await db
+    .select()
+    .from(projectImages)
+    .where(eq(projectImages.id, imageId))
+    .limit(1);
+
+  if (!existing) {
+    throw new NotFoundError("Project image");
+  }
+
+  await requireProjectOwnership(existing.projectId, userId);
+  assertValidImageParts(input);
+
+  let originalFilename = existing.originalFilename;
+  if (input.originalFilename !== undefined) {
+    originalFilename = validateOriginalFilename(input.originalFilename);
+    const derivedTarget = normalizeImageTarget(originalFilename);
+    if (!derivedTarget || derivedTarget !== existing.normalizedTarget) {
+      throw new ValidationError(
+        "Replacement filename must match the existing normalized target"
+      );
+    }
+  }
+
+  const tooltipExt = extensionForMimeType(input.tooltip.mimeType);
+  const modalExt = extensionForMimeType(input.modal.mimeType);
+  const tooltipFilename = generateProjectImageFilename("tooltip", tooltipExt);
+  const modalFilename = generateProjectImageFilename("modal", modalExt);
+
+  await ensureProjectImageDir(existing.projectId);
+
+  const tooltipPath = getProjectImageFullPath(
+    existing.projectId,
+    tooltipFilename
+  );
+  const modalPath = getProjectImageFullPath(existing.projectId, modalFilename);
+
+  await fs.writeFile(tooltipPath, input.tooltip.buffer);
+  await fs.writeFile(modalPath, input.modal.buffer);
+
+  try {
+    const [updated] = await db
+      .update(projectImages)
+      .set({
+        originalFilename,
+        tooltipFilename,
+        modalFilename,
+      })
+      .where(eq(projectImages.id, imageId))
+      .returning();
+
+    if (!updated) {
+      throw new NotFoundError("Project image");
+    }
+
+    await unlinkProjectImageFile(existing.projectId, existing.tooltipFilename);
+    await unlinkProjectImageFile(existing.projectId, existing.modalFilename);
+
+    return mapToProjectImage(updated);
+  } catch (error) {
+    await unlinkProjectImageFile(existing.projectId, tooltipFilename);
+    await unlinkProjectImageFile(existing.projectId, modalFilename);
+    throw error;
+  }
+}
+
+/**
+ * Delete a project image and its files.
+ *
+ * Deletes the DB row first, then unlinks files, so a failed unlink cannot leave
+ * a row pointing at missing files.
+ */
+export async function deleteProjectImage(
+  imageId: string,
+  userId: string
+): Promise<void> {
+  const db = getDb();
+
+  const [row] = await db
+    .select({
+      id: projectImages.id,
+      projectId: projectImages.projectId,
+      tooltipFilename: projectImages.tooltipFilename,
+      modalFilename: projectImages.modalFilename,
+      ownerId: projects.userId,
+    })
+    .from(projectImages)
+    .innerJoin(projects, eq(projectImages.projectId, projects.id))
+    .where(eq(projectImages.id, imageId))
+    .limit(1);
+
+  if (!row) {
+    throw new NotFoundError("Project image");
+  }
+
+  if (row.ownerId !== userId) {
+    throw new ForbiddenError("You do not have access to this project");
+  }
+
+  const deleted = await db
+    .delete(projectImages)
+    .where(eq(projectImages.id, imageId))
+    .returning({
+      id: projectImages.id,
+      projectId: projectImages.projectId,
+      tooltipFilename: projectImages.tooltipFilename,
+      modalFilename: projectImages.modalFilename,
+    });
+
+  if (deleted.length === 0) {
+    throw new NotFoundError("Project image");
+  }
+
+  const image = deleted[0];
+  await unlinkProjectImageFile(image.projectId, image.tooltipFilename);
+  await unlinkProjectImageFile(image.projectId, image.modalFilename);
+}

--- a/apps/backend/src/services/project-images.service.ts
+++ b/apps/backend/src/services/project-images.service.ts
@@ -108,7 +108,7 @@ async function unlinkProjectImageFile(
 
 /**
  * Write tooltip and modal image files with path containment checks.
- * Both writes run in parallel via Promise.all.
+ * Both writes run in parallel; if either fails, unlink both to avoid orphans.
  */
 async function writeImageFiles(
   projectId: string,
@@ -136,10 +136,19 @@ async function writeImageFiles(
     }
   }
 
-  await Promise.all([
+  const results = await Promise.allSettled([
     fs.writeFile(tooltipPath, tooltipBuffer),
     fs.writeFile(modalPath, modalBuffer),
   ]);
+
+  const writeError = results.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected"
+  );
+  if (writeError) {
+    await unlinkProjectImageFile(projectId, tooltipFilename);
+    await unlinkProjectImageFile(projectId, modalFilename);
+    throw writeError.reason;
+  }
 }
 
 function validateOriginalFilename(raw: string): string {

--- a/apps/backend/src/services/project-images.service.ts
+++ b/apps/backend/src/services/project-images.service.ts
@@ -5,6 +5,7 @@
  */
 
 import { promises as fs } from "node:fs";
+import path from "node:path";
 import { eq, asc } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { projectImages, projects } from "../db/schema/index.js";
@@ -18,6 +19,7 @@ import {
   generateProjectImageFilename,
   getProjectImageFullPath,
   getProjectImagePath,
+  getProjectImageRootDirPath,
 } from "../lib/storage.js";
 import { getBasePath } from "../lib/config.js";
 import { isUniqueConstraintViolation } from "../lib/db.js";
@@ -78,7 +80,19 @@ async function unlinkProjectImageFile(
   filename: string
 ): Promise<void> {
   try {
-    await fs.unlink(getProjectImageFullPath(projectId, filename));
+    const filePath = getProjectImageFullPath(projectId, filename);
+    {
+      const rootDir = getProjectImageRootDirPath();
+      const relative = path.relative(rootDir, filePath);
+      if (
+        relative.startsWith(".." + path.sep) ||
+        relative === ".." ||
+        path.isAbsolute(relative)
+      ) {
+        throw new ValidationError("Invalid project image path");
+      }
+    }
+    await fs.unlink(filePath);
   } catch (error) {
     if (
       !(error instanceof Error && "code" in error) ||
@@ -175,6 +189,21 @@ export async function uploadProjectImage(
 
   const tooltipPath = getProjectImageFullPath(projectId, tooltipFilename);
   const modalPath = getProjectImageFullPath(projectId, modalFilename);
+  {
+    const rootDir = getProjectImageRootDirPath();
+    const tooltipRelative = path.relative(rootDir, tooltipPath);
+    const modalRelative = path.relative(rootDir, modalPath);
+    if (
+      tooltipRelative.startsWith(".." + path.sep) ||
+      tooltipRelative === ".." ||
+      path.isAbsolute(tooltipRelative) ||
+      modalRelative.startsWith(".." + path.sep) ||
+      modalRelative === ".." ||
+      path.isAbsolute(modalRelative)
+    ) {
+      throw new ValidationError("Invalid project image path");
+    }
+  }
 
   await fs.writeFile(tooltipPath, input.tooltip.buffer);
   await fs.writeFile(modalPath, input.modal.buffer);
@@ -259,6 +288,21 @@ export async function replaceProjectImage(
     tooltipFilename
   );
   const modalPath = getProjectImageFullPath(existing.projectId, modalFilename);
+  {
+    const rootDir = getProjectImageRootDirPath();
+    const tooltipRelative = path.relative(rootDir, tooltipPath);
+    const modalRelative = path.relative(rootDir, modalPath);
+    if (
+      tooltipRelative.startsWith(".." + path.sep) ||
+      tooltipRelative === ".." ||
+      path.isAbsolute(tooltipRelative) ||
+      modalRelative.startsWith(".." + path.sep) ||
+      modalRelative === ".." ||
+      path.isAbsolute(modalRelative)
+    ) {
+      throw new ValidationError("Invalid project image path");
+    }
+  }
 
   await fs.writeFile(tooltipPath, input.tooltip.buffer);
   await fs.writeFile(modalPath, input.modal.buffer);

--- a/apps/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/apps/frontend/src/components/ProjectSettingsDialog.tsx
@@ -24,6 +24,7 @@ import {
   Route as RouteIcon,
   Wand2,
   BookText,
+  Images,
   X,
 } from "lucide-react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
@@ -34,6 +35,7 @@ import { useDirtyDialogWarning } from "@/hooks/useDirtyDialogWarning";
 import { CharacterSettingsContent } from "@/components/characters/CharacterSettingsContent";
 import { RouteSettingsContent } from "@/components/routes/RouteSettingsContent";
 import { VisualSystemFormContent } from "@/components/visual-system/VisualSystemDialog";
+import { ProjectImagesSettingsContent } from "@/components/project-images/ProjectImagesSettingsContent";
 import { WorldElementsSettingsContent } from "@/components/world-elements/WorldElementsSettingsContent";
 import { useVisualSystem } from "@/hooks/useVisualSystem";
 import { parseGroupPrefixes } from "@/components/visual-system/visual-system.helpers";
@@ -51,7 +53,8 @@ export interface ProjectSettingsDialogProps {
   defaultTab?: SettingsTab;
 }
 
-export type SettingsTab = "characters" | "routes" | "visual" | "world";
+export type SettingsTab =
+  "characters" | "routes" | "visual" | "world" | "images";
 
 // ============================================================================
 // Helpers
@@ -61,6 +64,7 @@ const TAB_LABELS: Record<SettingsTab, string> = {
   characters: "Characters",
   routes: "Routes",
   world: "World Bible",
+  images: "Images",
   visual: "Visual System",
 };
 
@@ -71,10 +75,17 @@ const TAB_ICONS: Record<
   characters: Users,
   routes: RouteIcon,
   world: BookText,
+  images: Images,
   visual: Wand2,
 };
 
-const TAB_ORDER: SettingsTab[] = ["characters", "routes", "world", "visual"];
+const TAB_ORDER: SettingsTab[] = [
+  "characters",
+  "routes",
+  "world",
+  "images",
+  "visual",
+];
 
 // ============================================================================
 // Component
@@ -140,8 +151,8 @@ export function ProjectSettingsDialog({
             <div>
               <h2 className="text-lg font-medium">Project Settings</h2>
               <p className="text-sm text-muted-foreground mt-1">
-                Configure characters, routes, visual system, and world bible
-                elements.
+                Configure characters, routes, preview images, visual system, and
+                world bible elements.
               </p>
             </div>
             <button
@@ -187,6 +198,9 @@ export function ProjectSettingsDialog({
               </TabsPanel>
               <TabsPanel value="world" className="space-y-4">
                 <WorldElementsSettingsContent projectId={projectId} />
+              </TabsPanel>
+              <TabsPanel value="images" className="space-y-4">
+                <ProjectImagesSettingsContent projectId={projectId} />
               </TabsPanel>
               <TabsPanel value="visual" className="space-y-4">
                 <VisualSystemTabContent

--- a/apps/frontend/src/components/__tests__/TechnicalPopover.test.tsx
+++ b/apps/frontend/src/components/__tests__/TechnicalPopover.test.tsx
@@ -1,9 +1,25 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
+import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
 import { TechnicalPopover } from "@/components/write-mode/TechnicalPopover";
+import { ToastProvider } from "@/contexts/ToastContext";
+import { createTestQueryClient } from "@/test/query-client";
 import type { StatCondition } from "@branchforge/shared";
+import type { ReactNode } from "react";
 
 describe("TechnicalPopover", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+  });
+
   it("renders plain English for stat conditions", () => {
     const data = {
       stats: {
@@ -17,7 +33,8 @@ describe("TechnicalPopover", () => {
         type="conditions"
         onClose={() => undefined}
         data={data}
-      />
+      />,
+      { wrapper }
     );
 
     // Check that the stat names are rendered

--- a/apps/frontend/src/components/project-images/ProjectImagesList.tsx
+++ b/apps/frontend/src/components/project-images/ProjectImagesList.tsx
@@ -1,0 +1,109 @@
+/**
+ * Project Images List
+ *
+ * Compact grid of uploaded preview images with tooltip thumbnails.
+ */
+
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import type { ProjectImage } from "@branchforge/shared";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+
+interface ProjectImagesListProps {
+  images: ProjectImage[];
+  isDeleting: boolean;
+  onDelete: (imageId: string) => void | Promise<void>;
+}
+
+export function ProjectImagesList({
+  images,
+  isDeleting,
+  onDelete,
+}: ProjectImagesListProps) {
+  const [deleteTarget, setDeleteTarget] = useState<ProjectImage | null>(null);
+  const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+
+  if (images.length === 0) {
+    return null;
+  }
+
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) {
+      return;
+    }
+
+    setIsConfirmingDelete(true);
+    try {
+      await onDelete(deleteTarget.id);
+      setDeleteTarget(null);
+    } finally {
+      setIsConfirmingDelete(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
+        {images.map((image) => (
+          <div
+            key={image.id}
+            className="relative flex flex-col gap-1.5 rounded-md border border-border/30 p-2"
+          >
+            <div className="relative aspect-square overflow-hidden rounded border border-border/30 bg-muted/20">
+              <img
+                src={image.tooltipUrl}
+                alt={`Preview for ${image.normalizedTarget}`}
+                className="size-full object-cover"
+              />
+              <Button
+                type="button"
+                variant="secondary"
+                size="icon"
+                className="absolute top-1 right-1 size-7 text-destructive hover:text-destructive bg-background/90 hover:bg-background shadow-sm"
+                disabled={isDeleting}
+                onClick={() => setDeleteTarget(image)}
+                aria-label={`Delete ${image.originalFilename}`}
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </div>
+            <div className="min-w-0 px-0.5">
+              <p
+                className="text-xs font-medium truncate"
+                title={image.originalFilename}
+              >
+                {image.originalFilename}
+              </p>
+              <p
+                className="text-[10px] leading-tight text-muted-foreground font-mono truncate"
+                title={image.normalizedTarget}
+              >
+                {image.normalizedTarget}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteTarget(null);
+          }
+        }}
+        onConfirm={handleConfirmDelete}
+        title="Delete preview image?"
+        description={
+          deleteTarget
+            ? `Remove "${deleteTarget.originalFilename}" (${deleteTarget.normalizedTarget}) from this project?`
+            : ""
+        }
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        isLoading={isConfirmingDelete}
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/components/project-images/ProjectImagesList.tsx
+++ b/apps/frontend/src/components/project-images/ProjectImagesList.tsx
@@ -2,6 +2,7 @@
  * Project Images List
  *
  * Compact grid of uploaded preview images with tooltip thumbnails.
+ * Delete confirmation dialog surfaces failures via toast.
  */
 
 import { useState } from "react";
@@ -9,6 +10,7 @@ import { Trash2 } from "lucide-react";
 import type { ProjectImage } from "@branchforge/shared";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { useToast } from "@/contexts/ToastContext";
 
 interface ProjectImagesListProps {
   images: ProjectImage[];
@@ -23,6 +25,7 @@ export function ProjectImagesList({
 }: ProjectImagesListProps) {
   const [deleteTarget, setDeleteTarget] = useState<ProjectImage | null>(null);
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+  const toast = useToast();
 
   if (images.length === 0) {
     return null;
@@ -94,6 +97,12 @@ export function ProjectImagesList({
           }
         }}
         onConfirm={handleConfirmDelete}
+        onError={(error) => {
+          toast.error(
+            `Failed to remove image: ${error instanceof Error ? error.message : "Unknown error"}`,
+            "Delete failed"
+          );
+        }}
         title="Delete preview image?"
         description={
           deleteTarget

--- a/apps/frontend/src/components/project-images/ProjectImagesSettingsContent.tsx
+++ b/apps/frontend/src/components/project-images/ProjectImagesSettingsContent.tsx
@@ -11,9 +11,9 @@ import { normalizeImageTarget } from "@branchforge/shared";
 import { InlineMessage } from "@/components/ui/inline-error";
 import { useProjectImages } from "@/hooks/useProjectImages";
 import { processProjectImageFile } from "@/lib/project-image-processing";
-import { ApiRequestError } from "@/lib/api/client";
 import { ProjectImagesList } from "./ProjectImagesList";
 import { ProjectImagesUploadZone } from "./ProjectImagesUploadZone";
+import { getProjectImageUploadErrorMessage } from "./project-image-upload-error";
 
 interface ProjectImagesSettingsContentProps {
   projectId: string;
@@ -37,21 +37,6 @@ function createQueueItem(file: File): UploadQueueItem {
     status: "pending",
     normalizedTarget: normalizeImageTarget(file.name),
   };
-}
-
-function getUploadErrorMessage(
-  error: unknown,
-  normalizedTarget: string
-): string {
-  if (error instanceof ApiRequestError && error.status === 409) {
-    return `An image for target "${normalizedTarget}" already exists. Delete the existing image or rename the file.`;
-  }
-
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return "Upload failed.";
 }
 
 function UploadQueueRow({ item }: { item: UploadQueueItem }) {
@@ -96,6 +81,8 @@ function UploadQueueRow({ item }: { item: UploadQueueItem }) {
     </div>
   );
 }
+
+const CONFLICT_HINT = "Delete the existing image or rename the file.";
 
 export function ProjectImagesSettingsContent({
   projectId,
@@ -143,7 +130,11 @@ export function ProjectImagesSettingsContent({
           } catch (error) {
             updateQueueItem(item.id, {
               status: "error",
-              error: getUploadErrorMessage(error, item.normalizedTarget),
+              error: getProjectImageUploadErrorMessage(
+                error,
+                item.normalizedTarget,
+                CONFLICT_HINT
+              ),
             });
           }
         })
@@ -153,11 +144,9 @@ export function ProjectImagesSettingsContent({
   );
 
   const handleDelete = async (imageId: string) => {
-    try {
-      await deleteImage(imageId);
-    } catch {
-      // Error handled by hook toast
-    }
+    // Suppress hook toast — ConfirmDialog.onError in ProjectImagesList
+    // surfaces the failure with a clear message and keeps the dialog open.
+    await deleteImage(imageId, { showErrorToast: false });
   };
 
   const isBusy = isUploadingImage || isDeletingImage;

--- a/apps/frontend/src/components/project-images/ProjectImagesSettingsContent.tsx
+++ b/apps/frontend/src/components/project-images/ProjectImagesSettingsContent.tsx
@@ -1,0 +1,238 @@
+/**
+ * Project Images Settings Content
+ *
+ * Body of the "Images" tab in Project Settings. Supports bulk upload,
+ * per-file progress/errors, and listing/deleting existing preview images.
+ */
+
+import { useCallback, useState } from "react";
+import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
+import { normalizeImageTarget } from "@branchforge/shared";
+import { InlineMessage } from "@/components/ui/inline-error";
+import { useProjectImages } from "@/hooks/useProjectImages";
+import { processProjectImageFile } from "@/lib/project-image-processing";
+import { ApiRequestError } from "@/lib/api/client";
+import { ProjectImagesList } from "./ProjectImagesList";
+import { ProjectImagesUploadZone } from "./ProjectImagesUploadZone";
+
+interface ProjectImagesSettingsContentProps {
+  projectId: string;
+}
+
+type UploadQueueStatus =
+  "pending" | "processing" | "uploading" | "success" | "error";
+
+interface UploadQueueItem {
+  id: string;
+  file: File;
+  status: UploadQueueStatus;
+  normalizedTarget: string;
+  error?: string;
+}
+
+function createQueueItem(file: File): UploadQueueItem {
+  return {
+    id: `${file.name}-${file.size}-${file.lastModified}-${crypto.randomUUID()}`,
+    file,
+    status: "pending",
+    normalizedTarget: normalizeImageTarget(file.name),
+  };
+}
+
+function getUploadErrorMessage(
+  error: unknown,
+  normalizedTarget: string
+): string {
+  if (error instanceof ApiRequestError && error.status === 409) {
+    return `An image for target "${normalizedTarget}" already exists. Delete the existing image or rename the file.`;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Upload failed.";
+}
+
+function UploadQueueRow({ item }: { item: UploadQueueItem }) {
+  const statusLabel =
+    item.status === "pending"
+      ? "Waiting"
+      : item.status === "processing"
+        ? "Resizing"
+        : item.status === "uploading"
+          ? "Uploading"
+          : item.status === "success"
+            ? "Uploaded"
+            : "Failed";
+
+  return (
+    <div className="flex items-start gap-3 rounded-md border border-border/30 p-3">
+      <div className="mt-0.5 shrink-0">
+        {item.status === "success" ? (
+          <CheckCircle2 className="size-4 text-green-600 dark:text-green-400" />
+        ) : item.status === "error" ? (
+          <AlertCircle className="size-4 text-destructive" />
+        ) : (
+          <Loader2 className="size-4 animate-spin text-muted-foreground" />
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-sm font-medium truncate">{item.file.name}</p>
+          <span className="text-xs text-muted-foreground shrink-0">
+            {statusLabel}
+          </span>
+        </div>
+        {item.normalizedTarget ? (
+          <p className="text-xs text-muted-foreground font-mono truncate">
+            {item.normalizedTarget}
+          </p>
+        ) : null}
+        {item.error ? (
+          <p className="text-xs text-destructive mt-1">{item.error}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function ProjectImagesSettingsContent({
+  projectId,
+}: ProjectImagesSettingsContentProps) {
+  const {
+    images,
+    isLoadingImages,
+    imagesError,
+    isUploadingImage,
+    isDeletingImage,
+    uploadProcessedImage,
+    deleteImage,
+  } = useProjectImages(projectId);
+  const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([]);
+
+  const updateQueueItem = useCallback(
+    (id: string, patch: Partial<UploadQueueItem>) => {
+      setUploadQueue((current) =>
+        current.map((item) => (item.id === id ? { ...item, ...patch } : item))
+      );
+    },
+    []
+  );
+  const handleFilesSelected = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) {
+        return;
+      }
+
+      const queueItems = files.map(createQueueItem);
+      setUploadQueue((current) => [...queueItems, ...current]);
+
+      await Promise.all(
+        queueItems.map(async (item) => {
+          updateQueueItem(item.id, { status: "processing" });
+
+          try {
+            const processed = await processProjectImageFile(item.file);
+            updateQueueItem(item.id, { status: "uploading" });
+            await uploadProcessedImage(processed, {
+              showSuccessToast: false,
+              showErrorToast: false,
+            });
+            updateQueueItem(item.id, { status: "success" });
+          } catch (error) {
+            updateQueueItem(item.id, {
+              status: "error",
+              error: getUploadErrorMessage(error, item.normalizedTarget),
+            });
+          }
+        })
+      );
+    },
+    [updateQueueItem, uploadProcessedImage]
+  );
+
+  const handleDelete = async (imageId: string) => {
+    try {
+      await deleteImage(imageId);
+    } catch {
+      // Error handled by hook toast
+    }
+  };
+
+  const isBusy = isUploadingImage || isDeletingImage;
+  const activeUploads = uploadQueue.filter(
+    (item) =>
+      item.status === "pending" ||
+      item.status === "processing" ||
+      item.status === "uploading"
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <div>
+          <h3 className="text-sm font-medium">Upload preview images</h3>
+          <p className="text-sm text-muted-foreground">
+            Images are resized client-side before upload. Match filenames to
+            scene, show, and hide targets in your script.
+          </p>
+        </div>
+        <ProjectImagesUploadZone
+          disabled={isBusy}
+          onFilesSelected={handleFilesSelected}
+        />
+      </div>
+
+      {uploadQueue.length > 0 ? (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <h3 className="text-sm font-medium">Upload progress</h3>
+            {activeUploads.length === 0 ? (
+              <button
+                type="button"
+                className="text-xs text-muted-foreground hover:text-foreground"
+                onClick={() => setUploadQueue([])}
+              >
+                Clear
+              </button>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            {uploadQueue.map((item) => (
+              <UploadQueueRow key={item.id} item={item} />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="space-y-3">
+        <h3 className="text-sm font-medium">Uploaded images</h3>
+        {isLoadingImages ? (
+          <div className="flex items-center justify-center py-8">
+            <output>
+              <Loader2 className="size-6 animate-spin text-muted-foreground" />
+            </output>
+          </div>
+        ) : imagesError ? (
+          <InlineMessage variant="error">
+            Failed to load project images
+          </InlineMessage>
+        ) : images.length === 0 ? (
+          <div className="p-8 border border-dashed border-border/30 rounded-md text-center">
+            <p className="text-sm text-muted-foreground">
+              No preview images yet. Upload images to match visual statement
+              targets in Write and Script modes.
+            </p>
+          </div>
+        ) : (
+          <ProjectImagesList
+            images={images}
+            isDeleting={isDeletingImage}
+            onDelete={handleDelete}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/project-images/ProjectImagesUploadZone.tsx
+++ b/apps/frontend/src/components/project-images/ProjectImagesUploadZone.tsx
@@ -1,0 +1,100 @@
+/**
+ * Project Images Upload Zone
+ *
+ * Multi-file drag-and-drop and browse UI for preview image uploads.
+ */
+
+import { useRef } from "react";
+import { Upload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  isValidProjectImageMimeType,
+  PROJECT_IMAGE_ALLOWED_MIME_TYPES,
+  PROJECT_IMAGE_MAX_SIZE_MB,
+} from "@branchforge/shared";
+
+const ACCEPT = PROJECT_IMAGE_ALLOWED_MIME_TYPES.join(",");
+
+interface ProjectImagesUploadZoneProps {
+  disabled?: boolean;
+  onFilesSelected: (files: File[]) => void;
+}
+
+export function ProjectImagesUploadZone({
+  disabled = false,
+  onFilesSelected,
+}: ProjectImagesUploadZoneProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = (fileList: FileList | null) => {
+    if (!fileList || fileList.length === 0) {
+      return;
+    }
+
+    const accepted = Array.from(fileList).filter((file) =>
+      isValidProjectImageMimeType(file.type)
+    );
+
+    if (accepted.length === 0) {
+      return;
+    }
+
+    onFilesSelected(accepted);
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    if (disabled) {
+      return;
+    }
+
+    handleFiles(event.dataTransfer.files);
+  };
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  };
+
+  return (
+    <div
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
+      className="border-2 border-dashed rounded-lg p-6 text-center transition-colors border-border/30 hover:border-border/60 hover:bg-muted/50"
+    >
+      <div className="space-y-3">
+        <Upload className="size-10 mx-auto text-muted-foreground" />
+        <div>
+          <p className="font-medium">Drop preview images here</p>
+          <p className="text-sm text-muted-foreground">
+            PNG, JPEG, or WebP up to {PROJECT_IMAGE_MAX_SIZE_MB}MB each
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={disabled}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          Browse Files
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPT}
+          multiple
+          onChange={(event) => {
+            handleFiles(event.target.files);
+            event.target.value = "";
+          }}
+          className="hidden"
+          disabled={disabled}
+          aria-label="Upload preview images"
+        />
+        <p className="text-xs text-muted-foreground">
+          Filenames are normalized to match scene/show/hide targets (for
+          example, eileen_happy.png becomes eileen_happy).
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/project-images/ProjectImagesUploadZone.tsx
+++ b/apps/frontend/src/components/project-images/ProjectImagesUploadZone.tsx
@@ -2,6 +2,7 @@
  * Project Images Upload Zone
  *
  * Multi-file drag-and-drop and browse UI for preview image uploads.
+ * Filters files by MIME type and size client-side, toasting rejections.
  */
 
 import { useRef } from "react";
@@ -10,10 +11,16 @@ import { Button } from "@/components/ui/button";
 import {
   isValidProjectImageMimeType,
   PROJECT_IMAGE_ALLOWED_MIME_TYPES,
+  PROJECT_IMAGE_MAX_SIZE,
   PROJECT_IMAGE_MAX_SIZE_MB,
 } from "@branchforge/shared";
+import { useToast } from "@/contexts/ToastContext";
 
 const ACCEPT = PROJECT_IMAGE_ALLOWED_MIME_TYPES.join(",");
+
+const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+  event.preventDefault();
+};
 
 interface ProjectImagesUploadZoneProps {
   disabled?: boolean;
@@ -25,21 +32,39 @@ export function ProjectImagesUploadZone({
   onFilesSelected,
 }: ProjectImagesUploadZoneProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const toast = useToast();
 
   const handleFiles = (fileList: FileList | null) => {
     if (!fileList || fileList.length === 0) {
       return;
     }
 
-    const accepted = Array.from(fileList).filter((file) =>
-      isValidProjectImageMimeType(file.type)
-    );
+    const accepted: File[] = [];
+    const rejected: { file: File; reason: string }[] = [];
 
-    if (accepted.length === 0) {
-      return;
+    for (const file of Array.from(fileList)) {
+      if (!isValidProjectImageMimeType(file.type)) {
+        rejected.push({
+          file,
+          reason: `${file.name}: Unsupported file type. Use JPEG, PNG, or WebP.`,
+        });
+      } else if (file.size > PROJECT_IMAGE_MAX_SIZE) {
+        rejected.push({
+          file,
+          reason: `${file.name}: File exceeds the ${PROJECT_IMAGE_MAX_SIZE_MB}MB size limit.`,
+        });
+      } else {
+        accepted.push(file);
+      }
     }
 
-    onFilesSelected(accepted);
+    for (const { reason } of rejected) {
+      toast.error(reason, "File rejected");
+    }
+
+    if (accepted.length > 0) {
+      onFilesSelected(accepted);
+    }
   };
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
@@ -49,10 +74,6 @@ export function ProjectImagesUploadZone({
     }
 
     handleFiles(event.dataTransfer.files);
-  };
-
-  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
   };
 
   return (

--- a/apps/frontend/src/components/project-images/VisualPreviewModal.tsx
+++ b/apps/frontend/src/components/project-images/VisualPreviewModal.tsx
@@ -17,10 +17,11 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { InlineMessage } from "@/components/ui/inline-error";
-import { ApiRequestError } from "@/lib/api/client";
 import { useVisualPreviewLookup } from "@/hooks/useVisualPreviewLookup";
+import { getProjectImageUploadErrorMessage } from "./project-image-upload-error";
 
 const ACCEPT = PROJECT_IMAGE_ALLOWED_MIME_TYPES.join(",");
+const CONFLICT_HINT = "Use Replace, or delete it first.";
 
 export interface VisualPreviewSelection {
   statementType: string;
@@ -32,18 +33,6 @@ interface VisualPreviewModalProps {
   onOpenChange: (open: boolean) => void;
   projectId: string | null | undefined;
   selection: VisualPreviewSelection | null;
-}
-
-function getUploadErrorMessage(error: unknown, target: string): string {
-  if (error instanceof ApiRequestError && error.status === 409) {
-    return `An image for "${target}" already exists. Use Replace, or delete it first.`;
-  }
-
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return "Upload failed.";
 }
 
 export function VisualPreviewModal({
@@ -93,7 +82,13 @@ export function VisualPreviewModal({
       }
       handleOpenChange(false);
     } catch (error) {
-      setUploadError(getUploadErrorMessage(error, selection.target));
+      setUploadError(
+        getProjectImageUploadErrorMessage(
+          error,
+          selection.target,
+          CONFLICT_HINT
+        )
+      );
     } finally {
       if (fileInputRef.current) {
         fileInputRef.current.value = "";

--- a/apps/frontend/src/components/project-images/VisualPreviewModal.tsx
+++ b/apps/frontend/src/components/project-images/VisualPreviewModal.tsx
@@ -1,0 +1,235 @@
+/**
+ * Shared modal for visual statement preview images (Write + Script modes).
+ */
+
+import { useRef, useState } from "react";
+import { ImageIcon, Loader2, Trash2, Upload } from "lucide-react";
+import {
+  PROJECT_IMAGE_ALLOWED_MIME_TYPES,
+  PROJECT_IMAGE_MODAL_SIZE,
+} from "@branchforge/shared";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { InlineMessage } from "@/components/ui/inline-error";
+import { ApiRequestError } from "@/lib/api/client";
+import { useVisualPreviewLookup } from "@/hooks/useVisualPreviewLookup";
+
+const ACCEPT = PROJECT_IMAGE_ALLOWED_MIME_TYPES.join(",");
+
+export interface VisualPreviewSelection {
+  statementType: string;
+  target: string;
+}
+
+interface VisualPreviewModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string | null | undefined;
+  selection: VisualPreviewSelection | null;
+}
+
+function getUploadErrorMessage(error: unknown, target: string): string {
+  if (error instanceof ApiRequestError && error.status === 409) {
+    return `An image for "${target}" already exists. Use Replace, or delete it first.`;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Upload failed.";
+}
+
+export function VisualPreviewModal({
+  open,
+  onOpenChange,
+  projectId,
+  selection,
+}: VisualPreviewModalProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const {
+    getImageForTarget,
+    uploadImage,
+    replaceImage,
+    deleteImage,
+    isUploadingImage,
+    isDeletingImage,
+  } = useVisualPreviewLookup(projectId, { enabled: open && !!projectId });
+
+  const image =
+    selection && selection.target
+      ? getImageForTarget(selection.target)
+      : undefined;
+
+  const isBusy = isUploadingImage || isDeletingImage;
+  const statementLabel = selection?.statementType?.toLowerCase() ?? "visual";
+  const target = selection?.target ?? "";
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setUploadError(null);
+    }
+    onOpenChange(nextOpen);
+  };
+  const handleFileSelected = async (fileList: FileList | null) => {
+    if (!fileList || fileList.length === 0 || !selection?.target) {
+      return;
+    }
+
+    setUploadError(null);
+
+    try {
+      if (image) {
+        await replaceImage(image.id, fileList[0], selection.target);
+      } else {
+        await uploadImage(fileList[0], selection.target);
+      }
+      handleOpenChange(false);
+    } catch (error) {
+      setUploadError(getUploadErrorMessage(error, selection.target));
+    } finally {
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!image) {
+      return;
+    }
+
+    setUploadError(null);
+
+    try {
+      await deleteImage(image.id);
+      handleOpenChange(false);
+    } catch {
+      // Toast handled by hook
+    }
+  };
+
+  const handleReplace = () => {
+    setUploadError(null);
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-3xl w-full">
+        <DialogHeader>
+          <DialogTitle>Visual preview</DialogTitle>
+          <DialogDescription>
+            {selection ? (
+              <>
+                <span className="capitalize">{statementLabel}</span>
+                {target ? (
+                  <>
+                    {" "}
+                    <span className="font-mono text-foreground">{target}</span>
+                  </>
+                ) : null}
+              </>
+            ) : (
+              "Preview image for a visual statement"
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {image ? (
+            <div className="flex justify-center">
+              <img
+                src={image.modalUrl}
+                alt={`Preview for ${target}`}
+                className="max-h-[min(70vh,800px)] w-auto max-w-full rounded-md border border-border/40 object-contain"
+                style={{ maxWidth: PROJECT_IMAGE_MODAL_SIZE }}
+              />
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border/40 bg-muted/20 px-6 py-10 text-center">
+              <ImageIcon className="size-10 text-muted-foreground" />
+              <div className="space-y-1">
+                <p className="text-sm font-medium">No preview image linked</p>
+                <p className="text-sm text-muted-foreground">
+                  Upload an image whose filename matches this target (for
+                  example,{" "}
+                  <span className="font-mono">
+                    {target || "eileen_happy"}.png
+                  </span>
+                  ).
+                </p>
+              </div>
+              <Button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isBusy || !projectId || !target}
+              >
+                {isUploadingImage ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Upload className="size-4" />
+                )}
+                Upload preview image
+              </Button>
+            </div>
+          )}
+
+          {uploadError ? (
+            <InlineMessage variant="error">{uploadError}</InlineMessage>
+          ) : null}
+
+          {image ? (
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleReplace}
+                disabled={isBusy}
+              >
+                {isUploadingImage ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Upload className="size-4" />
+                )}
+                Replace
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={handleDelete}
+                disabled={isBusy}
+              >
+                {isDeletingImage ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Trash2 className="size-4" />
+                )}
+                Delete
+              </Button>
+            </div>
+          ) : null}
+        </div>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPT}
+          className="hidden"
+          disabled={isBusy || !projectId}
+          aria-label="Upload visual preview image"
+          onChange={(event) => {
+            void handleFileSelected(event.target.files);
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/project-images/VisualPreviewRow.tsx
+++ b/apps/frontend/src/components/project-images/VisualPreviewRow.tsx
@@ -1,0 +1,85 @@
+/**
+ * Visual preview row for TechnicalPopover visuals list.
+ */
+
+import {
+  PROJECT_IMAGE_TOOLTIP_SIZE,
+  type ProjectImage,
+} from "@branchforge/shared";
+import { Tooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+export interface VisualPreviewRowData {
+  type: string;
+  target: string;
+}
+
+interface VisualPreviewRowProps {
+  visual: VisualPreviewRowData;
+  image?: ProjectImage;
+  onOpenPreview: (visual: VisualPreviewRowData) => void;
+}
+
+export function VisualPreviewRow({
+  visual,
+  image,
+  onOpenPreview,
+}: VisualPreviewRowProps) {
+  const hasPreview = Boolean(image?.tooltipUrl);
+
+  const rowButton = (
+    <button
+      type="button"
+      className={cn(
+        "flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left transition-colors",
+        "hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      )}
+      onClick={() => onOpenPreview(visual)}
+      aria-label={
+        hasPreview
+          ? `Open preview for ${visual.type} ${visual.target}`
+          : `Upload preview for ${visual.type} ${visual.target}`
+      }
+    >
+      <span
+        className={cn(
+          "size-1.5 shrink-0 rounded-full",
+          hasPreview ? "bg-primary/80" : "bg-transparent"
+        )}
+        aria-hidden="true"
+      />
+      <span>{visual.type}</span>
+      {visual.target ? (
+        <span className="font-mono text-foreground">{visual.target}</span>
+      ) : null}
+    </button>
+  );
+
+  if (!hasPreview || !image) {
+    return <li>{rowButton}</li>;
+  }
+
+  return (
+    <li>
+      <Tooltip
+        content={
+          <img
+            src={image.tooltipUrl}
+            alt=""
+            className="rounded object-contain"
+            style={{
+              width: PROJECT_IMAGE_TOOLTIP_SIZE,
+              height: PROJECT_IMAGE_TOOLTIP_SIZE,
+              maxWidth: PROJECT_IMAGE_TOOLTIP_SIZE,
+              maxHeight: PROJECT_IMAGE_TOOLTIP_SIZE,
+            }}
+          />
+        }
+        side="bottom"
+        className="p-1"
+      >
+        {rowButton}
+      </Tooltip>
+    </li>
+  );
+}

--- a/apps/frontend/src/components/project-images/project-image-upload-error.ts
+++ b/apps/frontend/src/components/project-images/project-image-upload-error.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared upload error helper for project image uploads.
+ *
+ * Parameterized by conflict-hint text so each caller can provide
+ * the appropriate user-facing instructions for 409 conflicts.
+ */
+
+import { ApiRequestError } from "@/lib/api/client";
+
+export function getProjectImageUploadErrorMessage(
+  error: unknown,
+  target: string,
+  conflictHint: string
+): string {
+  if (error instanceof ApiRequestError && error.status === 409) {
+    return `An image for "${target}" already exists. ${conflictHint}`;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Upload failed.";
+}

--- a/apps/frontend/src/components/script-mode/ScriptEditor.lazy.tsx
+++ b/apps/frontend/src/components/script-mode/ScriptEditor.lazy.tsx
@@ -34,9 +34,11 @@ interface ScriptEditorProps {
   /** Controlled line wrap mode. When provided, overrides internal state. */
   lineWrap?: boolean;
   onLineWrapChange?: (wrap: boolean) => void;
-  /** Controlled label titles visibility. When provided, overrides internal state. */
-  showLabelTitles?: boolean;
-  onShowLabelTitlesChange?: (show: boolean) => void;
+  /** Controlled overlays visibility (label titles + image hover previews). When provided, overrides internal state. */
+  showOverlays?: boolean;
+  onShowOverlaysChange?: (show: boolean) => void;
+  /** Project ID for visual statement preview images */
+  projectId?: string | null;
   ref?: React.Ref<ScriptEditorRef>;
 }
 

--- a/apps/frontend/src/components/script-mode/ScriptEditor/ScriptEditor.tsx
+++ b/apps/frontend/src/components/script-mode/ScriptEditor/ScriptEditor.tsx
@@ -1,5 +1,12 @@
 import CodeMirror from "@uiw/react-codemirror";
-import { useMemo, useCallback, useImperativeHandle, useEffect } from "react";
+import {
+  useMemo,
+  useCallback,
+  useImperativeHandle,
+  useEffect,
+  useState,
+  useRef,
+} from "react";
 import type React from "react";
 // react-doctor-disable-next-line react-doctor/prefer-dynamic-import
 import { EditorView } from "@codemirror/view";
@@ -16,6 +23,16 @@ import {
   setLabelTitlesEffect,
   type LabelTitleMap,
 } from "@/lib/codemirror/label-title-decoration";
+import {
+  visualPreviewExtension,
+  setVisualPreviewHandlersEffect,
+  type ParsedVisualStatement,
+} from "@/lib/codemirror/visual-preview-decoration";
+import {
+  VisualPreviewModal,
+  type VisualPreviewSelection,
+} from "@/components/project-images/VisualPreviewModal";
+import { useVisualPreviewLookup } from "@/hooks/useVisualPreviewLookup";
 import { useLocalStorageBoolean } from "@/hooks/useLocalStorage";
 import type { SaveStatus } from "@/hooks/useAutosave";
 import { createHighlightExtension } from "./ScriptEditorHighlight";
@@ -39,9 +56,11 @@ interface ScriptEditorProps {
   /** Controlled line wrap mode. When provided, overrides internal state. */
   lineWrap?: boolean;
   onLineWrapChange?: (wrap: boolean) => void;
-  /** Controlled label titles visibility. When provided, overrides internal state. */
-  showLabelTitles?: boolean;
-  onShowLabelTitlesChange?: (show: boolean) => void;
+  /** Controlled overlays visibility (label titles + image hover previews). When provided, overrides internal state. */
+  showOverlays?: boolean;
+  onShowOverlaysChange?: (show: boolean) => void;
+  /** Project ID for visual statement preview images */
+  projectId?: string | null;
 }
 
 export const ScriptEditor = function ScriptEditor({
@@ -56,8 +75,9 @@ export const ScriptEditor = function ScriptEditor({
   labelTitles,
   lineWrap: propsLineWrap,
   onLineWrapChange,
-  showLabelTitles: propsShowLabelTitles,
-  onShowLabelTitlesChange,
+  showOverlays: propsShowOverlays,
+  onShowOverlaysChange,
+  projectId,
   ref,
 }: ScriptEditorProps & { ref?: React.Ref<ScriptEditorRef> }) {
   const [internalLineWrap, setInternalLineWrap] = useLocalStorageBoolean(
@@ -73,27 +93,86 @@ export const ScriptEditor = function ScriptEditor({
 
   const cleanContent = useMemo(() => stripBOM(content), [content]);
 
-  const [internalShowLabelTitles, setInternalShowLabelTitles] =
+  const [internalShowOverlays, setInternalShowOverlays] =
     useLocalStorageBoolean("script:show-label-titles", true);
-  const showLabelTitles = propsShowLabelTitles ?? internalShowLabelTitles;
-  const setShowLabelTitles =
-    onShowLabelTitlesChange ?? setInternalShowLabelTitles;
+  const showOverlays = propsShowOverlays ?? internalShowOverlays;
+  const setShowOverlays = onShowOverlaysChange ?? setInternalShowOverlays;
 
-  // Create the highlight extension (only once)
+  const [previewSelection, setPreviewSelection] =
+    useState<VisualPreviewSelection | null>(null);
+  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
+
+  const { getImageForTarget } = useVisualPreviewLookup(projectId, {
+    enabled: !!projectId,
+  });
+
+  const openVisualPreview = useCallback((parsed: ParsedVisualStatement) => {
+    setPreviewSelection({
+      statementType: parsed.type,
+      target: parsed.target,
+    });
+    setIsPreviewModalOpen(true);
+  }, []);
+
+  // Keep latest handlers in refs so we can dispatch them on editor create
+  // (useEffect often runs while the lazy ScriptEditor fallback is still showing).
+  const getImageForTargetRef = useRef(getImageForTarget);
+  const openVisualPreviewRef = useRef(openVisualPreview);
+  const hoverPreviewsEnabledRef = useRef(showOverlays);
+  useEffect(() => {
+    getImageForTargetRef.current = getImageForTarget;
+  });
+  useEffect(() => {
+    openVisualPreviewRef.current = openVisualPreview;
+  });
+  useEffect(() => {
+    hoverPreviewsEnabledRef.current = showOverlays;
+  });
+
   const { highlightStateField, setHighlightEffect } = useMemo(
     () => createHighlightExtension(),
     []
   );
 
-  // Editor controller (scroll, highlight, font-size listener)
   const { editorViewRef, handleCreateEditor } = useScriptEditorController({
     scrollToLine,
     labelTitles,
-    showLabelTitles,
+    showOverlays,
     setHighlightEffect,
   });
 
-  // Expose focus method to parent via ref
+  const dispatchVisualPreviewHandlers = useCallback(
+    (view: EditorView) => {
+      if (!projectId) {
+        return;
+      }
+
+      view.dispatch({
+        effects: [
+          setVisualPreviewHandlersEffect.of({
+            getImageForTarget: (target) => {
+              const image = getImageForTargetRef.current(target);
+              return image ? { tooltipUrl: image.tooltipUrl } : undefined;
+            },
+            onOpenPreview: (parsed) => {
+              openVisualPreviewRef.current(parsed);
+            },
+            hoverPreviewsEnabled: hoverPreviewsEnabledRef.current,
+          }),
+        ],
+      });
+    },
+    [projectId]
+  );
+
+  const handleCreateEditorWithPreviews = useCallback(
+    (view: EditorView) => {
+      handleCreateEditor(view);
+      dispatchVisualPreviewHandlers(view);
+    },
+    [handleCreateEditor, dispatchVisualPreviewHandlers]
+  );
+
   useImperativeHandle(
     ref,
     () => ({
@@ -122,27 +201,38 @@ export const ScriptEditor = function ScriptEditor({
         updateListener,
         highlightStateField,
         labelTitleExtension,
-        // Explicitly add search extension with default configuration
+        projectId ? visualPreviewExtension : [],
         search({}),
-        // Highlight matches of the current selection
         highlightSelectionMatches(),
       ].flat(),
-    [lineWrapExtension, updateListener, highlightStateField]
+    [lineWrapExtension, updateListener, highlightStateField, projectId]
   );
 
-  // Dispatch label title updates when the map changes or visibility toggles
   useEffect(() => {
     const view = editorViewRef.current;
     if (view) {
       view.dispatch({
         effects: [
           setLabelTitlesEffect.of(
-            showLabelTitles && labelTitles ? labelTitles : new Map()
+            showOverlays && labelTitles ? labelTitles : new Map()
           ),
         ],
       });
     }
-  }, [editorViewRef, labelTitles, showLabelTitles]);
+  }, [editorViewRef, labelTitles, showOverlays]);
+
+  useEffect(() => {
+    const view = editorViewRef.current;
+    if (!view) {
+      return;
+    }
+    dispatchVisualPreviewHandlers(view);
+  }, [
+    editorViewRef,
+    dispatchVisualPreviewHandlers,
+    getImageForTarget,
+    showOverlays,
+  ]);
 
   return (
     <div className="h-full w-full overflow-hidden min-h-0 min-w-0 flex flex-col">
@@ -154,7 +244,7 @@ export const ScriptEditor = function ScriptEditor({
           editable={!readOnly}
           extensions={extensions}
           onChange={onChange}
-          onCreateEditor={handleCreateEditor}
+          onCreateEditor={handleCreateEditorWithPreviews}
           basicSetup={{
             lineNumbers: true,
             highlightActiveLine: true,
@@ -163,7 +253,6 @@ export const ScriptEditor = function ScriptEditor({
             bracketMatching: true,
             closeBrackets: true,
             autocompletion: false,
-            // searchKeymap is removed since we add search extension explicitly
           }}
         />
       </div>
@@ -171,14 +260,20 @@ export const ScriptEditor = function ScriptEditor({
         isFocusMode={isFocusMode}
         lineWrap={lineWrap}
         toggleLineWrap={toggleLineWrap}
-        showLabelTitles={showLabelTitles}
-        setShowLabelTitles={setShowLabelTitles}
+        showOverlays={showOverlays}
+        setShowOverlays={setShowOverlays}
         saveStatus={saveStatus}
         saveConflict={saveConflict}
         onSaveRequest={onSaveRequest}
         cursorPosition={cursorPosition}
         selectionInfo={selectionInfo}
         totalLines={totalLines}
+      />
+      <VisualPreviewModal
+        open={isPreviewModalOpen}
+        onOpenChange={setIsPreviewModalOpen}
+        projectId={projectId}
+        selection={previewSelection}
       />
     </div>
   );

--- a/apps/frontend/src/components/script-mode/ScriptEditor/ScriptEditorToolbar.tsx
+++ b/apps/frontend/src/components/script-mode/ScriptEditor/ScriptEditorToolbar.tsx
@@ -10,8 +10,8 @@ interface ScriptEditorToolbarProps {
   isFocusMode: boolean;
   lineWrap: boolean;
   toggleLineWrap: () => void;
-  showLabelTitles: boolean;
-  setShowLabelTitles: (show: boolean) => void;
+  showOverlays: boolean;
+  setShowOverlays: (show: boolean) => void;
   saveStatus?: SaveStatus;
   saveConflict?: boolean;
   onSaveRequest?: () => void;
@@ -24,8 +24,8 @@ export function ScriptEditorToolbar({
   isFocusMode,
   lineWrap,
   toggleLineWrap,
-  showLabelTitles,
-  setShowLabelTitles,
+  showOverlays,
+  setShowOverlays,
   saveStatus,
   saveConflict,
   onSaveRequest,
@@ -52,21 +52,25 @@ export function ScriptEditorToolbar({
         <PaletteSwitcher />
         <button
           type="button"
-          onClick={() => setShowLabelTitles(!showLabelTitles)}
-          aria-pressed={showLabelTitles}
+          onClick={() => setShowOverlays(!showOverlays)}
+          aria-pressed={showOverlays}
           className={`px-3 py-1.5 text-xs font-code border rounded flex items-center gap-2 transition-colors ${
-            showLabelTitles
+            showOverlays
               ? "bg-accent/50 hover:bg-accent border-border"
               : "bg-muted/50 hover:bg-muted border-border"
           }`}
-          title={showLabelTitles ? "Hide label titles" : "Show label titles"}
+          title={
+            showOverlays
+              ? "Hide overlays (label titles + image hover previews)"
+              : "Show overlays (label titles + image hover previews)"
+          }
         >
-          {showLabelTitles ? (
+          {showOverlays ? (
             <Eye className="size-3" />
           ) : (
             <EyeOff className="size-3" />
           )}
-          <span>Titles: {showLabelTitles ? "On" : "Off"}</span>
+          <span>Overlays: {showOverlays ? "On" : "Off"}</span>
         </button>
       </div>
       <div className="flex items-center gap-3">

--- a/apps/frontend/src/components/script-mode/ScriptEditor/useScriptEditorController.ts
+++ b/apps/frontend/src/components/script-mode/ScriptEditor/useScriptEditorController.ts
@@ -16,14 +16,14 @@ import { EDITOR_FONT_SIZE_CHANGED } from "../../FontSizeSwitcher";
 interface UseScriptEditorControllerOptions {
   scrollToLine: number | null | undefined;
   labelTitles: LabelTitleMap | undefined;
-  showLabelTitles: boolean;
+  showOverlays: boolean;
   setHighlightEffect: StateEffectType<number | null>;
 }
 
 export function useScriptEditorController({
   scrollToLine,
   labelTitles,
-  showLabelTitles,
+  showOverlays,
   setHighlightEffect,
 }: UseScriptEditorControllerOptions) {
   const hasScrolled = useRef(false);
@@ -45,9 +45,9 @@ export function useScriptEditorController({
   useEffect(() => {
     labelTitlesRef.current = labelTitles;
   });
-  const showLabelTitlesRef = useRef(showLabelTitles);
+  const showOverlaysRef = useRef(showOverlays);
   useEffect(() => {
-    showLabelTitlesRef.current = showLabelTitles;
+    showOverlaysRef.current = showOverlays;
   });
 
   // Track previous scrollToLine to detect changes
@@ -158,11 +158,7 @@ export function useScriptEditorController({
       // Dispatch label titles on initial mount (effect fires while
       // lazy-loaded fallback is still showing, so ref wasn't set yet)
       const currentTitles = labelTitlesRef.current;
-      if (
-        currentTitles &&
-        currentTitles.size > 0 &&
-        showLabelTitlesRef.current
-      ) {
+      if (currentTitles && currentTitles.size > 0 && showOverlaysRef.current) {
         view.dispatch({
           effects: [setLabelTitlesEffect.of(currentTitles)],
         });

--- a/apps/frontend/src/components/write-mode/TechnicalBadgeRow.tsx
+++ b/apps/frontend/src/components/write-mode/TechnicalBadgeRow.tsx
@@ -1,6 +1,12 @@
+import { useCallback, useState } from "react";
 import { TechnicalBadge } from "./TechnicalBadge";
 import { TechnicalPopover } from "./TechnicalPopover";
 import type { DialogueEntry } from "@/lib/prose-types";
+import { useProject } from "@/hooks/useProject";
+import {
+  VisualPreviewModal,
+  type VisualPreviewSelection,
+} from "@/components/project-images/VisualPreviewModal";
 
 type PopoverType = "conditions" | "jump" | "visuals" | "menu" | null;
 
@@ -21,100 +27,135 @@ export function TechnicalBadgeRow({
   popoverType,
   setPopoverType,
 }: TechnicalBadgeRowProps) {
-  if (
-    !showBadges ||
-    !technicalInfo ||
-    (!technicalInfo.choices &&
-      !technicalInfo.conditions &&
-      !technicalInfo.jumpTarget &&
-      !(technicalInfo.visuals && technicalInfo.visuals.length > 0))
-  ) {
+  const { currentProject } = useProject();
+  const [previewSelection, setPreviewSelection] =
+    useState<VisualPreviewSelection | null>(null);
+  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
+
+  const handleOpenVisualPreview = useCallback(
+    (selection: VisualPreviewSelection) => {
+      setPreviewSelection(selection);
+      setIsPreviewModalOpen(true);
+      // Close the popover so its outside-click handler cannot unmount the modal
+      // (native <dialog> is outside the popover DOM tree).
+      setPopoverType(null);
+    },
+    [setPopoverType]
+  );
+
+  const hasTechnicalContent = Boolean(
+    technicalInfo &&
+    (technicalInfo.choices ||
+      technicalInfo.conditions ||
+      technicalInfo.jumpTarget ||
+      (technicalInfo.visuals && technicalInfo.visuals.length > 0))
+  );
+  const showBadgeUi = Boolean(showBadges && hasTechnicalContent);
+
+  // Keep the preview modal mounted even when badge UI is hidden (badges
+  // toggled off / line no longer showing badges). Returning null here would
+  // unmount VisualPreviewModal and dismiss an open dialog on the next render.
+  if (!showBadgeUi && !isPreviewModalOpen) {
     return null;
   }
 
   return (
-    <div className={`mt-1 mb-3 relative ${isStacked ? "" : "ml-[172px]"}`}>
-      <div className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border-b border-border/40 bg-muted/15">
-        {/* Menu choices badge (first per spec stacking order) */}
-        {technicalInfo.choices && technicalInfo.choices.length > 0 && (
-          <TechnicalBadge
-            type="menu"
-            data={technicalInfo.choices}
-            isLineHovered={isHovered}
-            onClick={() =>
-              setPopoverType((prev) => (prev === "menu" ? null : "menu"))
-            }
-          />
-        )}
+    <>
+      {showBadgeUi && technicalInfo ? (
+        <div className={`mt-1 mb-3 relative ${isStacked ? "" : "ml-[172px]"}`}>
+          <div className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border-b border-border/40 bg-muted/15">
+            {/* Menu choices badge (first per spec stacking order) */}
+            {technicalInfo.choices && technicalInfo.choices.length > 0 && (
+              <TechnicalBadge
+                type="menu"
+                data={technicalInfo.choices}
+                isLineHovered={isHovered}
+                onClick={() =>
+                  setPopoverType((prev) => (prev === "menu" ? null : "menu"))
+                }
+              />
+            )}
 
-        {/* Conditions badge */}
-        {technicalInfo.conditions && (
-          <TechnicalBadge
-            type="conditions"
-            data={technicalInfo.conditions}
-            isLineHovered={isHovered}
-            onClick={() =>
-              setPopoverType((prev) =>
-                prev === "conditions" ? null : "conditions"
-              )
-            }
-          />
-        )}
+            {/* Conditions badge */}
+            {technicalInfo.conditions && (
+              <TechnicalBadge
+                type="conditions"
+                data={technicalInfo.conditions}
+                isLineHovered={isHovered}
+                onClick={() =>
+                  setPopoverType((prev) =>
+                    prev === "conditions" ? null : "conditions"
+                  )
+                }
+              />
+            )}
 
-        {/* Jump badge */}
-        {technicalInfo.jumpTarget && (
-          <TechnicalBadge
-            type="jump"
-            data={technicalInfo.jumpTarget}
-            isLineHovered={isHovered}
-            onClick={() =>
-              setPopoverType((prev) => (prev === "jump" ? null : "jump"))
-            }
-          />
-        )}
+            {/* Jump badge */}
+            {technicalInfo.jumpTarget && (
+              <TechnicalBadge
+                type="jump"
+                data={technicalInfo.jumpTarget}
+                isLineHovered={isHovered}
+                onClick={() =>
+                  setPopoverType((prev) => (prev === "jump" ? null : "jump"))
+                }
+              />
+            )}
 
-        {/* Visuals badge */}
-        {technicalInfo.visuals && technicalInfo.visuals.length > 0 && (
-          <TechnicalBadge
-            type="visuals"
-            data={technicalInfo.visuals}
-            isLineHovered={isHovered}
-            onClick={() =>
-              setPopoverType((prev) => (prev === "visuals" ? null : "visuals"))
-            }
-          />
-        )}
-      </div>
+            {/* Visuals badge */}
+            {technicalInfo.visuals && technicalInfo.visuals.length > 0 && (
+              <TechnicalBadge
+                type="visuals"
+                data={technicalInfo.visuals}
+                isLineHovered={isHovered}
+                onClick={() =>
+                  setPopoverType((prev) =>
+                    prev === "visuals" ? null : "visuals"
+                  )
+                }
+              />
+            )}
+          </div>
 
-      {/* Popover - renders once at container level, anchored under badge row */}
-      {popoverType === "menu" && technicalInfo.choices && (
-        <TechnicalPopover
-          type="menu"
-          data={technicalInfo.choices}
-          onClose={() => setPopoverType(null)}
-        />
-      )}
-      {popoverType === "conditions" && technicalInfo.conditions && (
-        <TechnicalPopover
-          type="conditions"
-          data={technicalInfo.conditions}
-          onClose={() => setPopoverType(null)}
-        />
-      )}
-      {popoverType === "jump" && technicalInfo.jumpTarget && (
-        <TechnicalPopover
-          type="jump"
-          data={technicalInfo.jumpTarget}
-          onClose={() => setPopoverType(null)}
-        />
-      )}
-      {popoverType === "visuals" && technicalInfo.visuals && (
-        <TechnicalPopover
-          type="visuals"
-          data={technicalInfo.visuals}
-          onClose={() => setPopoverType(null)}
-        />
-      )}
-    </div>
+          {/* Popover - renders once at container level, anchored under badge row */}
+          {popoverType === "menu" && technicalInfo.choices && (
+            <TechnicalPopover
+              type="menu"
+              data={technicalInfo.choices}
+              onClose={() => setPopoverType(null)}
+            />
+          )}
+          {popoverType === "conditions" && technicalInfo.conditions && (
+            <TechnicalPopover
+              type="conditions"
+              data={technicalInfo.conditions}
+              onClose={() => setPopoverType(null)}
+            />
+          )}
+          {popoverType === "jump" && technicalInfo.jumpTarget && (
+            <TechnicalPopover
+              type="jump"
+              data={technicalInfo.jumpTarget}
+              onClose={() => setPopoverType(null)}
+            />
+          )}
+          {popoverType === "visuals" && technicalInfo.visuals && (
+            <TechnicalPopover
+              type="visuals"
+              data={technicalInfo.visuals}
+              onClose={() => setPopoverType(null)}
+              onOpenVisualPreview={handleOpenVisualPreview}
+            />
+          )}
+        </div>
+      ) : null}
+
+      <VisualPreviewModal
+        open={isPreviewModalOpen}
+        onOpenChange={setIsPreviewModalOpen}
+        projectId={currentProject?.id}
+        selection={previewSelection}
+      />
+    </>
   );
 }

--- a/apps/frontend/src/components/write-mode/TechnicalPopover.tsx
+++ b/apps/frontend/src/components/write-mode/TechnicalPopover.tsx
@@ -12,6 +12,10 @@ import {
   formatStatCondition,
 } from "@/lib/format-conditions";
 import { FormattedCondition } from "@/components/write-mode/FormattedCondition";
+import { useProject } from "@/hooks/useProject";
+import { useVisualPreviewLookup } from "@/hooks/useVisualPreviewLookup";
+import type { VisualPreviewSelection } from "@/components/project-images/VisualPreviewModal";
+import { VisualPreviewRow } from "@/components/project-images/VisualPreviewRow";
 
 interface ConditionsData {
   stats?: Record<string, StatCondition>;
@@ -40,15 +44,33 @@ interface TechnicalPopoverProps {
   type: "conditions" | "jump" | "visuals" | "menu";
   data: ConditionsData | JumpData | VisualData[] | MenuChoiceData[] | null;
   onClose: () => void;
+  /**
+   * Open the visual preview modal for a statement. Owned by the parent so the
+   * popover can close without unmounting the modal (native dialog is outside
+   * this popover's DOM tree).
+   */
+  onOpenVisualPreview?: (selection: VisualPreviewSelection) => void;
 }
 
 export function TechnicalPopover({
   type,
   data,
   onClose,
+  onOpenVisualPreview,
 }: TechnicalPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [isFlipped, setIsFlipped] = useState(false);
+  const { currentProject } = useProject();
+  const { getImageForTarget } = useVisualPreviewLookup(currentProject?.id, {
+    enabled: type === "visuals" && !!currentProject?.id,
+  });
+
+  const openVisualPreview = (visual: VisualData) => {
+    onOpenVisualPreview?.({
+      statementType: visual.type,
+      target: visual.target,
+    });
+  };
 
   const measureAndSetFlip = useCallback(() => {
     const popover = popoverRef.current;
@@ -58,7 +80,6 @@ export function TechnicalPopover({
     const viewportHeight = window.innerHeight;
     const spaceBelow = viewportHeight - rect.bottom;
 
-    // If less than 16px space below (allow some margin), flip upwards
     if (spaceBelow < 16) {
       setIsFlipped(true);
     } else {
@@ -66,13 +87,17 @@ export function TechnicalPopover({
     }
   }, []);
 
-  // Handle click outside to close
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (
-        popoverRef.current &&
-        !popoverRef.current.contains(event.target as Node)
-      ) {
+      const target = event.target;
+      // Native <dialog> (e.g. visual preview) lives outside this popover DOM.
+      // Ignore those clicks so parents can own nested modals without us
+      // dismissing ourselves first.
+      if (target instanceof Element && target.closest("dialog")) {
+        return;
+      }
+
+      if (popoverRef.current && !popoverRef.current.contains(target as Node)) {
         onClose();
       }
     };
@@ -83,7 +108,6 @@ export function TechnicalPopover({
     };
   }, [onClose]);
 
-  // Calculate position - flip upwards if not enough space below
   useLayoutEffect(() => {
     measureAndSetFlip();
 
@@ -182,20 +206,19 @@ export function TechnicalPopover({
                 <Image className="w-4 h-4 text-muted-foreground flex-shrink-0" />
                 <span className="text-sm font-medium">Visuals</span>
               </div>
-              <ul className="text-xs text-muted-foreground space-y-1.5">
+              <ul className="text-xs text-muted-foreground space-y-1">
                 {visualsData.map((visual, index) => (
-                  // react-doctor-disable-next-line react-doctor/no-array-index-as-key -- type_target can collide; index is local list order tiebreaker
-                  <li
+                  <VisualPreviewRow
+                    // react-doctor-disable-next-line react-doctor/no-array-index-as-key -- type_target can collide; index is local list order tiebreaker
                     key={`${visual.type}_${visual.target}_${index}`}
-                    className="flex items-center gap-1.5"
-                  >
-                    <span>{visual.type}</span>
-                    {visual.target && (
-                      <span className="font-mono text-foreground">
-                        {visual.target}
-                      </span>
-                    )}
-                  </li>
+                    visual={visual}
+                    image={
+                      visual.target
+                        ? getImageForTarget(visual.target)
+                        : undefined
+                    }
+                    onOpenPreview={openVisualPreview}
+                  />
                 ))}
               </ul>
             </div>

--- a/apps/frontend/src/components/write-mode/__tests__/DialogueLine.test.tsx
+++ b/apps/frontend/src/components/write-mode/__tests__/DialogueLine.test.tsx
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { QueryClientProvider } from "@tanstack/react-query";
 import type { Character } from "@branchforge/shared";
 import type { DialogueEntry } from "@/lib/prose-types";
+import { createTestQueryClient } from "@/test/query-client";
 import { DialogueLine } from "../DialogueLine";
+import type { ReactElement } from "react";
 
 const characters: Character[] = [
   {
@@ -42,8 +45,15 @@ const characters: Character[] = [
   },
 ];
 
+function renderWithQueryClient(ui: ReactElement) {
+  const queryClient = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  );
+}
+
 const renderDialogueLine = (entry: DialogueEntry) =>
-  render(
+  renderWithQueryClient(
     <DialogueLine
       entry={entry}
       characters={characters}
@@ -65,7 +75,7 @@ describe("DialogueLine", () => {
       text: "Narration text",
     };
 
-    render(
+    renderWithQueryClient(
       <div>
         <DialogueLine
           entry={entry}
@@ -197,7 +207,7 @@ describe("DialogueLine", () => {
       text: "Once upon a time...",
     };
 
-    const { container } = render(
+    const { container } = renderWithQueryClient(
       <DialogueLine
         entry={entry}
         characters={characters}

--- a/apps/frontend/src/hooks/useProjectImages.ts
+++ b/apps/frontend/src/hooks/useProjectImages.ts
@@ -5,7 +5,6 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { QueryClient } from "@tanstack/react-query";
 import {
   projectImagesApi,
   type UploadProjectImageInput,
@@ -28,22 +27,15 @@ interface ToastLike {
   error: (message: string, title?: string, duration?: number) => void;
 }
 
-function createImageMutationHandlers(
-  projectId: string,
-  queryClient: QueryClient,
+function createImageMutationToastHandlers(
   toast: ToastLike,
   actionName: string,
   successMessage: string
 ) {
-  const invalidate = () => {
-    queryClient.invalidateQueries({
-      queryKey: projectImageKeys.lists(projectId),
-    });
-  };
-
   return {
-    onSuccess: (data: { mutationOptions?: ProjectImageMutationOptions }) => {
-      invalidate();
+    onSuccessToast: (data: {
+      mutationOptions?: ProjectImageMutationOptions;
+    }) => {
       if (data.mutationOptions?.showSuccessToast !== false) {
         toast.success(successMessage, "Success");
       }
@@ -113,9 +105,7 @@ export function useProjectImages(
     staleTime: 5 * 60 * 1000,
   });
 
-  const handlers = createImageMutationHandlers(
-    projectId!,
-    queryClient,
+  const uploadToasts = createImageMutationToastHandlers(
     toast,
     "upload image",
     "Preview image uploaded"
@@ -132,7 +122,13 @@ export function useProjectImages(
       const response = await projectImagesApi.upload(projectId!, processed);
       return { image: response.image, mutationOptions };
     },
-    ...handlers,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: projectImageKeys.lists(projectId!),
+      });
+      uploadToasts.onSuccessToast(data);
+    },
+    onError: uploadToasts.onError,
   });
 
   const uploadImageMutation = useMutation({
@@ -149,12 +145,16 @@ export function useProjectImages(
       const response = await projectImagesApi.upload(projectId!, processed);
       return { image: response.image, mutationOptions };
     },
-    ...handlers,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: projectImageKeys.lists(projectId!),
+      });
+      uploadToasts.onSuccessToast(data);
+    },
+    onError: uploadToasts.onError,
   });
 
-  const replaceHandlers = createImageMutationHandlers(
-    projectId!,
-    queryClient,
+  const replaceToasts = createImageMutationToastHandlers(
     toast,
     "replace image",
     "Preview image replaced"
@@ -180,12 +180,16 @@ export function useProjectImages(
       });
       return { image: response.image, mutationOptions };
     },
-    ...replaceHandlers,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: projectImageKeys.lists(projectId!),
+      });
+      replaceToasts.onSuccessToast(data);
+    },
+    onError: replaceToasts.onError,
   });
 
-  const deleteHandlers = createImageMutationHandlers(
-    projectId!,
-    queryClient,
+  const deleteToasts = createImageMutationToastHandlers(
     toast,
     "remove image",
     "Preview image removed"
@@ -202,7 +206,13 @@ export function useProjectImages(
       await projectImagesApi.delete(imageId);
       return { mutationOptions };
     },
-    ...deleteHandlers,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: projectImageKeys.lists(projectId!),
+      });
+      deleteToasts.onSuccessToast(data);
+    },
+    onError: deleteToasts.onError,
   });
 
   return {

--- a/apps/frontend/src/hooks/useProjectImages.ts
+++ b/apps/frontend/src/hooks/useProjectImages.ts
@@ -5,6 +5,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 import {
   projectImagesApi,
   type UploadProjectImageInput,
@@ -20,6 +21,42 @@ import type { ProjectImage } from "@branchforge/shared";
 export interface ProjectImageMutationOptions {
   showSuccessToast?: boolean;
   showErrorToast?: boolean;
+}
+
+interface ToastLike {
+  success: (message: string, title?: string, duration?: number) => void;
+  error: (message: string, title?: string, duration?: number) => void;
+}
+
+function createImageMutationHandlers(
+  projectId: string,
+  queryClient: QueryClient,
+  toast: ToastLike,
+  actionName: string,
+  successMessage: string
+) {
+  const invalidate = () => {
+    queryClient.invalidateQueries({
+      queryKey: projectImageKeys.lists(projectId),
+    });
+  };
+
+  return {
+    onSuccess: (data: { mutationOptions?: ProjectImageMutationOptions }) => {
+      invalidate();
+      if (data.mutationOptions?.showSuccessToast !== false) {
+        toast.success(successMessage, "Success");
+      }
+    },
+    onError: (
+      error: Error,
+      variables: { mutationOptions?: ProjectImageMutationOptions }
+    ) => {
+      if (variables.mutationOptions?.showErrorToast !== false) {
+        toast.error(`Failed to ${actionName}: ${error.message}`, "Error");
+      }
+    },
+  };
 }
 
 export interface UseProjectImagesReturn {
@@ -76,6 +113,14 @@ export function useProjectImages(
     staleTime: 5 * 60 * 1000,
   });
 
+  const handlers = createImageMutationHandlers(
+    projectId!,
+    queryClient,
+    toast,
+    "upload image",
+    "Preview image uploaded"
+  );
+
   const uploadProcessedImageMutation = useMutation({
     mutationFn: async ({
       processed,
@@ -87,19 +132,7 @@ export function useProjectImages(
       const response = await projectImagesApi.upload(projectId!, processed);
       return { image: response.image, mutationOptions };
     },
-    onSuccess: ({ mutationOptions }) => {
-      queryClient.invalidateQueries({
-        queryKey: projectImageKeys.lists(projectId!),
-      });
-      if (mutationOptions?.showSuccessToast !== false) {
-        toast.success("Preview image uploaded", "Success");
-      }
-    },
-    onError: (error: Error, { mutationOptions }) => {
-      if (mutationOptions?.showErrorToast) {
-        toast.error(`Failed to upload image: ${error.message}`, "Error");
-      }
-    },
+    ...handlers,
   });
 
   const uploadImageMutation = useMutation({
@@ -116,20 +149,16 @@ export function useProjectImages(
       const response = await projectImagesApi.upload(projectId!, processed);
       return { image: response.image, mutationOptions };
     },
-    onSuccess: ({ mutationOptions }) => {
-      queryClient.invalidateQueries({
-        queryKey: projectImageKeys.lists(projectId!),
-      });
-      if (mutationOptions?.showSuccessToast !== false) {
-        toast.success("Preview image uploaded", "Success");
-      }
-    },
-    onError: (error: Error, { mutationOptions }) => {
-      if (mutationOptions?.showErrorToast) {
-        toast.error(`Failed to upload image: ${error.message}`, "Error");
-      }
-    },
+    ...handlers,
   });
+
+  const replaceHandlers = createImageMutationHandlers(
+    projectId!,
+    queryClient,
+    toast,
+    "replace image",
+    "Preview image replaced"
+  );
 
   const replaceImageMutation = useMutation({
     mutationFn: async ({
@@ -151,20 +180,16 @@ export function useProjectImages(
       });
       return { image: response.image, mutationOptions };
     },
-    onSuccess: ({ mutationOptions }) => {
-      queryClient.invalidateQueries({
-        queryKey: projectImageKeys.lists(projectId!),
-      });
-      if (mutationOptions?.showSuccessToast !== false) {
-        toast.success("Preview image replaced", "Success");
-      }
-    },
-    onError: (error: Error, { mutationOptions }) => {
-      if (mutationOptions?.showErrorToast) {
-        toast.error(`Failed to replace image: ${error.message}`, "Error");
-      }
-    },
+    ...replaceHandlers,
   });
+
+  const deleteHandlers = createImageMutationHandlers(
+    projectId!,
+    queryClient,
+    toast,
+    "remove image",
+    "Preview image removed"
+  );
 
   const deleteImageMutation = useMutation({
     mutationFn: async ({
@@ -177,19 +202,7 @@ export function useProjectImages(
       await projectImagesApi.delete(imageId);
       return { mutationOptions };
     },
-    onSuccess: ({ mutationOptions }) => {
-      queryClient.invalidateQueries({
-        queryKey: projectImageKeys.lists(projectId!),
-      });
-      if (mutationOptions?.showSuccessToast !== false) {
-        toast.success("Preview image removed", "Success");
-      }
-    },
-    onError: (error: Error, { mutationOptions }) => {
-      if (mutationOptions?.showErrorToast !== false) {
-        toast.error(`Failed to remove image: ${error.message}`, "Error");
-      }
-    },
+    ...deleteHandlers,
   });
 
   return {

--- a/apps/frontend/src/hooks/useProjectImages.ts
+++ b/apps/frontend/src/hooks/useProjectImages.ts
@@ -1,0 +1,222 @@
+/**
+ * useProjectImages Hook
+ *
+ * Provides project preview image state and operations using TanStack Query.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  projectImagesApi,
+  type UploadProjectImageInput,
+} from "@/lib/api/project-images";
+import { projectImageKeys } from "@/lib/query-keys";
+import { useToast } from "@/contexts/ToastContext";
+import {
+  processProjectImageFile,
+  type ProcessedProjectImageFiles,
+} from "@/lib/project-image-processing";
+import type { ProjectImage } from "@branchforge/shared";
+
+export interface ProjectImageMutationOptions {
+  showSuccessToast?: boolean;
+  showErrorToast?: boolean;
+}
+
+export interface UseProjectImagesReturn {
+  images: ProjectImage[];
+  isLoadingImages: boolean;
+  imagesError: Error | null;
+  refreshImages: () => void;
+  isUploadingImage: boolean;
+  isDeletingImage: boolean;
+  uploadImage: (
+    file: File,
+    expectedTarget?: string,
+    options?: ProjectImageMutationOptions
+  ) => Promise<ProjectImage>;
+  uploadProcessedImage: (
+    processed: ProcessedProjectImageFiles | UploadProjectImageInput,
+    options?: ProjectImageMutationOptions
+  ) => Promise<ProjectImage>;
+  replaceImage: (
+    imageId: string,
+    file: File,
+    expectedTarget?: string,
+    options?: ProjectImageMutationOptions
+  ) => Promise<ProjectImage>;
+  deleteImage: (
+    imageId: string,
+    options?: ProjectImageMutationOptions
+  ) => Promise<void>;
+}
+
+export function useProjectImages(
+  projectId: string | null | undefined,
+  options?: { enabled?: boolean }
+): UseProjectImagesReturn {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const enabled =
+    options?.enabled !== undefined
+      ? options.enabled && !!projectId
+      : !!projectId;
+
+  const {
+    data,
+    isLoading: isLoadingImages,
+    error: imagesError,
+    refetch: refreshImages,
+  } = useQuery({
+    queryKey: projectImageKeys.lists(projectId ?? ""),
+    queryFn: async () => {
+      const response = await projectImagesApi.list(projectId!);
+      return response.images;
+    },
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const uploadProcessedImageMutation = useMutation({
+    mutationFn: async ({
+      processed,
+      mutationOptions,
+    }: {
+      processed: ProcessedProjectImageFiles | UploadProjectImageInput;
+      mutationOptions?: ProjectImageMutationOptions;
+    }) => {
+      const response = await projectImagesApi.upload(projectId!, processed);
+      return { image: response.image, mutationOptions };
+    },
+    onSuccess: ({ mutationOptions }) => {
+      queryClient.invalidateQueries({
+        queryKey: projectImageKeys.lists(projectId!),
+      });
+      if (mutationOptions?.showSuccessToast !== false) {
+        toast.success("Preview image uploaded", "Success");
+      }
+    },
+    onError: (error: Error, { mutationOptions }) => {
+      if (mutationOptions?.showErrorToast) {
+        toast.error(`Failed to upload image: ${error.message}`, "Error");
+      }
+    },
+  });
+
+  const uploadImageMutation = useMutation({
+    mutationFn: async ({
+      file,
+      expectedTarget,
+      mutationOptions,
+    }: {
+      file: File;
+      expectedTarget?: string;
+      mutationOptions?: ProjectImageMutationOptions;
+    }) => {
+      const processed = await processProjectImageFile(file, expectedTarget);
+      const response = await projectImagesApi.upload(projectId!, processed);
+      return { image: response.image, mutationOptions };
+    },
+    onSuccess: ({ mutationOptions }) => {
+      queryClient.invalidateQueries({
+        queryKey: projectImageKeys.lists(projectId!),
+      });
+      if (mutationOptions?.showSuccessToast !== false) {
+        toast.success("Preview image uploaded", "Success");
+      }
+    },
+    onError: (error: Error, { mutationOptions }) => {
+      if (mutationOptions?.showErrorToast) {
+        toast.error(`Failed to upload image: ${error.message}`, "Error");
+      }
+    },
+  });
+
+  const replaceImageMutation = useMutation({
+    mutationFn: async ({
+      imageId,
+      file,
+      expectedTarget,
+      mutationOptions,
+    }: {
+      imageId: string;
+      file: File;
+      expectedTarget?: string;
+      mutationOptions?: ProjectImageMutationOptions;
+    }) => {
+      const processed = await processProjectImageFile(file, expectedTarget);
+      const response = await projectImagesApi.replace(imageId, {
+        originalFilename: processed.originalFilename,
+        tooltip: processed.tooltip,
+        modal: processed.modal,
+      });
+      return { image: response.image, mutationOptions };
+    },
+    onSuccess: ({ mutationOptions }) => {
+      queryClient.invalidateQueries({
+        queryKey: projectImageKeys.lists(projectId!),
+      });
+      if (mutationOptions?.showSuccessToast !== false) {
+        toast.success("Preview image replaced", "Success");
+      }
+    },
+    onError: (error: Error, { mutationOptions }) => {
+      if (mutationOptions?.showErrorToast) {
+        toast.error(`Failed to replace image: ${error.message}`, "Error");
+      }
+    },
+  });
+
+  const deleteImageMutation = useMutation({
+    mutationFn: async ({
+      imageId,
+      mutationOptions,
+    }: {
+      imageId: string;
+      mutationOptions?: ProjectImageMutationOptions;
+    }) => {
+      await projectImagesApi.delete(imageId);
+      return { mutationOptions };
+    },
+    onSuccess: ({ mutationOptions }) => {
+      queryClient.invalidateQueries({
+        queryKey: projectImageKeys.lists(projectId!),
+      });
+      if (mutationOptions?.showSuccessToast !== false) {
+        toast.success("Preview image removed", "Success");
+      }
+    },
+    onError: (error: Error, { mutationOptions }) => {
+      if (mutationOptions?.showErrorToast !== false) {
+        toast.error(`Failed to remove image: ${error.message}`, "Error");
+      }
+    },
+  });
+
+  return {
+    images: data ?? [],
+    isLoadingImages,
+    imagesError: imagesError as Error | null,
+    refreshImages,
+    isUploadingImage:
+      uploadImageMutation.isPending ||
+      uploadProcessedImageMutation.isPending ||
+      replaceImageMutation.isPending,
+    isDeletingImage: deleteImageMutation.isPending,
+    uploadImage: (file, expectedTarget, mutationOptions) =>
+      uploadImageMutation
+        .mutateAsync({ file, expectedTarget, mutationOptions })
+        .then(({ image }) => image),
+    uploadProcessedImage: (processed, mutationOptions) =>
+      uploadProcessedImageMutation
+        .mutateAsync({ processed, mutationOptions })
+        .then(({ image }) => image),
+    replaceImage: (imageId, file, expectedTarget, mutationOptions) =>
+      replaceImageMutation
+        .mutateAsync({ imageId, file, expectedTarget, mutationOptions })
+        .then(({ image }) => image),
+    deleteImage: (imageId, mutationOptions) =>
+      deleteImageMutation
+        .mutateAsync({ imageId, mutationOptions })
+        .then(() => undefined),
+  };
+}

--- a/apps/frontend/src/hooks/useVisualPreviewLookup.ts
+++ b/apps/frontend/src/hooks/useVisualPreviewLookup.ts
@@ -1,0 +1,59 @@
+/**
+ * Visual preview lookup for Write Mode and Script Mode.
+ *
+ * Loads project images and exposes target → image matching.
+ */
+
+import { useCallback } from "react";
+import {
+  findProjectImageForTarget,
+  type ProjectImage,
+} from "@branchforge/shared";
+import { useProjectImages } from "@/hooks/useProjectImages";
+
+export interface UseVisualPreviewLookupReturn {
+  images: ProjectImage[];
+  isLoadingImages: boolean;
+  getImageForTarget: (target: string) => ProjectImage | undefined;
+  uploadImage: ReturnType<typeof useProjectImages>["uploadImage"];
+  uploadProcessedImage: ReturnType<
+    typeof useProjectImages
+  >["uploadProcessedImage"];
+  replaceImage: ReturnType<typeof useProjectImages>["replaceImage"];
+  deleteImage: ReturnType<typeof useProjectImages>["deleteImage"];
+  isUploadingImage: boolean;
+  isDeletingImage: boolean;
+}
+
+export function useVisualPreviewLookup(
+  projectId: string | null | undefined,
+  options?: { enabled?: boolean }
+): UseVisualPreviewLookupReturn {
+  const {
+    images,
+    isLoadingImages,
+    uploadImage,
+    uploadProcessedImage,
+    replaceImage,
+    deleteImage,
+    isUploadingImage,
+    isDeletingImage,
+  } = useProjectImages(projectId, options);
+
+  const getImageForTarget = useCallback(
+    (target: string) => findProjectImageForTarget(images, target),
+    [images]
+  );
+
+  return {
+    images,
+    isLoadingImages,
+    getImageForTarget,
+    uploadImage,
+    uploadProcessedImage,
+    replaceImage,
+    deleteImage,
+    isUploadingImage,
+    isDeletingImage,
+  };
+}

--- a/apps/frontend/src/lib/api/project-images.ts
+++ b/apps/frontend/src/lib/api/project-images.ts
@@ -1,0 +1,93 @@
+/**
+ * Project Images API Client
+ *
+ * Client for project preview image list/upload/delete operations.
+ */
+
+import { request } from "./client";
+import type { ProjectImage } from "@branchforge/shared";
+
+export interface ListProjectImagesResponse {
+  images: ProjectImage[];
+}
+
+export interface UploadProjectImageResponse {
+  image: ProjectImage;
+}
+
+export interface UploadProjectImageInput {
+  originalFilename: string;
+  normalizedTarget?: string;
+  tooltip: File;
+  modal: File;
+}
+
+export interface ReplaceProjectImageInput {
+  originalFilename?: string;
+  tooltip: File;
+  modal: File;
+}
+
+export const projectImagesApi = {
+  async list(projectId: string): Promise<ListProjectImagesResponse> {
+    return await request<ListProjectImagesResponse>(
+      `/projects/${encodeURIComponent(projectId)}/images`,
+      { method: "GET" }
+    );
+  },
+
+  async upload(
+    projectId: string,
+    input: UploadProjectImageInput
+  ): Promise<UploadProjectImageResponse> {
+    const formData = new FormData();
+    formData.append("originalFilename", input.originalFilename);
+    if (input.normalizedTarget) {
+      formData.append("normalizedTarget", input.normalizedTarget);
+    }
+    formData.append("tooltip", input.tooltip);
+    formData.append("modal", input.modal);
+
+    return await request<UploadProjectImageResponse>(
+      `/projects/${encodeURIComponent(projectId)}/images`,
+      {
+        method: "POST",
+        body: formData,
+      }
+    );
+  },
+
+  async replace(
+    imageId: string,
+    input: ReplaceProjectImageInput
+  ): Promise<UploadProjectImageResponse> {
+    const formData = new FormData();
+    if (input.originalFilename) {
+      formData.append("originalFilename", input.originalFilename);
+    }
+    formData.append("tooltip", input.tooltip);
+    formData.append("modal", input.modal);
+
+    return await request<UploadProjectImageResponse>(
+      `/project-images/${encodeURIComponent(imageId)}`,
+      {
+        method: "PUT",
+        body: formData,
+      }
+    );
+  },
+
+  async delete(imageId: string): Promise<void> {
+    await request(`/project-images/${encodeURIComponent(imageId)}`, {
+      method: "DELETE",
+    });
+  },
+};
+
+export const listProjectImages = projectImagesApi.list.bind(projectImagesApi);
+export const uploadProjectImage =
+  projectImagesApi.upload.bind(projectImagesApi);
+export const deleteProjectImage =
+  projectImagesApi.delete.bind(projectImagesApi);
+export const replaceProjectImage =
+  projectImagesApi.replace.bind(projectImagesApi);

--- a/apps/frontend/src/lib/api/project-images.ts
+++ b/apps/frontend/src/lib/api/project-images.ts
@@ -83,11 +83,3 @@ export const projectImagesApi = {
     });
   },
 };
-
-export const listProjectImages = projectImagesApi.list.bind(projectImagesApi);
-export const uploadProjectImage =
-  projectImagesApi.upload.bind(projectImagesApi);
-export const deleteProjectImage =
-  projectImagesApi.delete.bind(projectImagesApi);
-export const replaceProjectImage =
-  projectImagesApi.replace.bind(projectImagesApi);

--- a/apps/frontend/src/lib/codemirror/__tests__/visual-preview-decoration.unit.test.ts
+++ b/apps/frontend/src/lib/codemirror/__tests__/visual-preview-decoration.unit.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { parseVisualStatementLine } from "../visual-preview-decoration";
+
+describe("parseVisualStatementLine", () => {
+  it("parses scene targets and strips with clauses", () => {
+    expect(parseVisualStatementLine("scene bg school")).toEqual({
+      type: "scene",
+      target: "bg school",
+    });
+    expect(parseVisualStatementLine("scene bg school with dissolve")).toEqual({
+      type: "scene",
+      target: "bg school",
+    });
+  });
+
+  it("parses show targets and strips at/with/zorder", () => {
+    expect(parseVisualStatementLine("show eileen happy")).toEqual({
+      type: "show",
+      target: "eileen happy",
+    });
+    expect(
+      parseVisualStatementLine("show eileen happy at left with dissolve")
+    ).toEqual({
+      type: "show",
+      target: "eileen happy",
+    });
+    expect(
+      parseVisualStatementLine("show eileen happy zorder 10 with fade")
+    ).toEqual({
+      type: "show",
+      target: "eileen happy",
+    });
+    expect(
+      parseVisualStatementLine("show eileen happy with dissolve at left")
+    ).toEqual({
+      type: "show",
+      target: "eileen happy",
+    });
+    expect(parseVisualStatementLine("show eileen happy as eileen2")).toEqual({
+      type: "show",
+      target: "eileen happy",
+    });
+  });
+
+  it("parses hide targets", () => {
+    expect(parseVisualStatementLine("hide eileen")).toEqual({
+      type: "hide",
+      target: "eileen",
+    });
+    expect(parseVisualStatementLine("hide eileen with dissolve")).toEqual({
+      type: "hide",
+      target: "eileen",
+    });
+  });
+
+  it("returns null for non-visual lines", () => {
+    expect(parseVisualStatementLine('e "Hello"')).toBeNull();
+    expect(parseVisualStatementLine("")).toBeNull();
+  });
+});

--- a/apps/frontend/src/lib/codemirror/visual-preview-decoration.ts
+++ b/apps/frontend/src/lib/codemirror/visual-preview-decoration.ts
@@ -1,0 +1,292 @@
+/**
+ * CodeMirror extension for visual statement preview hover/click in Script Mode.
+ */
+
+// react-doctor-disable-next-line react-doctor/prefer-dynamic-import
+import { StateEffect, StateField, type EditorState } from "@codemirror/state";
+// react-doctor-disable-next-line react-doctor/prefer-dynamic-import
+import {
+  Decoration,
+  EditorView,
+  ViewPlugin,
+  type DecorationSet,
+  type PluginValue,
+} from "@codemirror/view";
+import { PROJECT_IMAGE_TOOLTIP_SIZE } from "@branchforge/shared";
+
+export interface ParsedVisualStatement {
+  type: "scene" | "show" | "hide";
+  target: string;
+}
+
+export interface VisualPreviewImage {
+  tooltipUrl: string;
+}
+
+export interface VisualPreviewHandlers {
+  getImageForTarget: (target: string) => VisualPreviewImage | undefined;
+  onOpenPreview: (info: ParsedVisualStatement) => void;
+  /** When false, hover tooltips are suppressed (Ctrl/Cmd+click still works). */
+  hoverPreviewsEnabled: boolean;
+}
+
+export const setVisualPreviewHandlersEffect =
+  StateEffect.define<VisualPreviewHandlers>();
+
+const noopHandlers: VisualPreviewHandlers = {
+  getImageForTarget: () => undefined,
+  onOpenPreview: () => undefined,
+  hoverPreviewsEnabled: false,
+};
+
+const visualPreviewHandlersField = StateField.define<VisualPreviewHandlers>({
+  create: () => noopHandlers,
+  update: (value, transaction) => {
+    for (const effect of transaction.effects) {
+      if (effect.is(setVisualPreviewHandlersEffect)) {
+        return effect.value;
+      }
+    }
+    return value;
+  },
+});
+
+const VISUAL_STATEMENT_STOP_WORD = /\b(?:at|with|as|zorder)\b/i;
+
+export function parseVisualStatementLine(
+  lineText: string
+): ParsedVisualStatement | null {
+  const trimmed = lineText.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const match = trimmed.match(/^(scene|show|hide)\s+(.+)$/i);
+  if (!match?.[1] || !match[2]) {
+    return null;
+  }
+
+  const type = match[1].toLowerCase() as ParsedVisualStatement["type"];
+  const rest = match[2].trim();
+
+  if (type === "hide") {
+    const target = rest.match(/^(\S+)/)?.[1];
+    return target ? { type, target } : null;
+  }
+
+  const stopIndex = rest.search(VISUAL_STATEMENT_STOP_WORD);
+  const target = (stopIndex === -1 ? rest : rest.slice(0, stopIndex)).trim();
+  return target ? { type, target } : null;
+}
+
+function buildLineDecorations(state: EditorState): DecorationSet {
+  const handlers = state.field(visualPreviewHandlersField);
+  const decorations: ReturnType<Decoration["range"]>[] = [];
+
+  for (let lineNumber = 1; lineNumber <= state.doc.lines; lineNumber++) {
+    const line = state.doc.line(lineNumber);
+    const parsed = parseVisualStatementLine(line.text);
+    if (!parsed?.target) {
+      continue;
+    }
+
+    const image = handlers.getImageForTarget(parsed.target);
+    const classes = [
+      "cm-visual-preview-line",
+      image ? "cm-visual-preview-line--has-image" : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    decorations.push(
+      Decoration.line({
+        class: classes,
+        attributes: {
+          title: "Ctrl/Cmd+click to open visual preview",
+        },
+      }).range(line.from)
+    );
+  }
+
+  return Decoration.set(decorations, true);
+}
+
+const visualPreviewLineDecorations = StateField.define<DecorationSet>({
+  create(state) {
+    return buildLineDecorations(state);
+  },
+  update(decorations, transaction) {
+    const handlersChanged =
+      transaction.state.field(visualPreviewHandlersField) !==
+      transaction.startState.field(visualPreviewHandlersField);
+
+    if (transaction.docChanged || handlersChanged) {
+      return buildLineDecorations(transaction.state);
+    }
+
+    return decorations.map(transaction.changes);
+  },
+  provide: (field) => EditorView.decorations.from(field),
+});
+
+class VisualPreviewTooltipPlugin implements PluginValue {
+  private tooltipEl: HTMLDivElement | null = null;
+
+  constructor(private readonly view: EditorView) {}
+
+  destroy() {
+    this.hideTooltip();
+  }
+
+  private hideTooltip() {
+    if (this.tooltipEl) {
+      this.tooltipEl.remove();
+      this.tooltipEl = null;
+    }
+  }
+
+  private showTooltip(imageUrl: string, x: number, y: number) {
+    if (!this.tooltipEl) {
+      const el = document.createElement("div");
+      el.className = "cm-visual-preview-tooltip";
+      el.style.position = "fixed";
+      el.style.zIndex = "10000";
+      el.style.pointerEvents = "none";
+      el.style.padding = "4px";
+      el.style.borderRadius = "6px";
+      el.style.border =
+        "1px solid color-mix(in srgb, var(--border) 70%, transparent)";
+      el.style.background = "var(--popover)";
+      el.style.boxShadow = "0 8px 24px rgb(0 0 0 / 0.18)";
+
+      const img = document.createElement("img");
+      img.width = PROJECT_IMAGE_TOOLTIP_SIZE;
+      img.height = PROJECT_IMAGE_TOOLTIP_SIZE;
+      img.style.display = "block";
+      img.style.objectFit = "contain";
+      el.appendChild(img);
+      document.body.appendChild(el);
+      this.tooltipEl = el;
+    }
+
+    const img = this.tooltipEl.querySelector("img");
+    if (img instanceof HTMLImageElement) {
+      img.src = imageUrl;
+      img.alt = "";
+    }
+
+    const offset = 12;
+    const maxLeft = window.innerWidth - PROJECT_IMAGE_TOOLTIP_SIZE - 16;
+    const maxTop = window.innerHeight - PROJECT_IMAGE_TOOLTIP_SIZE - 16;
+    this.tooltipEl.style.left = `${Math.min(x + offset, maxLeft)}px`;
+    this.tooltipEl.style.top = `${Math.min(y + offset, maxTop)}px`;
+    this.tooltipEl.style.display = "block";
+  }
+
+  private getVisualAtPosition(pos: number): {
+    parsed: ParsedVisualStatement;
+    image?: VisualPreviewImage;
+  } | null {
+    const line = this.view.state.doc.lineAt(pos);
+    const parsed = parseVisualStatementLine(line.text);
+    if (!parsed?.target) {
+      return null;
+    }
+
+    const handlers = this.view.state.field(visualPreviewHandlersField);
+    return {
+      parsed,
+      image: handlers.getImageForTarget(parsed.target),
+    };
+  }
+
+  update() {
+    const handlers = this.view.state.field(visualPreviewHandlersField);
+    if (!handlers.hoverPreviewsEnabled) {
+      this.hideTooltip();
+    }
+  }
+
+  onMouseMove(event: MouseEvent) {
+    const handlers = this.view.state.field(visualPreviewHandlersField);
+    if (!handlers.hoverPreviewsEnabled) {
+      this.hideTooltip();
+      return;
+    }
+
+    const pos = this.view.posAtCoords({ x: event.clientX, y: event.clientY });
+    if (pos == null) {
+      this.hideTooltip();
+      return;
+    }
+
+    const visual = this.getVisualAtPosition(pos);
+    if (!visual?.image?.tooltipUrl) {
+      this.hideTooltip();
+      return;
+    }
+
+    this.showTooltip(visual.image.tooltipUrl, event.clientX, event.clientY);
+  }
+
+  onMouseLeave() {
+    this.hideTooltip();
+  }
+
+  /**
+   * Ctrl/Cmd + primary-button opens the preview modal.
+   * Handled on mousedown so CodeMirror caret placement / selection
+   * does not consume the gesture before click fires.
+   */
+  onModifierOpen(event: MouseEvent): boolean {
+    if (!(event.ctrlKey || event.metaKey) || event.button !== 0) {
+      return false;
+    }
+
+    const pos = this.view.posAtCoords({ x: event.clientX, y: event.clientY });
+    if (pos == null) {
+      return false;
+    }
+
+    const visual = this.getVisualAtPosition(pos);
+    if (!visual) {
+      return false;
+    }
+
+    event.preventDefault();
+    this.hideTooltip();
+    const handlers = this.view.state.field(visualPreviewHandlersField);
+    handlers.onOpenPreview(visual.parsed);
+    return true;
+  }
+}
+
+const visualPreviewTooltipPlugin = ViewPlugin.fromClass(
+  VisualPreviewTooltipPlugin,
+  {
+    eventHandlers: {
+      mousemove(this: VisualPreviewTooltipPlugin, event) {
+        this.onMouseMove(event);
+      },
+      mouseleave(this: VisualPreviewTooltipPlugin) {
+        this.onMouseLeave();
+      },
+      mousedown(this: VisualPreviewTooltipPlugin, event) {
+        return this.onModifierOpen(event);
+      },
+    },
+  }
+);
+
+export const visualPreviewTheme = EditorView.baseTheme({
+  ".cm-visual-preview-line--has-image": {
+    backgroundColor: "color-mix(in srgb, var(--primary) 6%, transparent)",
+  },
+});
+
+export const visualPreviewExtension = [
+  visualPreviewHandlersField,
+  visualPreviewLineDecorations,
+  visualPreviewTooltipPlugin,
+  visualPreviewTheme,
+];

--- a/apps/frontend/src/lib/project-image-processing.ts
+++ b/apps/frontend/src/lib/project-image-processing.ts
@@ -1,0 +1,203 @@
+/**
+ * Client-side project image processing (canvas resize).
+ */
+
+import {
+  isValidProjectImageMimeType,
+  normalizeImageTarget,
+  PROJECT_IMAGE_MAX_SIZE,
+  PROJECT_IMAGE_MODAL_SIZE,
+  PROJECT_IMAGE_ORIGINAL_FILENAME_MAX,
+  PROJECT_IMAGE_TOOLTIP_SIZE,
+} from "@branchforge/shared";
+
+export { normalizeImageTarget };
+
+export interface ProcessedProjectImageBlobs {
+  originalFilename: string;
+  normalizedTarget: string;
+  tooltip: Blob;
+  modal: Blob;
+  extension: "webp" | "jpg";
+}
+
+export interface ProcessedProjectImageFiles {
+  originalFilename: string;
+  normalizedTarget: string;
+  tooltip: File;
+  modal: File;
+}
+
+export class ProjectImageProcessingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProjectImageProcessingError";
+  }
+}
+
+export function validateProjectImageFile(
+  file: File,
+  expectedTarget?: string
+): string {
+  if (!isValidProjectImageMimeType(file.type)) {
+    throw new ProjectImageProcessingError(
+      "Unsupported image type. Use JPEG, PNG, or WebP."
+    );
+  }
+
+  if (file.name.length > PROJECT_IMAGE_ORIGINAL_FILENAME_MAX) {
+    throw new ProjectImageProcessingError(
+      `Filename exceeds the ${PROJECT_IMAGE_ORIGINAL_FILENAME_MAX} character limit.`
+    );
+  }
+
+  if (file.size > PROJECT_IMAGE_MAX_SIZE) {
+    throw new ProjectImageProcessingError("Image exceeds the 5MB size limit.");
+  }
+
+  const normalizedTarget = normalizeImageTarget(file.name);
+  if (!normalizedTarget) {
+    throw new ProjectImageProcessingError(
+      "Filename must include a valid image target name."
+    );
+  }
+
+  if (
+    expectedTarget &&
+    normalizeImageTarget(expectedTarget) !== normalizedTarget
+  ) {
+    throw new ProjectImageProcessingError(
+      `This image targets "${normalizedTarget}" but "${normalizeImageTarget(expectedTarget)}" was expected. Rename the file or choose a matching image.`
+    );
+  }
+
+  return normalizedTarget;
+}
+
+function loadImageFromFile(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const image = new Image();
+
+    image.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(image);
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new ProjectImageProcessingError("Failed to load image file."));
+    };
+    image.src = url;
+  });
+}
+
+function tryCanvasToBlob(
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality: number
+): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => resolve(blob), type, quality);
+  });
+}
+
+async function encodeCanvas(
+  canvas: HTMLCanvasElement
+): Promise<{ blob: Blob; extension: "webp" | "jpg" }> {
+  const webpBlob = await tryCanvasToBlob(canvas, "image/webp", 0.9);
+  if (webpBlob) {
+    return { blob: webpBlob, extension: "webp" };
+  }
+
+  const jpegBlob = await tryCanvasToBlob(canvas, "image/jpeg", 0.9);
+  if (jpegBlob) {
+    return { blob: jpegBlob, extension: "jpg" };
+  }
+
+  throw new ProjectImageProcessingError("Failed to encode resized image.");
+}
+
+async function resizeToBlob(
+  image: HTMLImageElement,
+  maxSize: number
+): Promise<{ blob: Blob; extension: "webp" | "jpg" }> {
+  const scale = Math.min(1, maxSize / Math.max(image.width, image.height));
+  const width = Math.max(1, Math.round(image.width * scale));
+  const height = Math.max(1, Math.round(image.height * scale));
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new ProjectImageProcessingError("Canvas is not available.");
+  }
+
+  context.drawImage(image, 0, 0, width, height);
+  return encodeCanvas(canvas);
+}
+
+function blobToFile(blob: Blob, filename: string): File {
+  return new File([blob], filename, {
+    type: blob.type || "image/webp",
+  });
+}
+
+/**
+ * Resize an image file into tooltip (200px) and modal (800px) variants.
+ *
+ * When `expectedTarget` is provided, the normalized filename must match it.
+ */
+export async function processProjectImageFile(
+  file: File,
+  expectedTarget?: string
+): Promise<ProcessedProjectImageFiles> {
+  const normalizedTarget = validateProjectImageFile(file, expectedTarget);
+  const image = await loadImageFromFile(file);
+  const [tooltipResult, modalResult] = await Promise.all([
+    resizeToBlob(image, PROJECT_IMAGE_TOOLTIP_SIZE),
+    resizeToBlob(image, PROJECT_IMAGE_MODAL_SIZE),
+  ]);
+
+  const extension = tooltipResult.extension;
+  const baseName = normalizedTarget;
+  const originalFilename = file.name.includes(".")
+    ? file.name
+    : `${baseName}.${extension}`;
+
+  return {
+    originalFilename,
+    normalizedTarget,
+    tooltip: blobToFile(tooltipResult.blob, `${baseName}_tooltip.${extension}`),
+    modal: blobToFile(modalResult.blob, `${baseName}_modal.${extension}`),
+  };
+}
+
+/**
+ * Resize an image file into tooltip/modal blobs without wrapping as File objects.
+ */
+export async function processProjectImageBlobs(
+  file: File,
+  expectedTarget?: string
+): Promise<ProcessedProjectImageBlobs> {
+  const normalizedTarget = validateProjectImageFile(file, expectedTarget);
+  const image = await loadImageFromFile(file);
+  const [tooltipResult, modalResult] = await Promise.all([
+    resizeToBlob(image, PROJECT_IMAGE_TOOLTIP_SIZE),
+    resizeToBlob(image, PROJECT_IMAGE_MODAL_SIZE),
+  ]);
+
+  const extension = tooltipResult.extension;
+  const originalFilename = file.name.includes(".")
+    ? file.name
+    : `${normalizedTarget}.${extension}`;
+
+  return {
+    originalFilename,
+    normalizedTarget,
+    tooltip: tooltipResult.blob,
+    modal: modalResult.blob,
+    extension,
+  };
+}

--- a/apps/frontend/src/lib/project-image-processing.ts
+++ b/apps/frontend/src/lib/project-image-processing.ts
@@ -13,14 +13,6 @@ import {
 
 export { normalizeImageTarget };
 
-export interface ProcessedProjectImageBlobs {
-  originalFilename: string;
-  normalizedTarget: string;
-  tooltip: Blob;
-  modal: Blob;
-  extension: "webp" | "jpg";
-}
-
 export interface ProcessedProjectImageFiles {
   originalFilename: string;
   normalizedTarget: string;
@@ -76,6 +68,7 @@ export function validateProjectImageFile(
 
 function loadImageFromFile(file: File): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
+    // react-doctor-disable-next-line react-doctor/no-create-object-url-without-revoke -- revoked in onload and onerror below; analyzer misses same-function callback pairing
     const url = URL.createObjectURL(file);
     const image = new Image();
 
@@ -202,29 +195,5 @@ export async function processProjectImageFile(
       `${normalizedTarget}_tooltip.${extension}`
     ),
     modal: blobToFile(modalBlob, `${normalizedTarget}_modal.${extension}`),
-  };
-}
-
-/**
- * Resize an image file into tooltip/modal blobs without wrapping as File objects.
- */
-export async function processProjectImageBlobs(
-  file: File,
-  expectedTarget?: string
-): Promise<ProcessedProjectImageBlobs> {
-  const {
-    normalizedTarget,
-    originalFilename,
-    extension,
-    tooltipBlob,
-    modalBlob,
-  } = await processImageFile(file, expectedTarget);
-
-  return {
-    originalFilename,
-    normalizedTarget,
-    tooltip: tooltipBlob,
-    modal: modalBlob,
-    extension,
   };
 }

--- a/apps/frontend/src/lib/project-image-processing.ts
+++ b/apps/frontend/src/lib/project-image-processing.ts
@@ -144,43 +144,18 @@ function blobToFile(blob: Blob, filename: string): File {
   });
 }
 
-/**
- * Resize an image file into tooltip (200px) and modal (800px) variants.
- *
- * When `expectedTarget` is provided, the normalized filename must match it.
- */
-export async function processProjectImageFile(
-  file: File,
-  expectedTarget?: string
-): Promise<ProcessedProjectImageFiles> {
-  const normalizedTarget = validateProjectImageFile(file, expectedTarget);
-  const image = await loadImageFromFile(file);
-  const [tooltipResult, modalResult] = await Promise.all([
-    resizeToBlob(image, PROJECT_IMAGE_TOOLTIP_SIZE),
-    resizeToBlob(image, PROJECT_IMAGE_MODAL_SIZE),
-  ]);
-
-  const extension = tooltipResult.extension;
-  const baseName = normalizedTarget;
-  const originalFilename = file.name.includes(".")
-    ? file.name
-    : `${baseName}.${extension}`;
-
-  return {
-    originalFilename,
-    normalizedTarget,
-    tooltip: blobToFile(tooltipResult.blob, `${baseName}_tooltip.${extension}`),
-    modal: blobToFile(modalResult.blob, `${baseName}_modal.${extension}`),
-  };
+interface InternalProcessedImage {
+  normalizedTarget: string;
+  originalFilename: string;
+  extension: "webp" | "jpg";
+  tooltipBlob: Blob;
+  modalBlob: Blob;
 }
 
-/**
- * Resize an image file into tooltip/modal blobs without wrapping as File objects.
- */
-export async function processProjectImageBlobs(
+async function processImageFile(
   file: File,
   expectedTarget?: string
-): Promise<ProcessedProjectImageBlobs> {
+): Promise<InternalProcessedImage> {
   const normalizedTarget = validateProjectImageFile(file, expectedTarget);
   const image = await loadImageFromFile(file);
   const [tooltipResult, modalResult] = await Promise.all([
@@ -194,10 +169,62 @@ export async function processProjectImageBlobs(
     : `${normalizedTarget}.${extension}`;
 
   return {
+    normalizedTarget,
+    originalFilename,
+    extension,
+    tooltipBlob: tooltipResult.blob,
+    modalBlob: modalResult.blob,
+  };
+}
+
+/**
+ * Resize an image file into tooltip (200px) and modal (800px) variants.
+ *
+ * When `expectedTarget` is provided, the normalized filename must match it.
+ */
+export async function processProjectImageFile(
+  file: File,
+  expectedTarget?: string
+): Promise<ProcessedProjectImageFiles> {
+  const {
+    normalizedTarget,
+    originalFilename,
+    extension,
+    tooltipBlob,
+    modalBlob,
+  } = await processImageFile(file, expectedTarget);
+
+  return {
     originalFilename,
     normalizedTarget,
-    tooltip: tooltipResult.blob,
-    modal: modalResult.blob,
+    tooltip: blobToFile(
+      tooltipBlob,
+      `${normalizedTarget}_tooltip.${extension}`
+    ),
+    modal: blobToFile(modalBlob, `${normalizedTarget}_modal.${extension}`),
+  };
+}
+
+/**
+ * Resize an image file into tooltip/modal blobs without wrapping as File objects.
+ */
+export async function processProjectImageBlobs(
+  file: File,
+  expectedTarget?: string
+): Promise<ProcessedProjectImageBlobs> {
+  const {
+    normalizedTarget,
+    originalFilename,
+    extension,
+    tooltipBlob,
+    modalBlob,
+  } = await processImageFile(file, expectedTarget);
+
+  return {
+    originalFilename,
+    normalizedTarget,
+    tooltip: tooltipBlob,
+    modal: modalBlob,
     extension,
   };
 }

--- a/apps/frontend/src/lib/project-image-processing.ts
+++ b/apps/frontend/src/lib/project-image-processing.ts
@@ -140,7 +140,8 @@ function blobToFile(blob: Blob, filename: string): File {
 interface InternalProcessedImage {
   normalizedTarget: string;
   originalFilename: string;
-  extension: "webp" | "jpg";
+  tooltipExtension: "webp" | "jpg";
+  modalExtension: "webp" | "jpg";
   tooltipBlob: Blob;
   modalBlob: Blob;
 }
@@ -156,15 +157,15 @@ async function processImageFile(
     resizeToBlob(image, PROJECT_IMAGE_MODAL_SIZE),
   ]);
 
-  const extension = tooltipResult.extension;
   const originalFilename = file.name.includes(".")
     ? file.name
-    : `${normalizedTarget}.${extension}`;
+    : `${normalizedTarget}.${tooltipResult.extension}`;
 
   return {
     normalizedTarget,
     originalFilename,
-    extension,
+    tooltipExtension: tooltipResult.extension,
+    modalExtension: modalResult.extension,
     tooltipBlob: tooltipResult.blob,
     modalBlob: modalResult.blob,
   };
@@ -182,7 +183,8 @@ export async function processProjectImageFile(
   const {
     normalizedTarget,
     originalFilename,
-    extension,
+    tooltipExtension,
+    modalExtension,
     tooltipBlob,
     modalBlob,
   } = await processImageFile(file, expectedTarget);
@@ -192,8 +194,8 @@ export async function processProjectImageFile(
     normalizedTarget,
     tooltip: blobToFile(
       tooltipBlob,
-      `${normalizedTarget}_tooltip.${extension}`
+      `${normalizedTarget}_tooltip.${tooltipExtension}`
     ),
-    modal: blobToFile(modalBlob, `${normalizedTarget}_modal.${extension}`),
+    modal: blobToFile(modalBlob, `${normalizedTarget}_modal.${modalExtension}`),
   };
 }

--- a/apps/frontend/src/lib/query-keys.ts
+++ b/apps/frontend/src/lib/query-keys.ts
@@ -153,6 +153,16 @@ export const variableKeys = {
 } as const;
 
 // ============================================================================
+// Project Image Keys
+// ============================================================================
+
+export const projectImageKeys = {
+  all: ["projectImages"] as const,
+  lists: (projectId: string) => ["projectImages", projectId, "list"] as const,
+  detail: (imageId: string) => ["projectImages", "detail", imageId] as const,
+} as const;
+
+// ============================================================================
 // Character Keys
 // ============================================================================
 

--- a/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
+++ b/apps/frontend/src/pages/ide/components/ScriptModeEditorLayout.tsx
@@ -250,7 +250,7 @@ export function ScriptModeEditorLayout({
     [isMobile, setStoredLineWrap]
   );
 
-  const [showLabelTitles, setShowLabelTitles] = useLocalStorageBoolean(
+  const [showOverlays, setShowOverlays] = useLocalStorageBoolean(
     "script:show-label-titles",
     true
   );
@@ -450,8 +450,9 @@ export function ScriptModeEditorLayout({
                       labelTitles={labelTitles}
                       lineWrap={lineWrap}
                       onLineWrapChange={handleLineWrapChange}
-                      showLabelTitles={showLabelTitles}
-                      onShowLabelTitlesChange={setShowLabelTitles}
+                      showOverlays={showOverlays}
+                      onShowOverlaysChange={setShowOverlays}
+                      projectId={projectId}
                     />
                   </div>
                 </>
@@ -468,8 +469,9 @@ export function ScriptModeEditorLayout({
                   labelTitles={labelTitles}
                   lineWrap={lineWrap}
                   onLineWrapChange={handleLineWrapChange}
-                  showLabelTitles={showLabelTitles}
-                  onShowLabelTitlesChange={setShowLabelTitles}
+                  showOverlays={showOverlays}
+                  onShowOverlaysChange={setShowOverlays}
+                  projectId={projectId}
                 />
               ) : activeLabel ? (
                 <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-3">
@@ -559,15 +561,15 @@ export function ScriptModeEditorLayout({
         />
         <FABToggle
           icon={
-            showLabelTitles ? (
+            showOverlays ? (
               <Eye className="size-4" />
             ) : (
               <EyeOff className="size-4" />
             )
           }
-          label="Show Titles"
-          active={showLabelTitles}
-          onClick={() => setShowLabelTitles((v) => !v)}
+          label="Show Overlays"
+          active={showOverlays}
+          onClick={() => setShowOverlays((v) => !v)}
         />
         <div className="h-px bg-border/30 my-1" />
         <FABFocusButton

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1188,3 +1188,21 @@ export const FLOW_LAYOUT_MODE_LABELS: Record<FlowLayoutMode, string> = {
   ROUTE: "Route view",
   FILE: "File view",
 };
+
+// ============================================================================
+// Project Images (visual statement previews)
+// ============================================================================
+
+export {
+  PROJECT_IMAGE_ALLOWED_MIME_TYPES,
+  PROJECT_IMAGE_MAX_SIZE_MB,
+  PROJECT_IMAGE_MAX_SIZE,
+  PROJECT_IMAGE_ORIGINAL_FILENAME_MAX,
+  PROJECT_IMAGE_TOOLTIP_SIZE,
+  PROJECT_IMAGE_MODAL_SIZE,
+  isValidProjectImageMimeType,
+  normalizeImageTarget,
+  visualTargetsMatch,
+  findProjectImageForTarget,
+  type ProjectImage,
+} from "./project-images.js";

--- a/packages/shared/src/project-images.test.ts
+++ b/packages/shared/src/project-images.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  findProjectImageForTarget,
+  isValidProjectImageMimeType,
+  normalizeImageTarget,
+  visualTargetsMatch,
+} from "./project-images.js";
+
+describe("normalizeImageTarget", () => {
+  it("strips extension and lowercases", () => {
+    expect(normalizeImageTarget("Eileen_Happy.PNG")).toBe("eileen_happy");
+    expect(normalizeImageTarget("example_123.webp")).toBe("example_123");
+  });
+
+  it("converts spaces to underscores", () => {
+    expect(normalizeImageTarget("Eileen Happy.png")).toBe("eileen_happy");
+    expect(normalizeImageTarget("eileen  happy")).toBe("eileen_happy");
+  });
+
+  it("handles empty and extension-only inputs", () => {
+    expect(normalizeImageTarget("")).toBe("");
+    expect(normalizeImageTarget("   ")).toBe("");
+    expect(normalizeImageTarget(".png")).toBe("");
+  });
+});
+
+describe("visualTargetsMatch", () => {
+  it("matches exact underscore targets", () => {
+    expect(visualTargetsMatch("example_123", "example_123")).toBe(true);
+  });
+
+  it("matches spaces to underscores", () => {
+    expect(visualTargetsMatch("eileen happy", "eileen_happy")).toBe(true);
+    expect(visualTargetsMatch("Eileen Happy", "eileen_happy")).toBe(true);
+  });
+
+  it("rejects non-matches", () => {
+    expect(visualTargetsMatch("eileen sad", "eileen_happy")).toBe(false);
+    expect(visualTargetsMatch("", "eileen_happy")).toBe(false);
+  });
+});
+
+describe("findProjectImageForTarget", () => {
+  const images = [
+    { id: "1", normalizedTarget: "eileen_happy" },
+    { id: "2", normalizedTarget: "bg_school" },
+  ];
+
+  it("finds matching image", () => {
+    expect(findProjectImageForTarget(images, "eileen happy")?.id).toBe("1");
+    expect(findProjectImageForTarget(images, "bg school")?.id).toBe("2");
+  });
+
+  it("returns undefined when missing", () => {
+    expect(findProjectImageForTarget(images, "missing")).toBeUndefined();
+  });
+});
+
+describe("isValidProjectImageMimeType", () => {
+  it("accepts common image types", () => {
+    expect(isValidProjectImageMimeType("image/png")).toBe(true);
+    expect(isValidProjectImageMimeType("image/JPEG")).toBe(true);
+    expect(isValidProjectImageMimeType("image/webp")).toBe(true);
+  });
+
+  it("rejects non-images", () => {
+    expect(isValidProjectImageMimeType("application/pdf")).toBe(false);
+  });
+});

--- a/packages/shared/src/project-images.ts
+++ b/packages/shared/src/project-images.ts
@@ -1,0 +1,106 @@
+/**
+ * Project image preview types and matching helpers.
+ *
+ * Used to auto-link uploaded preview images to Ren'Py visual statements
+ * (scene / show / hide) by filename.
+ */
+
+/** MIME types accepted for project preview image uploads */
+export const PROJECT_IMAGE_ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+] as const;
+
+/** Max original upload size before client-side resize (5MB) */
+export const PROJECT_IMAGE_MAX_SIZE_MB = 5;
+export const PROJECT_IMAGE_MAX_SIZE = PROJECT_IMAGE_MAX_SIZE_MB * 1024 * 1024;
+
+/** Max length for the stored originalFilename */
+export const PROJECT_IMAGE_ORIGINAL_FILENAME_MAX = 255;
+
+/** Preview sizes produced client-side before upload */
+export const PROJECT_IMAGE_TOOLTIP_SIZE = 200;
+export const PROJECT_IMAGE_MODAL_SIZE = 800;
+
+export function isValidProjectImageMimeType(mimeType: string): boolean {
+  return PROJECT_IMAGE_ALLOWED_MIME_TYPES.includes(
+    mimeType.toLowerCase() as (typeof PROJECT_IMAGE_ALLOWED_MIME_TYPES)[number]
+  );
+}
+
+/**
+ * Public project image DTO (URLs are absolute app paths for static serving).
+ */
+export interface ProjectImage {
+  id: string;
+  projectId: string;
+  originalFilename: string;
+  /** Underscore-form target used for matching, unique per project */
+  normalizedTarget: string;
+  tooltipUrl: string;
+  modalUrl: string;
+  createdAt: string;
+}
+
+/**
+ * Normalize a filename or statement target into the stored match key.
+ *
+ * - Strips a single trailing image extension when present
+ * - Trims whitespace
+ * - Collapses internal whitespace runs to single underscores
+ * - Lowercases for case-insensitive uniqueness / matching
+ *
+ * @example
+ * normalizeImageTarget("Eileen Happy.png") // "eileen_happy"
+ * normalizeImageTarget("example_123.webp") // "example_123"
+ * normalizeImageTarget("eileen happy") // "eileen_happy"
+ */
+export function normalizeImageTarget(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const withoutExt = trimmed.replace(/\.(png|jpe?g|webp|gif|bmp)$/i, "");
+
+  return withoutExt
+    .trim()
+    .toLowerCase()
+    .replace(/[\s]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+}
+
+/**
+ * Compare a visual statement target to a stored normalized_target.
+ *
+ * Matching is case-insensitive and treats underscores and spaces as equivalent.
+ * Statement targets should already exclude trailing `at` / `with` / `as` clauses
+ * (those are separate fields on VisualStatement).
+ *
+ * @example
+ * visualTargetsMatch("eileen happy", "eileen_happy") // true
+ * visualTargetsMatch("example_123", "example_123") // true
+ * visualTargetsMatch("Eileen Happy", "eileen_happy") // true
+ */
+export function visualTargetsMatch(
+  statementTarget: string,
+  normalizedTarget: string
+): boolean {
+  const left = normalizeImageTarget(statementTarget);
+  const right = normalizeImageTarget(normalizedTarget);
+  return left.length > 0 && left === right;
+}
+
+/**
+ * Find the first project image that matches a visual statement target.
+ */
+export function findProjectImageForTarget<
+  T extends { normalizedTarget: string },
+>(images: readonly T[], statementTarget: string): T | undefined {
+  return images.find((image) =>
+    visualTargetsMatch(statementTarget, image.normalizedTarget)
+  );
+}


### PR DESCRIPTION
## Description

Adds project-scoped preview images for Ren'Py `scene` / `show` / `hide` statements. Uploads auto-link by normalized filename and surface as hover tooltips plus click-to-modal previews in Write Mode and Script Mode.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (adding or updating tests)

## Related Issue

Fixes #252

## Changes Made

- Added `project_images` table/migration and nested storage under `uploads/project-images/<projectId>/`
- Added list/upload/replace/delete API with unique-target rejection and multipart `files: 2` override
- Added Project Settings → Images tab with client-side 200/800 resize and compact grid list
- Wired Write Mode Visuals popover + Script Mode hover/Ctrl-Cmd-click preview modal
- Renamed Script Mode switch to Overlays and gated hover tooltips behind it
- Added atomic replace (`PUT /project-images/:imageId`) so replace no longer deletes before upload
- Improved statement parsing to ignore `at` / `with` / `as` / `zorder` in any order

## Testing

- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Manually tested the following scenarios:
  - Upload batch in Project Settings → Images
  - Write Mode visuals hover/click modal
  - Script Mode hover with Overlays On/Off and Ctrl/Cmd+click
  - Replace/delete flows
- [x] Focused unit tests + package typechecks pass locally

## Checklist

- [x] My code follows the style guidelines of this project (run `pnpm lint` and `pnpm format`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings (run `pnpm typecheck`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm changeset` (if applicable)

## Additional Notes

After merge, run backend migration `0057` (`pnpm --filter @branchforge/backend db:migrate`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project **Images** tab with drag-and-drop uploads, progress UI, and preview image replace/delete.
  * Added authenticated preview image APIs and “visual statement” hover + click-to-open modal for scene/show/hide in **Write** and **Script** modes.
  * Introduced Script mode **Overlays** toggle and CodeMirror visual overlay/preview integration.
* **Bug Fixes**
  * Hardened upload/replace/delete validation (MIME type, size, filename/target normalization) and secure server-side storage path handling.
  * Improved error handling and conflict messaging for uploads, including consistent not-found behavior and cleanup on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->