### PR TITLE
chore: add db bootstrap and ignore local agent dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ plans/
 tmp/
 create-issues.sh
 
+.claude/
+!.claude/CLAUDE.md
+.cursor/
+
 # Security audit notes — PRIVATE, never commit/publish
 docs/security/audit-*.md
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,10 +72,10 @@ When reporting bugs or requesting features:
    # Edit .env with your configuration
    ```
 
-5. Set up the database:
+5. Set up the database (creates DBs if missing, then migrates main + test):
 
    ```bash
-   pnpm --filter @branchforge/backend db:migrate
+   pnpm --filter @branchforge/backend db:bootstrap
    ```
 
 6. Start development servers:

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ pnpm install
 cp .env.example .env
 # Edit .env - required: SESSION_SECRET, ENCRYPTION_KEY (32-byte hex)
 
-# Prepare the database
-pnpm --filter @branchforge/backend db:migrate
+# Prepare the database (creates DBs if missing, then migrates main + test)
+pnpm --filter @branchforge/backend db:bootstrap
 
 # Start writing!
 pnpm dev

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -12,6 +12,7 @@
     "test:integration": "dotenv -e ../../.env -- vitest run --config vitest.integration.config.ts",
     "db:generate": "tsc -p tsconfig.schema.json && drizzle-kit --config=drizzle.config.cjs generate",
     "db:validate": "tsx scripts/validate-migrations.ts",
+    "db:bootstrap": "dotenv -e ../../.env -- tsx scripts/db-bootstrap.ts",
     "db:migrate": "dotenv -e ../../.env -- tsx scripts/run-migrations.ts",
     "db:migrate:dev": "drizzle-kit --config=drizzle.config.cjs push",
     "db:migrate:test": "tsc -p tsconfig.schema.json && NODE_ENV=test dotenv -e ../../.env -- tsx scripts/run-migrations.ts",

--- a/apps/backend/scripts/db-bootstrap.ts
+++ b/apps/backend/scripts/db-bootstrap.ts
@@ -1,0 +1,162 @@
+/**
+ * Bootstrap local/dev databases for a fresh Postgres instance.
+ *
+ * Ensures DATABASE_URL and DATABASE_URL_TEST databases exist, then runs
+ * migrations on both. Safe to re-run.
+ *
+ * Usage: pnpm db:bootstrap
+ */
+
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { drizzle } from "drizzle-orm/node-postgres";
+import pg from "pg";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const { Client, Pool } = pg;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const migrationsFolder = resolve(__dirname, "../src/db/migrations");
+
+function requireEnv(name: "DATABASE_URL" | "DATABASE_URL_TEST"): string {
+  const value = process.env[name] ?? "";
+  if (!value) {
+    throw new Error(`${name} environment variable is required`);
+  }
+  return value;
+}
+
+function databaseNameFromUrl(connectionString: string): string {
+  const url = new URL(connectionString);
+  const dbName = decodeURIComponent(url.pathname.replace(/^\//, ""));
+  if (!dbName) {
+    throw new Error(
+      `Connection string is missing a database name: ${url.host}`
+    );
+  }
+  return dbName;
+}
+
+function quoteIdent(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function adminConnectionString(
+  connectionString: string,
+  maintenanceDb: string
+): string {
+  const url = new URL(connectionString);
+  url.pathname = `/${maintenanceDb}`;
+  return url.toString();
+}
+
+async function databaseExists(connectionString: string): Promise<boolean> {
+  const client = new Client({ connectionString });
+  try {
+    await client.connect();
+    return true;
+  } catch (error) {
+    const code =
+      typeof error === "object" && error !== null && "code" in error
+        ? String((error as { code: unknown }).code)
+        : undefined;
+    if (code === "3D000") {
+      // invalid_catalog_name — database does not exist
+      return false;
+    }
+    throw error;
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+async function createDatabase(connectionString: string, dbName: string) {
+  const maintenanceDbs = ["postgres", "template1"];
+  let lastError: unknown;
+
+  for (const maintenanceDb of maintenanceDbs) {
+    const client = new Client({
+      connectionString: adminConnectionString(connectionString, maintenanceDb),
+    });
+
+    try {
+      await client.connect();
+      const existing = await client.query(
+        "SELECT 1 FROM pg_database WHERE datname = $1",
+        [dbName]
+      );
+
+      if ((existing.rowCount ?? 0) > 0) {
+        console.log(`✓ Database "${dbName}" already exists`);
+        return;
+      }
+
+      // CREATE DATABASE cannot use query parameters for the identifier.
+      await client.query(`CREATE DATABASE ${quoteIdent(dbName)}`);
+      console.log(`✓ Created database "${dbName}"`);
+      return;
+    } catch (error) {
+      lastError = error;
+    } finally {
+      await client.end().catch(() => {});
+    }
+  }
+
+  throw new Error(
+    `Failed to create database "${dbName}". Ensure the Postgres role can connect to postgres/template1 and has CREATEDB. Last error: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`
+  );
+}
+
+async function ensureDatabase(label: string, connectionString: string) {
+  const dbName = databaseNameFromUrl(connectionString);
+  console.log(`Checking ${label} database "${dbName}"...`);
+
+  if (await databaseExists(connectionString)) {
+    console.log(`✓ Database "${dbName}" already exists`);
+    return;
+  }
+
+  console.log(`Database "${dbName}" is missing; creating...`);
+  await createDatabase(connectionString, dbName);
+}
+
+async function runMigrations(label: string, connectionString: string) {
+  const pool = new Pool({
+    connectionString,
+    max: 1,
+  });
+
+  try {
+    const db = drizzle(pool, { logger: false });
+    console.log(`Running migrations on ${label} database...`);
+    await migrate(db, { migrationsFolder });
+    console.log(`✓ Migrations completed on ${label}`);
+  } finally {
+    await pool.end().catch(() => {});
+  }
+}
+
+async function bootstrap() {
+  const mainUrl = requireEnv("DATABASE_URL");
+  const testUrl = requireEnv("DATABASE_URL_TEST");
+
+  console.log("Bootstrapping BranchForge databases...\n");
+
+  await ensureDatabase("MAIN", mainUrl);
+  await ensureDatabase("TEST", testUrl);
+
+  console.log(`\nMigrations folder: ${migrationsFolder}\n`);
+
+  await runMigrations("MAIN", mainUrl);
+  await runMigrations("TEST", testUrl);
+
+  console.log("\n✅ Database bootstrap completed successfully");
+}
+
+bootstrap().catch((error) => {
+  console.error("❌ Database bootstrap failed:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description

Adds a `db:bootstrap` command for fresh Postgres hosts (create missing main/test databases, then migrate both), and ignores local agent tooling directories while keeping tracked `CLAUDE.md`.

## Type of Change

- [x] Chore / tooling
- [x] Documentation update

## Related Issue

N/A — follow-up from moving to a new server where Postgres only had the default `postgres` database.

## Changes Made

- Added `apps/backend/scripts/db-bootstrap.ts` and `pnpm --filter @branchforge/backend db:bootstrap`
- Updated Quick Start / contributor setup to use bootstrap instead of migrate alone
- Ignored `.claude/` (with `!.claude/CLAUDE.md` exception) and `.cursor/` in `.gitignore`

## Testing

- [x] Manually tested the following scenarios:
  - Idempotent bootstrap against existing `branchforge` / `branchforge_test`
  - Dropped `branchforge_test`, re-ran bootstrap, confirmed DB recreate + 58 migrations
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests

## Checklist

- [x] My code follows the style guidelines of this project (run `pnpm lint` and `pnpm format`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings (run `pnpm typecheck`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run `pnpm changeset` (if applicable)

## Additional Notes

Use this on a fresh server after Postgres is up:

```bash
pnpm --filter @branchforge/backend db:bootstrap
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a database bootstrap command that creates missing databases and applies migrations for both main and test environments.
  * The setup process can be safely rerun and reports progress during execution.
* **Documentation**
  * Updated the Quick Start and contributor setup instructions to use the new bootstrap command instead of migration-only setup.
* **Chores**
  * Updated repository ignore rules for local development configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->