### PR TITLE
feat: document keyboard shortcuts with in-app help and docs (#16)

### DIFF
--- a/.changeset/keyboard-shortcuts-docs.md
+++ b/.changeset/keyboard-shortcuts-docs.md
@@ -1,0 +1,5 @@
+---
+"@branchforge/frontend": patch
+---
+
+Documented keyboard shortcuts with an in-app help dialog, contextual hints, and a user guide page

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -40,7 +40,10 @@ export default defineConfig({
         },
         {
           text: "Reference",
-          items: [{ text: "Characters & Stats", link: "/user/characters" }],
+          items: [
+            { text: "Keyboard Shortcuts", link: "/user/keyboard-shortcuts" },
+            { text: "Characters & Stats", link: "/user/characters" },
+          ],
         },
       ],
       "/dev/": [

--- a/apps/docs/user/keyboard-shortcuts.md
+++ b/apps/docs/user/keyboard-shortcuts.md
@@ -1,0 +1,77 @@
+---
+title: Keyboard Shortcuts
+---
+
+# Keyboard Shortcuts
+
+BranchForge supports keyboard shortcuts across Write Mode and Script Mode. This page is the canonical reference for app and editor commands.
+
+## Modifier key notation
+
+Throughout this guide, **mod** means the primary modifier on your platform:
+
+| Platform        | Key      | Also called |
+| --------------- | -------- | ----------- |
+| Windows / Linux | **Ctrl** | Control     |
+| macOS           | **Cmd**  | Command (⌘) |
+
+Examples: `mod+s` is **Ctrl+S** on Windows/Linux and **Cmd+S** on macOS. `mod+shift+f` is **Ctrl+Shift+F** or **Cmd+Shift+F**.
+
+::: tip
+You can also open the in-app **Keyboard shortcuts** help from the sidebar or overflow menu while working in a project. It lists the same shortcuts for your current platform.
+:::
+
+## General
+
+These shortcuts work in both Write Mode and Script Mode.
+
+| Action            | Shortcut                 |
+| ----------------- | ------------------------ |
+| Save              | `mod+s`                  |
+| Undo              | `mod+z`                  |
+| Redo              | `mod+y` or `mod+shift+z` |
+| Toggle focus mode | `mod+shift+f`            |
+
+**Save** manually persists the current Script Mode file or Write Mode draft. Write Mode also autosaves in the background.
+
+**Undo** and **Redo** apply to BranchForge's in-memory editor history. Native undo and redo still work inside focused text fields.
+
+**Focus mode** hides chrome for a distraction-free editing surface. Use the same shortcut to exit.
+
+## Write Mode
+
+These apply while a dialogue line editor is focused.
+
+| Action            | Shortcut         |
+| ----------------- | ---------------- |
+| Add line          | `Enter`          |
+| Delete empty line | `Backspace`      |
+| Move line up      | `mod+arrow up`   |
+| Move line down    | `mod+arrow down` |
+
+**Add line** inserts a new dialogue line below the focused line. **Shift+Enter** inserts a newline inside the current line instead.
+
+**Delete empty line** removes the focused line only when all of the following are true:
+
+- The line has no text
+- The line is not a menu choice
+- At least one other line exists in the scene
+
+**Move line up** / **Move line down** reorder the focused dialogue line within the scene.
+
+## Script Mode
+
+Script Mode search uses CodeMirror editor commands inside the script editor.
+
+| Action        | Shortcut                    |
+| ------------- | --------------------------- |
+| Find          | `mod+f`                     |
+| Find next     | `F3` or `mod+g`             |
+| Find previous | `Shift+F3` or `mod+shift+g` |
+| Close search  | `Esc`                       |
+
+Open **Find** to search the open file. Use **Find next** and **Find previous** to move between matches. Press **Esc** to close the search panel.
+
+## Accessibility navigation
+
+BranchForge follows standard keyboard patterns for tabs, listboxes, menus, and other widgets (arrow keys, Home/End, Enter, Space, Escape, and so on). Those patterns are accessibility behavior, not app-specific shortcuts, and are not listed exhaustively here.

--- a/apps/docs/user/script-mode.md
+++ b/apps/docs/user/script-mode.md
@@ -27,7 +27,7 @@ When you switch back to Write Mode, BranchForge re-parses the source and the [te
 Script Mode uses CodeMirror 6 with custom Ren'Py syntax highlighting:
 
 - **Syntax highlighting** — keywords, strings, labels, and characters are colorized
-- **Search** — full-text search across the open file (`Ctrl/Cmd + F`)
+- **Search** — full-text search across the open file (see [Keyboard Shortcuts](./keyboard-shortcuts#script-mode) for find, next/previous match, and close)
 - **Font size** — adjust to your preference via the toolbar
 - **Line wrap** — toggle long-line wrapping
 

--- a/apps/docs/user/writing.md
+++ b/apps/docs/user/writing.md
@@ -29,14 +29,7 @@ Press Enter after each line to continue.
 
 ## Autosave
 
-Write Mode saves your work automatically every few seconds. You can also press Ctrl/Cmd + S to save manually.
-
-## Undo and Redo
-
-Use standard keyboard shortcuts to undo and redo:
-
-- Ctrl/Cmd + Z: Undo
-- Ctrl/Cmd + Shift + Z: Redo
+Write Mode saves your work automatically every few seconds. You can also save manually, undo and redo changes, and toggle focus mode from the keyboard. See [Keyboard Shortcuts](./keyboard-shortcuts) for the full list.
 
 ## Technical Badges (Display Only)
 

--- a/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
+++ b/apps/frontend/src/components/ide-shared/LeftSidebar.tsx
@@ -8,6 +8,7 @@ import { ProjectSettingsDialog } from "@/components/ProjectSettingsDialog";
 import { GitLabImportDialog } from "./GitLabImportDialog/GitLabImportDialog.lazy";
 import { ZipImportProjectDialog } from "./ZipImportProjectDialog/ZipImportProjectDialog.lazy";
 import { FlowDialog } from "@/components/flow/FlowDialog";
+import { KeyboardShortcutsDialog } from "@/components/keyboard-shortcuts";
 import { Logo } from "@/components/ui/logo";
 import { ModeSwitcher } from "./ModeSwitcher";
 import { ProjectSelector } from "./ProjectSelector";
@@ -61,7 +62,8 @@ type ModalKey =
   | "projectPopover"
   | "gitLabImport"
   | "zipImport"
-  | "flow";
+  | "flow"
+  | "keyboardShortcuts";
 interface ModalState {
   themeDropdown: boolean;
   settings: boolean;
@@ -70,6 +72,7 @@ interface ModalState {
   gitLabImport: boolean;
   zipImport: boolean;
   flow: boolean;
+  keyboardShortcuts: boolean;
 }
 type ModalAction =
   | { type: "OPEN"; key: ModalKey }
@@ -84,6 +87,7 @@ const initialModalState: ModalState = {
   gitLabImport: false,
   zipImport: false,
   flow: false,
+  keyboardShortcuts: false,
 };
 
 function modalReducer(state: ModalState, action: ModalAction): ModalState {
@@ -236,6 +240,9 @@ export function LeftSidebar(props: LeftSidebarProps) {
           <UserActions
             isCollapsed={isCollapsed}
             showLabel={showLabel}
+            onOpenKeyboardShortcuts={() =>
+              dispatchModal({ type: "OPEN", key: "keyboardShortcuts" })
+            }
             onOpenSettings={() => setSettingsOpen(true)}
             onLogout={onLogout}
           />
@@ -260,6 +267,9 @@ export function LeftSidebar(props: LeftSidebarProps) {
           dispatchModal({ type: "OPEN", key: "projectSettings" })
         }
         onOpenFlow={() => dispatchModal({ type: "OPEN", key: "flow" })}
+        onOpenKeyboardShortcuts={() =>
+          dispatchModal({ type: "OPEN", key: "keyboardShortcuts" })
+        }
         onOpenSettings={() => setSettingsOpen(true)}
         onLogout={onLogout}
         isDarkMode={isDarkMode}
@@ -320,6 +330,15 @@ export function LeftSidebar(props: LeftSidebarProps) {
           projectId={projectId}
         />
       )}
+      <KeyboardShortcutsDialog
+        open={modals.keyboardShortcuts}
+        onOpenChange={(open: boolean) =>
+          dispatchModal({
+            type: open ? "OPEN" : "CLOSE",
+            key: "keyboardShortcuts",
+          })
+        }
+      />
     </>
   );
 }

--- a/apps/frontend/src/components/ide-shared/SidebarMobileMenu.tsx
+++ b/apps/frontend/src/components/ide-shared/SidebarMobileMenu.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useEffectEvent, useRef, useState } from "react";
-import { BookOpen, SquarePen, Menu, Settings, LogOut } from "lucide-react";
+import {
+  BookOpen,
+  SquarePen,
+  Menu,
+  Keyboard,
+  Settings,
+  LogOut,
+} from "lucide-react";
 import { IconButton } from "@/components/ui/icon-button";
 import { ProjectSelector } from "./ProjectSelector";
 import { NavButtons } from "./NavButtons";
@@ -21,6 +28,7 @@ interface SidebarMobileMenuProps {
   onCloseProjectPopover: () => void;
   onOpenProjectSettings: () => void;
   onOpenFlow: () => void;
+  onOpenKeyboardShortcuts: () => void;
   onOpenSettings: () => void;
   onLogout: () => void;
   isDarkMode: boolean;
@@ -43,6 +51,7 @@ export function SidebarMobileMenu({
   onCloseProjectPopover,
   onOpenProjectSettings,
   onOpenFlow,
+  onOpenKeyboardShortcuts,
   onOpenSettings,
   onLogout,
   isDarkMode,
@@ -172,6 +181,22 @@ export function SidebarMobileMenu({
                 onToggle={() => {}}
                 onClose={() => {}}
               />
+            </div>
+
+            <div className="p-2 rounded-md text-sm font-medium text-muted-foreground border-b border-muted/60 transition-colors">
+              <button
+                type="button"
+                onClick={() => {
+                  setMobileMenuOpen(false);
+                  onOpenKeyboardShortcuts();
+                }}
+                className="flex items-center gap-3 p-2 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                title="Keyboard shortcuts"
+                aria-label="Keyboard shortcuts"
+              >
+                <Keyboard className="size-4 flex-shrink-0" />
+                <span>Keyboard shortcuts</span>
+              </button>
             </div>
 
             <div className="p-2 rounded-md text-sm font-medium text-muted-foreground border-b border-muted/60 transition-colors">

--- a/apps/frontend/src/components/ide-shared/UndoRedoControls.tsx
+++ b/apps/frontend/src/components/ide-shared/UndoRedoControls.tsx
@@ -3,16 +3,15 @@
  *
  * Undo/redo buttons with keyboard shortcuts.
  *
- * Shortcuts:
- * - Undo: Ctrl+Z (Windows/Linux) or Cmd+Z (macOS)
- * - Redo: Ctrl+Y or Ctrl+Shift+Z (Windows/Linux)
- *         Cmd+Y or Cmd+Shift+Z (macOS)
+ * Shortcuts are defined in @/lib/keyboard-shortcuts (undo, redo).
  *
  * Uses local in-memory undo only for instant response.
  */
 
 import { useEffect, useRef } from "react";
 import { Undo2, Redo2 } from "lucide-react";
+import { Tooltip } from "@/components/ui/tooltip";
+import { getShortcutActionDescription } from "@/lib/keyboard-shortcuts";
 
 interface UndoRedoControlsProps {
   canUndo: boolean;
@@ -27,6 +26,9 @@ export function UndoRedoControls({
   onUndo,
   onRedo,
 }: UndoRedoControlsProps) {
+  const undoHint = getShortcutActionDescription("undo", "Undo");
+  const redoHint = getShortcutActionDescription("redo", "Redo");
+
   // Store handlers in refs to avoid re-subscribing to keydown on every render
   const onUndoRef = useRef(onUndo);
   const onRedoRef = useRef(onRedo);
@@ -79,36 +81,38 @@ export function UndoRedoControls({
 
   return (
     <div className="flex items-center gap-1">
-      <button
-        type="button"
-        onClick={onUndo}
-        disabled={!canUndo}
-        aria-disabled={!canUndo}
-        className={`p-1.5 rounded-md transition-all ${
-          canUndo
-            ? "hover:bg-muted text-foreground hover:text-[var(--theme-color)]"
-            : "text-muted-foreground/30 cursor-not-allowed"
-        }`}
-        title="Undo (Ctrl+Z / Cmd+Z)"
-        aria-label="Undo"
-      >
-        <Undo2 className="size-4" />
-      </button>
-      <button
-        type="button"
-        onClick={onRedo}
-        disabled={!canRedo}
-        aria-disabled={!canRedo}
-        className={`p-1.5 rounded-md transition-all ${
-          canRedo
-            ? "hover:bg-muted text-foreground hover:text-[var(--theme-color)]"
-            : "text-muted-foreground/30 cursor-not-allowed"
-        }`}
-        title="Redo (Ctrl+Y / Cmd+Shift+Z)"
-        aria-label="Redo"
-      >
-        <Redo2 className="size-4" />
-      </button>
+      <Tooltip content={undoHint}>
+        <button
+          type="button"
+          onClick={onUndo}
+          disabled={!canUndo}
+          aria-disabled={!canUndo}
+          className={`p-1.5 rounded-md transition-all ${
+            canUndo
+              ? "hover:bg-muted text-foreground hover:text-[var(--theme-color)]"
+              : "text-muted-foreground/30 cursor-not-allowed"
+          }`}
+          aria-label="Undo"
+        >
+          <Undo2 className="size-4" />
+        </button>
+      </Tooltip>
+      <Tooltip content={redoHint}>
+        <button
+          type="button"
+          onClick={onRedo}
+          disabled={!canRedo}
+          aria-disabled={!canRedo}
+          className={`p-1.5 rounded-md transition-all ${
+            canRedo
+              ? "hover:bg-muted text-foreground hover:text-[var(--theme-color)]"
+              : "text-muted-foreground/30 cursor-not-allowed"
+          }`}
+          aria-label="Redo"
+        >
+          <Redo2 className="size-4" />
+        </button>
+      </Tooltip>
     </div>
   );
 }

--- a/apps/frontend/src/components/ide-shared/UserActions.tsx
+++ b/apps/frontend/src/components/ide-shared/UserActions.tsx
@@ -1,8 +1,10 @@
-import { Settings, LogOut } from "lucide-react";
+import { Keyboard, Settings, LogOut } from "lucide-react";
+import { Tooltip } from "@/components/ui/tooltip";
 
 interface UserActionsProps {
   isCollapsed: boolean;
   showLabel: boolean;
+  onOpenKeyboardShortcuts: () => void;
   onOpenSettings: () => void;
   onLogout: () => void;
 }
@@ -11,11 +13,34 @@ interface UserActionsProps {
 export function UserActions({
   isCollapsed,
   showLabel,
+  onOpenKeyboardShortcuts,
   onOpenSettings,
   onLogout,
 }: UserActionsProps) {
+  const keyboardShortcutsButton = (
+    <button
+      type="button"
+      onClick={onOpenKeyboardShortcuts}
+      className={`flex items-center ${
+        isCollapsed ? "justify-center p-3.5" : "gap-3 p-2"
+      } rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors`}
+      title={isCollapsed ? undefined : "Keyboard shortcuts"}
+      aria-label="Keyboard shortcuts"
+    >
+      <Keyboard className="size-4 flex-shrink-0" />
+      {showLabel && <span>Keyboard shortcuts</span>}
+    </button>
+  );
+
   return (
     <>
+      {isCollapsed ? (
+        <Tooltip content="Keyboard shortcuts">
+          {keyboardShortcutsButton}
+        </Tooltip>
+      ) : (
+        keyboardShortcutsButton
+      )}
       <button
         type="button"
         onClick={onOpenSettings}

--- a/apps/frontend/src/components/ide-shared/__tests__/LeftSidebar.test.tsx
+++ b/apps/frontend/src/components/ide-shared/__tests__/LeftSidebar.test.tsx
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastProvider } from "@/contexts/ToastContext";
 import { LeftSidebar } from "../LeftSidebar";
@@ -151,10 +152,34 @@ describe("LeftSidebar accessibility", () => {
   it("renders user action buttons with aria-labels", () => {
     render(<LeftSidebar {...defaultProps} />, { wrapper: createWrapper() });
 
+    const keyboardShortcutsButtons = screen.getAllByRole("button", {
+      name: "Keyboard shortcuts",
+    });
+    expect(keyboardShortcutsButtons.length).toBeGreaterThanOrEqual(1);
+    keyboardShortcutsButtons.forEach((btn) =>
+      expect(btn).toHaveAttribute("aria-label", "Keyboard shortcuts")
+    );
+
     expect(
       screen.getByRole("button", { name: "Settings" })
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Logout" })).toBeInTheDocument();
+  });
+
+  it("opens the keyboard shortcuts dialog from the help trigger", async () => {
+    const user = userEvent.setup();
+    render(<LeftSidebar {...defaultProps} />, { wrapper: createWrapper() });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    const helpTriggers = screen.getAllByRole("button", {
+      name: "Keyboard shortcuts",
+    });
+    await user.click(helpTriggers[0]!);
+
+    expect(
+      screen.getByRole("heading", { name: "Keyboard shortcuts" })
+    ).toBeInTheDocument();
   });
 
   it("renders mobile bottom nav hamburger with dynamic aria-label (closed state)", () => {

--- a/apps/frontend/src/components/ide-shared/__tests__/UndoRedoControls.test.tsx
+++ b/apps/frontend/src/components/ide-shared/__tests__/UndoRedoControls.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { getShortcutActionDescription } from "@/lib/keyboard-shortcuts";
 import { UndoRedoControls } from "../UndoRedoControls";
 
 describe("UndoRedoControls", () => {
@@ -250,16 +251,23 @@ describe("UndoRedoControls", () => {
       expect(redoButton).toHaveAttribute("aria-disabled", "true");
     });
 
-    it("should have proper title attributes for tooltips", () => {
+    it("should show registry-derived shortcut hints in tooltips", () => {
       render(
         <UndoRedoControls canUndo={true} canRedo={true} {...mockHandlers} />
       );
 
+      const undoHint = getShortcutActionDescription("undo", "Undo");
+      const redoHint = getShortcutActionDescription("redo", "Redo");
+
+      fireEvent.focus(screen.getByLabelText("Undo"));
       expect(
-        screen.getByTitle(/Undo \(Ctrl\+Z \/ Cmd\+Z\)/)
+        screen.getByRole("tooltip", { name: undoHint })
       ).toBeInTheDocument();
+
+      fireEvent.blur(screen.getByLabelText("Undo"));
+      fireEvent.focus(screen.getByLabelText("Redo"));
       expect(
-        screen.getByTitle(/Redo \(Ctrl\+Y \/ Cmd\+Shift\+Z\)/)
+        screen.getByRole("tooltip", { name: redoHint })
       ).toBeInTheDocument();
     });
   });

--- a/apps/frontend/src/components/keyboard-shortcuts/KeyboardShortcutKeys.tsx
+++ b/apps/frontend/src/components/keyboard-shortcuts/KeyboardShortcutKeys.tsx
@@ -1,0 +1,46 @@
+import { Fragment } from "react";
+import {
+  formatChordAccessible,
+  formatChordVisual,
+  type ShortcutChord,
+  type ShortcutPlatform,
+} from "@/lib/keyboard-shortcuts";
+import { cn } from "@/lib/utils";
+
+interface KeyboardShortcutKeysProps {
+  chord: ShortcutChord;
+  platform: ShortcutPlatform;
+  className?: string;
+}
+
+export function KeyboardShortcutKeys({
+  chord,
+  platform,
+  className,
+}: KeyboardShortcutKeysProps) {
+  const keyLabels = formatChordVisual(chord, platform);
+  const accessibleLabel = formatChordAccessible(chord, platform);
+
+  return (
+    <span className={cn("inline-flex items-center", className)}>
+      <span className="sr-only">{accessibleLabel}</span>
+      <span
+        aria-hidden
+        className="inline-flex items-center gap-0.5 flex-wrap justify-end"
+      >
+        {keyLabels.map((label, index) => (
+          <Fragment key={`${label}-${index}`}>
+            {index > 0 ? (
+              <span className="px-0.5 text-[10px] text-muted-foreground">
+                +
+              </span>
+            ) : null}
+            <kbd className="inline-flex min-h-6 min-w-6 items-center justify-center rounded border border-border/30 bg-muted/60 px-1.5 text-[11px] font-medium leading-none text-foreground">
+              {label}
+            </kbd>
+          </Fragment>
+        ))}
+      </span>
+    </span>
+  );
+}

--- a/apps/frontend/src/components/keyboard-shortcuts/KeyboardShortcutList.tsx
+++ b/apps/frontend/src/components/keyboard-shortcuts/KeyboardShortcutList.tsx
@@ -1,0 +1,58 @@
+import { Fragment } from "react";
+import {
+  KEYBOARD_SHORTCUT_GROUPS,
+  type ShortcutPlatform,
+} from "@/lib/keyboard-shortcuts";
+import { KeyboardShortcutKeys } from "./KeyboardShortcutKeys";
+
+interface KeyboardShortcutListProps {
+  platform: ShortcutPlatform;
+}
+
+export function KeyboardShortcutList({ platform }: KeyboardShortcutListProps) {
+  return (
+    <div className="space-y-8">
+      {KEYBOARD_SHORTCUT_GROUPS.map((group) => (
+        <section key={group.id} className="space-y-3">
+          <div className="space-y-1">
+            <h3 className="text-sm font-medium">{group.title}</h3>
+            {group.description ? (
+              <p className="text-sm text-muted-foreground">
+                {group.description}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            {group.shortcuts.map((shortcut) => (
+              <div
+                key={shortcut.id}
+                className="flex flex-col gap-3 rounded-md border border-border/30 p-3 sm:flex-row sm:items-start sm:justify-between"
+              >
+                <div className="min-w-0 space-y-1">
+                  <p className="text-sm font-medium">{shortcut.label}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {shortcut.description}
+                  </p>
+                </div>
+
+                <div className="flex shrink-0 flex-wrap items-center justify-start gap-2 sm:justify-end">
+                  {shortcut.chords.map((chord, chordIndex) => (
+                    <Fragment key={chordIndex}>
+                      {chordIndex > 0 ? (
+                        <span className="text-xs text-muted-foreground">
+                          or
+                        </span>
+                      ) : null}
+                      <KeyboardShortcutKeys chord={chord} platform={platform} />
+                    </Fragment>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/keyboard-shortcuts/KeyboardShortcutsDialog.tsx
+++ b/apps/frontend/src/components/keyboard-shortcuts/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+import { DialogShell } from "@/components/ui/DialogShell";
+import { detectShortcutPlatform } from "@/lib/keyboard-shortcuts";
+import { KeyboardShortcutList } from "./KeyboardShortcutList";
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function KeyboardShortcutsDialog({
+  open,
+  onOpenChange,
+}: KeyboardShortcutsDialogProps) {
+  const platform = useMemo(() => detectShortcutPlatform(), []);
+
+  return (
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Keyboard shortcuts"
+      description="Modifier keys follow your platform: Control (Ctrl) on Windows and Linux, Command (⌘) on macOS."
+      maxWidth="4xl"
+      footerMode="close-only"
+    >
+      <KeyboardShortcutList platform={platform} />
+    </DialogShell>
+  );
+}

--- a/apps/frontend/src/components/keyboard-shortcuts/__tests__/KeyboardShortcutsDialog.test.tsx
+++ b/apps/frontend/src/components/keyboard-shortcuts/__tests__/KeyboardShortcutsDialog.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import * as keyboardShortcuts from "@/lib/keyboard-shortcuts";
+import { KeyboardShortcutsDialog } from "../KeyboardShortcutsDialog";
+
+/**
+ * Interaction coverage for KeyboardShortcutsDialog.
+ *
+ * KeyboardShortcutsDialog is a DialogShell over the shared Dialog/useFocusTrap
+ * stack. This suite covers dialog-specific wiring:
+ * - trigger open + focus entry
+ * - footer Close / header X close
+ * - Escape via the native `cancel` event (jsdom does not implement Escape-to-close)
+ *
+ * Full Tab / Shift+Tab focus-trap cycling is covered by the shared primitive
+ * suite in `components/__tests__/DialogA11y.test.tsx`:
+ * - "cycles Tab from last to first focusable in dialog"
+ * - "cycles Shift+Tab from first to last focusable in dialog"
+ * Re-testing that trap here would only duplicate DialogShell's dependency.
+ */
+
+function ControlledDialog({
+  initiallyOpen = false,
+}: {
+  initiallyOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(initiallyOpen);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open shortcuts
+      </button>
+      <KeyboardShortcutsDialog open={open} onOpenChange={setOpen} />
+    </>
+  );
+}
+
+function getActiveElement() {
+  return document.activeElement as HTMLElement | null;
+}
+
+describe("KeyboardShortcutsDialog", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the open dialog with title, sections, and shortcuts", () => {
+    render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Keyboard shortcuts" })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("heading", { name: "General" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Write Mode" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Script Mode" })
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("Save")).toBeInTheDocument();
+    expect(screen.getByText("Undo")).toBeInTheDocument();
+    expect(screen.getByText("Redo")).toBeInTheDocument();
+    expect(screen.getByText("Toggle focus mode")).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+
+  it("follows dialog accessibility patterns for name and labelled content", () => {
+    render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} />);
+
+    const dialog = document.querySelector("dialog");
+    const heading = screen.getByRole("heading", { name: "Keyboard shortcuts" });
+
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog?.getAttribute("aria-labelledby")).toBe(
+      heading.getAttribute("id")
+    );
+    expect(
+      screen.getByText(
+        "Modifier keys follow your platform: Control (Ctrl) on Windows and Linux, Command (⌘) on macOS."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Close keyboard shortcuts dialog",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("uses mac platform keycaps when detectShortcutPlatform returns mac", () => {
+    vi.spyOn(keyboardShortcuts, "detectShortcutPlatform").mockReturnValue(
+      "mac"
+    );
+
+    render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} />);
+
+    expect(screen.getAllByText("⌘").length).toBeGreaterThan(0);
+  });
+
+  it("uses windows platform keycaps when detectShortcutPlatform returns windows", () => {
+    vi.spyOn(keyboardShortcuts, "detectShortcutPlatform").mockReturnValue(
+      "windows"
+    );
+
+    render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} />);
+
+    expect(screen.getAllByText("Ctrl").length).toBeGreaterThan(0);
+  });
+
+  it("opens from a trigger and moves focus into the dialog", async () => {
+    const user = userEvent.setup();
+    render(<ControlledDialog initiallyOpen={false} />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open shortcuts" }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Keyboard shortcuts" })
+    ).toBeInTheDocument();
+
+    const active = getActiveElement();
+    expect(active).not.toBeNull();
+    expect(dialog.contains(active)).toBe(true);
+  });
+
+  it("closes when the footer Close button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ControlledDialog initiallyOpen />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes when the header X close button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ControlledDialog initiallyOpen />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Close keyboard shortcuts dialog" })
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes on native cancel (Escape path in Dialog)", () => {
+    // jsdom does not fully implement native <dialog> Escape-to-close.
+    // Our Dialog listens for cancel and calls onOpenChange(false) — same
+    // pattern as DialogA11y.test.tsx.
+    render(<ControlledDialog initiallyOpen />);
+
+    const dialog = document.querySelector("dialog");
+    expect(dialog).not.toBeNull();
+
+    const cancelEvent = new Event("cancel", { cancelable: true });
+    act(() => {
+      dialog!.dispatchEvent(cancelEvent);
+    });
+
+    expect(cancelEvent.defaultPrevented).toBe(true);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/keyboard-shortcuts/index.ts
+++ b/apps/frontend/src/components/keyboard-shortcuts/index.ts
@@ -1,0 +1,3 @@
+export { KeyboardShortcutKeys } from "./KeyboardShortcutKeys";
+export { KeyboardShortcutList } from "./KeyboardShortcutList";
+export { KeyboardShortcutsDialog } from "./KeyboardShortcutsDialog";

--- a/apps/frontend/src/components/script-mode/ScriptEditor/ScriptEditorToolbar.tsx
+++ b/apps/frontend/src/components/script-mode/ScriptEditor/ScriptEditorToolbar.tsx
@@ -81,6 +81,7 @@ export function ScriptEditorToolbar({
               displayMode="compact"
               saveConflict={saveConflict}
               onRetry={onSaveRequest}
+              showSaveShortcutHint
             />
             <span className="w-px h-3 bg-border" aria-hidden="true" />
           </>

--- a/apps/frontend/src/components/write-mode/FocusModeToggle.tsx
+++ b/apps/frontend/src/components/write-mode/FocusModeToggle.tsx
@@ -9,6 +9,11 @@ import { memo } from "react";
 import type React from "react";
 import { Maximize2, Minimize2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Tooltip } from "@/components/ui/tooltip";
+import {
+  getFocusModeActionLabel,
+  getShortcutActionDescription,
+} from "@/lib/keyboard-shortcuts";
 
 interface FocusModeToggleProps {
   isFocusMode: boolean;
@@ -21,36 +26,39 @@ export const FocusModeToggle = memo(function FocusModeToggle({
   onToggle,
   ref,
 }: FocusModeToggleProps) {
-  const title = isFocusMode
-    ? "Exit focus mode (Ctrl+Shift+F)"
-    : "Enter focus mode (Ctrl+Shift+F)";
+  const actionLabel = getFocusModeActionLabel(isFocusMode);
+  const shortcutDescription = getShortcutActionDescription(
+    "focus-mode",
+    actionLabel
+  );
 
   return (
-    <button
-      type="button"
-      ref={ref}
-      onClick={onToggle}
-      aria-label={title}
-      title={title}
-      className={cn(
-        "group inline-flex items-center transition-all duration-200",
-        "focus-visible:outline-none focus-visible:ring-2",
-        "focus-visible:ring-[var(--theme-color)]/35",
-        isFocusMode
-          ? "gap-2 rounded-full border border-border/70 bg-card/90 px-3.5 py-2 whitespace-nowrap text-sm font-medium text-foreground shadow-lg backdrop-blur-sm hover:border-[var(--theme-color)]/35 hover:bg-card"
-          : "gap-2 rounded-md px-3 py-1.5 text-sm text-muted-foreground bg-muted/30 hover:bg-muted/60 hover:text-foreground hover:border-border/80 max-md:min-h-11"
-      )}
-    >
-      {isFocusMode ? (
-        <>
-          <span className="flex size-6 items-center justify-center rounded-full bg-[var(--theme-color)]/15 text-[var(--theme-color)]">
-            <Minimize2 className="size-3.5" />
-          </span>
-          <span className="font-semibold">Exit Focus</span>
-        </>
-      ) : (
-        <Maximize2 className="size-4" />
-      )}
-    </button>
+    <Tooltip content={shortcutDescription}>
+      <button
+        type="button"
+        ref={ref}
+        onClick={onToggle}
+        aria-label={actionLabel}
+        className={cn(
+          "group inline-flex items-center transition-all duration-200",
+          "focus-visible:outline-none focus-visible:ring-2",
+          "focus-visible:ring-[var(--theme-color)]/35",
+          isFocusMode
+            ? "gap-2 rounded-full border border-border/70 bg-card/90 px-3.5 py-2 whitespace-nowrap text-sm font-medium text-foreground shadow-lg backdrop-blur-sm hover:border-[var(--theme-color)]/35 hover:bg-card"
+            : "gap-2 rounded-md px-3 py-1.5 text-sm text-muted-foreground bg-muted/30 hover:bg-muted/60 hover:text-foreground hover:border-border/80 max-md:min-h-11"
+        )}
+      >
+        {isFocusMode ? (
+          <>
+            <span className="flex size-6 items-center justify-center rounded-full bg-[var(--theme-color)]/15 text-[var(--theme-color)]">
+              <Minimize2 className="size-3.5" />
+            </span>
+            <span className="font-semibold">Exit Focus</span>
+          </>
+        ) : (
+          <Maximize2 className="size-4" />
+        )}
+      </button>
+    </Tooltip>
   );
 });

--- a/apps/frontend/src/components/write-mode/ProseEditor/ProseEditorTopBar.tsx
+++ b/apps/frontend/src/components/write-mode/ProseEditor/ProseEditorTopBar.tsx
@@ -83,6 +83,7 @@ export function ProseEditorTopBar({
           displayMode="compact"
           lastSaved={lastSaved}
           saveConflict={saveConflict}
+          showSaveShortcutHint
         />
       </div>
     </div>

--- a/apps/frontend/src/components/write-mode/SaveIndicator.tsx
+++ b/apps/frontend/src/components/write-mode/SaveIndicator.tsx
@@ -14,6 +14,10 @@
 import { Check, AlertCircle, Loader2 } from "lucide-react";
 import { memo } from "react";
 import type { SaveStatus } from "@/hooks/useAutosave";
+import {
+  formatShortcutAccessible,
+  getKeyboardShortcut,
+} from "@/lib/keyboard-shortcuts";
 
 type SaveIndicatorDisplayMode = "compact" | "verbose";
 
@@ -23,6 +27,8 @@ interface SaveIndicatorProps {
   lastSaved?: Date | null;
   saveConflict?: boolean;
   onRetry?: () => void;
+  /** When true, append the save shortcut to status titles (write-mode discoverability). */
+  showSaveShortcutHint?: boolean;
 }
 
 // Constant lookup maps for O(1) status-based lookups
@@ -43,12 +49,28 @@ const STATUS_TEXT: Record<SaveStatus, { compact: string; verbose: string }> = {
   },
 };
 
+const saveShortcut = getKeyboardShortcut("save");
+const saveShortcutAccessible = saveShortcut
+  ? formatShortcutAccessible(saveShortcut)
+  : null;
+
+function withSaveShortcutHint(
+  statusText: string,
+  showSaveShortcutHint?: boolean
+): string {
+  if (!showSaveShortcutHint || !saveShortcutAccessible) {
+    return statusText;
+  }
+  return `${statusText} (${saveShortcutAccessible})`;
+}
+
 export const SaveIndicator = memo(function SaveIndicator({
   saveStatus,
   displayMode = "compact",
   lastSaved = null,
   saveConflict = false,
   onRetry,
+  showSaveShortcutHint = false,
 }: SaveIndicatorProps) {
   if (saveConflict) {
     return (
@@ -68,6 +90,7 @@ export const SaveIndicator = memo(function SaveIndicator({
   }
 
   const text = STATUS_TEXT[saveStatus][displayMode];
+  const title = withSaveShortcutHint(text, showSaveShortcutHint);
 
   // Compute icon JSX based on status
   const icon = (() => {
@@ -87,7 +110,7 @@ export const SaveIndicator = memo(function SaveIndicator({
       <output
         className="flex items-center justify-center text-xs transition-colors duration-300"
         aria-live="polite"
-        title={text}
+        title={title}
       >
         <span className={STATUS_TEXT_COLORS.saved}>{icon}</span>
       </output>
@@ -114,7 +137,7 @@ export const SaveIndicator = memo(function SaveIndicator({
       }`}
       role={isErrorWithRetry ? "button" : "status"}
       aria-live="polite"
-      title={text}
+      title={title}
       tabIndex={isErrorWithRetry ? 0 : undefined}
       onClick={isErrorWithRetry ? onRetry : undefined}
       onKeyDown={handleKeyDown}

--- a/apps/frontend/src/components/write-mode/__tests__/DialogueLine.test.tsx
+++ b/apps/frontend/src/components/write-mode/__tests__/DialogueLine.test.tsx
@@ -52,20 +52,40 @@ function renderWithQueryClient(ui: ReactElement) {
   );
 }
 
-const renderDialogueLine = (entry: DialogueEntry) =>
-  renderWithQueryClient(
+type DialogueLineOverrides = Partial<
+  Omit<React.ComponentProps<typeof DialogueLine>, "entry" | "characters">
+>;
+
+const renderDialogueLine = (
+  entry: DialogueEntry,
+  overrides: DialogueLineOverrides = {}
+) => {
+  const handlers = {
+    onChange: vi.fn(),
+    onDelete: vi.fn(),
+    onMoveUp: vi.fn(),
+    onMoveDown: vi.fn(),
+    onAddLine: vi.fn(),
+    index: 0,
+    totalEntries: 1,
+    ...overrides,
+  };
+
+  return renderWithQueryClient(
     <DialogueLine
       entry={entry}
       characters={characters}
       layoutMode="stacked"
-      index={0}
-      totalEntries={1}
-      onChange={vi.fn()}
-      onDelete={vi.fn()}
-      onMoveUp={vi.fn()}
-      onMoveDown={vi.fn()}
+      {...handlers}
     />
   );
+};
+
+async function focusDialogueTextarea(container: HTMLElement) {
+  const user = userEvent.setup();
+  await user.click(container.querySelector("[data-rendered-line-wrapper]")!);
+  return screen.getByRole("textbox") as HTMLTextAreaElement;
+}
 
 describe("DialogueLine", () => {
   it("speaker dropdown options have tabindex=-1 to prevent direct tab navigation", async () => {
@@ -197,6 +217,186 @@ describe("DialogueLine", () => {
     );
     expect(helloSpan).toBeDefined();
     expect((helloSpan as HTMLElement)?.style.fontWeight).toBe("bold");
+  });
+
+  describe("keyboard shortcuts", () => {
+    it("Enter adds a line via onAddLine", async () => {
+      const onAddLine = vi.fn();
+      const entry: DialogueEntry = {
+        id: "entry-1",
+        speakerId: null,
+        text: "Hello world",
+      };
+
+      const { container } = renderDialogueLine(entry, {
+        onAddLine,
+        index: 2,
+        totalEntries: 4,
+      });
+
+      const textarea = await focusDialogueTextarea(container);
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(onAddLine).toHaveBeenCalledWith(2);
+    });
+
+    it("Shift+Enter does not add a line", async () => {
+      const onAddLine = vi.fn();
+      const entry: DialogueEntry = {
+        id: "entry-1",
+        speakerId: null,
+        text: "Hello world",
+      };
+
+      const { container } = renderDialogueLine(entry, { onAddLine });
+      const textarea = await focusDialogueTextarea(container);
+
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
+      expect(onAddLine).not.toHaveBeenCalled();
+    });
+
+    it("Backspace on an empty non-choice line deletes when totalEntries > 1", async () => {
+      const onDelete = vi.fn();
+      const entry: DialogueEntry = {
+        id: "entry-1",
+        speakerId: null,
+        text: "",
+      };
+
+      const { container } = renderDialogueLine(entry, {
+        onDelete,
+        totalEntries: 2,
+      });
+      const textarea = await focusDialogueTextarea(container);
+
+      fireEvent.keyDown(textarea, { key: "Backspace" });
+
+      expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it("Backspace on a non-empty line does not delete", async () => {
+      const onDelete = vi.fn();
+      const entry: DialogueEntry = {
+        id: "entry-1",
+        speakerId: null,
+        text: "Still here",
+      };
+
+      const { container } = renderDialogueLine(entry, {
+        onDelete,
+        totalEntries: 2,
+      });
+      const textarea = await focusDialogueTextarea(container);
+
+      fireEvent.keyDown(textarea, { key: "Backspace" });
+
+      expect(onDelete).not.toHaveBeenCalled();
+    });
+
+    it("Ctrl/Meta+ArrowUp calls onMoveUp when not the first line", async () => {
+      const onMoveUp = vi.fn();
+      const entry: DialogueEntry = {
+        id: "entry-2",
+        speakerId: null,
+        text: "Second line",
+      };
+
+      const { container } = renderDialogueLine(entry, {
+        onMoveUp,
+        index: 1,
+        totalEntries: 3,
+      });
+      const textarea = await focusDialogueTextarea(container);
+
+      fireEvent.keyDown(textarea, {
+        key: "ArrowUp",
+        ctrlKey: true,
+      });
+      expect(onMoveUp).toHaveBeenCalledTimes(1);
+
+      onMoveUp.mockClear();
+      fireEvent.keyDown(textarea, {
+        key: "ArrowUp",
+        metaKey: true,
+      });
+      expect(onMoveUp).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onMoveUp at the first line", async () => {
+      const onMoveUp = vi.fn();
+      const entry: DialogueEntry = {
+        id: "entry-1",
+        speakerId: null,
+        text: "First line",
+      };
+
+      const { container } = renderDialogueLine(entry, {
+        onMoveUp,
+        index: 0,
+        totalEntries: 3,
+      });
+      const textarea = await focusDialogueTextarea(container);
+
+      fireEvent.keyDown(textarea, {
+        key: "ArrowUp",
+        ctrlKey: true,
+      });
+
+      expect(onMoveUp).not.toHaveBeenCalled();
+    });
+
+    it("Ctrl/Meta+ArrowDown calls onMoveDown when not the last line", async () => {
+      const onMoveDown = vi.fn();
+      const entry: DialogueEntry = {
+        id: "entry-1",
+        speakerId: null,
+        text: "First line",
+      };
+
+      const { container } = renderDialogueLine(entry, {
+        onMoveDown,
+        index: 0,
+        totalEntries: 3,
+      });
+      const textarea = await focusDialogueTextarea(container);
+
+      fireEvent.keyDown(textarea, {
+        key: "ArrowDown",
+        ctrlKey: true,
+      });
+      expect(onMoveDown).toHaveBeenCalledTimes(1);
+
+      onMoveDown.mockClear();
+      fireEvent.keyDown(textarea, {
+        key: "ArrowDown",
+        metaKey: true,
+      });
+      expect(onMoveDown).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onMoveDown at the last line", async () => {
+      const onMoveDown = vi.fn();
+      const entry: DialogueEntry = {
+        id: "entry-3",
+        speakerId: null,
+        text: "Last line",
+      };
+
+      const { container } = renderDialogueLine(entry, {
+        onMoveDown,
+        index: 2,
+        totalEntries: 3,
+      });
+      const textarea = await focusDialogueTextarea(container);
+
+      fireEvent.keyDown(textarea, {
+        key: "ArrowDown",
+        ctrlKey: true,
+      });
+
+      expect(onMoveDown).not.toHaveBeenCalled();
+    });
   });
 
   it("applies narrator styling (italic + muted color) to speaker button and textarea", async () => {

--- a/apps/frontend/src/hooks/__tests__/useFileEditor.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useFileEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, fireEvent, renderHook, waitFor } from "@testing-library/react";
 import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
@@ -282,6 +282,69 @@ describe("useFileEditor", () => {
       "This file changed elsewhere. Reload project files before editing again.",
       "Script conflict detected"
     );
+  });
+
+  it("saves on Ctrl+S and Meta+S keyboard shortcuts", async () => {
+    const updateFileContent = vi.fn().mockResolvedValue({
+      success: true,
+      contentHash: "hash-after-ctrl-save",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    });
+    const showErrorToast = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useFileEditor({
+          projectId: "project-1",
+          projectFiles: [FILE_A],
+          updateFileContent,
+          showErrorToast,
+        }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      const switched = await result.current.switchToFile(FILE_A);
+      expect(switched).toBe(true);
+    });
+
+    act(() => {
+      result.current.setEditedFileContent("saved with ctrl+s");
+    });
+
+    act(() => {
+      fireEvent.keyDown(window, { ctrlKey: true, code: "KeyS" });
+    });
+
+    await waitFor(() => {
+      expect(updateFileContent).toHaveBeenCalledWith(
+        "file-1",
+        "saved with ctrl+s",
+        {
+          expectedContentHash: "hash-file-1",
+        }
+      );
+    });
+
+    act(() => {
+      result.current.setEditedFileContent("saved with meta+s");
+    });
+
+    act(() => {
+      fireEvent.keyDown(window, { metaKey: true, code: "KeyS" });
+    });
+
+    await waitFor(() => {
+      expect(updateFileContent).toHaveBeenCalledWith(
+        "file-1",
+        "saved with meta+s",
+        {
+          expectedContentHash: "hash-after-ctrl-save",
+        }
+      );
+    });
+
+    expect(showErrorToast).not.toHaveBeenCalled();
   });
 
   it("blocks switching files when pending save cannot flush", async () => {

--- a/apps/frontend/src/hooks/__tests__/useFocusModeKeyboardHandler.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useFocusModeKeyboardHandler.test.tsx
@@ -1,0 +1,55 @@
+import { act, fireEvent, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useFocusModeKeyboardHandler } from "../useFocusModeKeyboardHandler";
+
+describe("useFocusModeKeyboardHandler", () => {
+  it("calls onToggle on Ctrl+Shift+F", () => {
+    const onToggle = vi.fn();
+
+    renderHook(() => useFocusModeKeyboardHandler(onToggle));
+
+    act(() => {
+      fireEvent.keyDown(window, {
+        ctrlKey: true,
+        shiftKey: true,
+        code: "KeyF",
+      });
+    });
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onToggle on Meta+Shift+F", () => {
+    const onToggle = vi.fn();
+
+    renderHook(() => useFocusModeKeyboardHandler(onToggle));
+
+    act(() => {
+      fireEvent.keyDown(window, {
+        metaKey: true,
+        shiftKey: true,
+        code: "KeyF",
+      });
+    });
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes the keydown listener on unmount", () => {
+    const onToggle = vi.fn();
+
+    const { unmount } = renderHook(() => useFocusModeKeyboardHandler(onToggle));
+
+    unmount();
+
+    act(() => {
+      fireEvent.keyDown(window, {
+        ctrlKey: true,
+        shiftKey: true,
+        code: "KeyF",
+      });
+    });
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/__tests__/useLocalStorage.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useLocalStorage.test.tsx
@@ -73,7 +73,9 @@ describe("useLocalStorage", () => {
 
   it("warns and falls back when read throws", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+    // Spy the localStorage instance — not Storage.prototype — so sessionStorage
+    // and other Storage consumers stay unaffected.
+    vi.spyOn(localStorage, "getItem").mockImplementation(() => {
       throw new Error("read-failure");
     });
 
@@ -85,7 +87,7 @@ describe("useLocalStorage", () => {
 
   it("warns and keeps state when write throws", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    vi.spyOn(localStorage, "setItem").mockImplementation(() => {
       throw new Error("write-failure");
     });
 
@@ -97,6 +99,23 @@ describe("useLocalStorage", () => {
 
     expect(result.current[0]).toBe(16);
     expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("clears only localStorage and leaves sessionStorage intact", () => {
+    localStorage.setItem("branchforge:isolation", "local");
+    sessionStorage.setItem("branchforge:isolation", "session");
+
+    localStorage.clear();
+
+    expect(localStorage.getItem("branchforge:isolation")).toBeNull();
+    expect(sessionStorage.getItem("branchforge:isolation")).toBe("session");
+  });
+
+  it("isolates values across clear between tests via beforeEach", () => {
+    // beforeEach cleared storage; this write must not see prior-test residue.
+    expect(localStorage.getItem("branchforge:leftover")).toBeNull();
+    localStorage.setItem("branchforge:leftover", "present");
+    expect(localStorage.getItem("branchforge:leftover")).toBe("present");
   });
 
   it("supports boolean convenience hook", () => {

--- a/apps/frontend/src/hooks/__tests__/useWriteAutosave.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useWriteAutosave.test.tsx
@@ -1,5 +1,5 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import type { LabelDetail, PublicLabel } from "@branchforge/shared";
 import { useWriteAutosave, type LabelDialogueDraft } from "../useWriteAutosave";
 
@@ -52,10 +52,6 @@ function createLabel(labelId: string, version: number, contentHash: string) {
 }
 
 describe("useWriteAutosave", () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
   it("tracks version/hash tokens across successful saves", async () => {
     const onUpdateDialogue = vi
       .fn()
@@ -152,6 +148,94 @@ describe("useWriteAutosave", () => {
     );
 
     expect(showErrorToast).not.toHaveBeenCalled();
+  });
+
+  it("saves on Ctrl+S and Meta+S keyboard shortcuts", async () => {
+    const onUpdateDialogue = vi.fn().mockResolvedValue({
+      success: true,
+      version: 4,
+      contentHash: "server-hash-4",
+      fileContentHash: "file-hash-1",
+      fileUpdatedAt: "2024-01-01T00:00:00.000Z",
+    });
+    const showErrorToast = vi.fn();
+    const label = createLabel("label-shortcut-1", 3, "server-hash-3");
+
+    const { rerender, unmount } = renderHook(
+      (props: {
+        draft: LabelDialogueDraft;
+        activeLabel: LabelDetail | undefined;
+      }) =>
+        useWriteAutosave({
+          projectId: "project-1",
+          draft: props.draft,
+          labels: [label],
+          activeLabel: props.activeLabel,
+          isUpdatingDialogue: false,
+          onUpdateDialogue,
+          showErrorToast,
+        }),
+      {
+        initialProps: {
+          draft: {
+            labelId: "label-shortcut-1",
+            entries: [{ id: "line-1", speakerId: null, text: "Original" }],
+          },
+          activeLabel: label,
+        },
+      }
+    );
+
+    rerender({
+      draft: {
+        labelId: "label-shortcut-1",
+        entries: [{ id: "line-1", speakerId: null, text: "Saved with Ctrl+S" }],
+      },
+      activeLabel: label,
+    });
+
+    act(() => {
+      fireEvent.keyDown(window, { ctrlKey: true, code: "KeyS" });
+    });
+
+    await waitFor(() => {
+      expect(onUpdateDialogue).toHaveBeenCalled();
+    });
+    expect(onUpdateDialogue).toHaveBeenCalledWith(
+      "label-shortcut-1",
+      [{ speakerId: null, text: "Saved with Ctrl+S" }],
+      expect.objectContaining({
+        expectedVersion: expect.any(Number),
+      })
+    );
+
+    onUpdateDialogue.mockClear();
+
+    rerender({
+      draft: {
+        labelId: "label-shortcut-1",
+        entries: [{ id: "line-1", speakerId: null, text: "Saved with Meta+S" }],
+      },
+      activeLabel: label,
+    });
+
+    act(() => {
+      fireEvent.keyDown(window, { metaKey: true, code: "KeyS" });
+    });
+
+    await waitFor(() => {
+      expect(onUpdateDialogue).toHaveBeenCalled();
+    });
+    expect(onUpdateDialogue).toHaveBeenCalledWith(
+      "label-shortcut-1",
+      [{ speakerId: null, text: "Saved with Meta+S" }],
+      expect.objectContaining({
+        expectedVersion: expect.any(Number),
+      })
+    );
+
+    expect(showErrorToast).not.toHaveBeenCalled();
+    unmount();
   });
 
   it("marks conflicts and updates expected tokens from conflict response", async () => {

--- a/apps/frontend/src/lib/__tests__/keyboard-shortcuts.unit.test.ts
+++ b/apps/frontend/src/lib/__tests__/keyboard-shortcuts.unit.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  KEYBOARD_SHORTCUTS,
+  detectShortcutPlatform,
+  formatChordAccessible,
+  formatChordVisual,
+  formatShortcutAccessible,
+  getFocusModeActionLabel,
+  getKeyboardShortcut,
+  getShortcutActionDescription,
+} from "@/lib/keyboard-shortcuts";
+
+describe("keyboard-shortcuts registry", () => {
+  describe("detectShortcutPlatform", () => {
+    it("detects mac from Mac user agents", () => {
+      expect(
+        detectShortcutPlatform("Mozilla/5.0 (Macintosh; Intel Mac OS X)")
+      ).toBe("mac");
+      expect(detectShortcutPlatform("iPhone")).toBe("mac");
+      expect(detectShortcutPlatform("iPad")).toBe("mac");
+      expect(detectShortcutPlatform("iPod")).toBe("mac");
+    });
+
+    it("detects windows from non-Apple user agents", () => {
+      expect(
+        detectShortcutPlatform("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")
+      ).toBe("windows");
+      expect(detectShortcutPlatform("Mozilla/5.0 (X11; Linux x86_64)")).toBe(
+        "windows"
+      );
+    });
+
+    it("defaults to windows for an empty user agent", () => {
+      expect(detectShortcutPlatform("")).toBe("windows");
+    });
+  });
+
+  describe("formatChordAccessible", () => {
+    const saveChord = { keys: ["mod", "s"] as const };
+
+    it("uses Command on mac", () => {
+      expect(formatChordAccessible(saveChord, "mac")).toBe("Command+S");
+    });
+
+    it("uses Control on windows", () => {
+      expect(formatChordAccessible(saveChord, "windows")).toBe("Control+S");
+    });
+  });
+
+  describe("formatChordVisual", () => {
+    const saveChord = { keys: ["mod", "s"] as const };
+
+    it("uses ⌘ on mac", () => {
+      expect(formatChordVisual(saveChord, "mac")).toEqual(["⌘", "S"]);
+    });
+
+    it("uses Ctrl on windows", () => {
+      expect(formatChordVisual(saveChord, "windows")).toEqual(["Ctrl", "S"]);
+    });
+  });
+
+  describe("formatShortcutAccessible", () => {
+    it("joins redo alternatives with or", () => {
+      const redo = getKeyboardShortcut("redo");
+      expect(redo).toBeDefined();
+
+      expect(formatShortcutAccessible(redo!, "mac")).toBe(
+        "Command+Y or Command+Shift+Z"
+      );
+      expect(formatShortcutAccessible(redo!, "windows")).toBe(
+        "Control+Y or Control+Shift+Z"
+      );
+    });
+  });
+
+  describe("getFocusModeActionLabel", () => {
+    it("returns enter label when focus mode is off", () => {
+      expect(getFocusModeActionLabel(false)).toBe("Enter focus mode");
+    });
+
+    it("returns exit label when focus mode is on", () => {
+      expect(getFocusModeActionLabel(true)).toBe("Exit focus mode");
+    });
+  });
+
+  describe("getShortcutActionDescription", () => {
+    it("includes the action label and formatted shortcut", () => {
+      expect(getShortcutActionDescription("save", "Save", "mac")).toBe(
+        "Save. Command+S."
+      );
+      expect(getShortcutActionDescription("undo", "Undo", "windows")).toBe(
+        "Undo. Control+Z."
+      );
+    });
+
+    it("returns the action label when the shortcut id is unknown", () => {
+      expect(
+        getShortcutActionDescription("missing", "Custom action", "mac")
+      ).toBe("Custom action");
+    });
+  });
+
+  describe("KEYBOARD_SHORTCUTS", () => {
+    const shortcutIds = KEYBOARD_SHORTCUTS.map((shortcut) => shortcut.id);
+
+    it("includes core general shortcut ids", () => {
+      expect(shortcutIds).toEqual(
+        expect.arrayContaining(["save", "undo", "redo", "focus-mode"])
+      );
+    });
+
+    it("includes write mode shortcut ids", () => {
+      expect(shortcutIds.some((id) => id.startsWith("write-"))).toBe(true);
+    });
+
+    it("includes script mode shortcut ids", () => {
+      expect(shortcutIds.some((id) => id.startsWith("script-"))).toBe(true);
+    });
+  });
+});

--- a/apps/frontend/src/lib/keyboard-shortcuts.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.ts
@@ -1,0 +1,333 @@
+/**
+ * Canonical BranchForge keyboard-shortcut registry.
+ *
+ * Frontend UI (modal, tooltips, hints) must render from this module.
+ * User docs mirror these entries manually — keep IDs/key combos in sync.
+ *
+ * Scope notes:
+ * - BranchForge-owned accelerators are documented as app features.
+ * - Script Mode search commands are CodeMirror editor commands.
+ * - Widget navigation (tabs/listboxes/menus) is accessibility behavior,
+ *   not listed here as global shortcuts.
+ */
+
+export type ShortcutPlatform = "mac" | "windows";
+
+export type ShortcutScope = "global" | "write-editor" | "script-editor";
+
+export type ShortcutGroupId = "general" | "write" | "script";
+
+export type ShortcutSource = "branchforge" | "editor";
+
+/** Semantic key tokens used to derive platform labels and keycaps. */
+export type ShortcutKeyToken =
+  | "mod"
+  | "shift"
+  | "alt"
+  | "enter"
+  | "backspace"
+  | "escape"
+  | "arrowup"
+  | "arrowdown"
+  | "f3"
+  | string;
+
+export interface ShortcutChord {
+  /** Ordered tokens for one chord, e.g. ["mod", "shift", "f"]. */
+  keys: readonly ShortcutKeyToken[];
+}
+
+export interface KeyboardShortcut {
+  id: string;
+  group: ShortcutGroupId;
+  scope: ShortcutScope;
+  source: ShortcutSource;
+  /** Short command name shown in UI. */
+  label: string;
+  /** One-line description for dialog/docs. */
+  description: string;
+  /** Primary and alternative chords that trigger the action. */
+  chords: readonly ShortcutChord[];
+  /**
+   * Action name used for aria-label on icon buttons.
+   * Do not include the shortcut here — attach it via description/tooltip.
+   */
+  actionLabel?: string;
+}
+
+export interface ShortcutGroup {
+  id: ShortcutGroupId;
+  title: string;
+  description?: string;
+  shortcuts: readonly KeyboardShortcut[];
+}
+
+const GENERAL_SHORTCUTS: readonly KeyboardShortcut[] = [
+  {
+    id: "save",
+    group: "general",
+    scope: "global",
+    source: "branchforge",
+    label: "Save",
+    description:
+      "Manually save the current Script Mode file or Write Mode draft.",
+    chords: [{ keys: ["mod", "s"] }],
+    actionLabel: "Save",
+  },
+  {
+    id: "undo",
+    group: "general",
+    scope: "global",
+    source: "branchforge",
+    label: "Undo",
+    description:
+      "Undo the last in-memory editor change. Native undo remains available inside text fields.",
+    chords: [{ keys: ["mod", "z"] }],
+    actionLabel: "Undo",
+  },
+  {
+    id: "redo",
+    group: "general",
+    scope: "global",
+    source: "branchforge",
+    label: "Redo",
+    description:
+      "Redo the last undone in-memory editor change. Native redo remains available inside text fields.",
+    chords: [{ keys: ["mod", "y"] }, { keys: ["mod", "shift", "z"] }],
+    actionLabel: "Redo",
+  },
+  {
+    id: "focus-mode",
+    group: "general",
+    scope: "global",
+    source: "branchforge",
+    label: "Toggle focus mode",
+    description:
+      "Enter or exit distraction-free focus mode in Write Mode or Script Mode.",
+    chords: [{ keys: ["mod", "shift", "f"] }],
+    actionLabel: "Toggle focus mode",
+  },
+];
+
+const WRITE_SHORTCUTS: readonly KeyboardShortcut[] = [
+  {
+    id: "write-add-line",
+    group: "write",
+    scope: "write-editor",
+    source: "branchforge",
+    label: "Add line",
+    description:
+      "Insert a new dialogue line below the focused line. Shift+Enter inserts a newline.",
+    chords: [{ keys: ["enter"] }],
+  },
+  {
+    id: "write-delete-empty-line",
+    group: "write",
+    scope: "write-editor",
+    source: "branchforge",
+    label: "Delete empty line",
+    description:
+      "Delete the focused empty non-choice line when another line exists in the scene.",
+    chords: [{ keys: ["backspace"] }],
+  },
+  {
+    id: "write-move-line-up",
+    group: "write",
+    scope: "write-editor",
+    source: "branchforge",
+    label: "Move line up",
+    description: "Move the focused dialogue line up one position.",
+    chords: [{ keys: ["mod", "arrowup"] }],
+  },
+  {
+    id: "write-move-line-down",
+    group: "write",
+    scope: "write-editor",
+    source: "branchforge",
+    label: "Move line down",
+    description: "Move the focused dialogue line down one position.",
+    chords: [{ keys: ["mod", "arrowdown"] }],
+  },
+];
+
+const SCRIPT_SHORTCUTS: readonly KeyboardShortcut[] = [
+  {
+    id: "script-search",
+    group: "script",
+    scope: "script-editor",
+    source: "editor",
+    label: "Find",
+    description:
+      "Open the Script Mode search panel (CodeMirror editor command).",
+    chords: [{ keys: ["mod", "f"] }],
+  },
+  {
+    id: "script-find-next",
+    group: "script",
+    scope: "script-editor",
+    source: "editor",
+    label: "Find next",
+    description: "Jump to the next search match in Script Mode.",
+    chords: [{ keys: ["f3"] }, { keys: ["mod", "g"] }],
+  },
+  {
+    id: "script-find-previous",
+    group: "script",
+    scope: "script-editor",
+    source: "editor",
+    label: "Find previous",
+    description: "Jump to the previous search match in Script Mode.",
+    chords: [{ keys: ["shift", "f3"] }, { keys: ["mod", "shift", "g"] }],
+  },
+  {
+    id: "script-close-search",
+    group: "script",
+    scope: "script-editor",
+    source: "editor",
+    label: "Close search",
+    description: "Close the Script Mode search panel.",
+    chords: [{ keys: ["escape"] }],
+  },
+];
+
+export const KEYBOARD_SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
+  {
+    id: "general",
+    title: "General",
+    description: "Available across Write Mode and Script Mode.",
+    shortcuts: GENERAL_SHORTCUTS,
+  },
+  {
+    id: "write",
+    title: "Write Mode",
+    description: "Apply while a dialogue line editor is focused.",
+    shortcuts: WRITE_SHORTCUTS,
+  },
+  {
+    id: "script",
+    title: "Script Mode",
+    description: "CodeMirror editor commands inside the script editor.",
+    shortcuts: SCRIPT_SHORTCUTS,
+  },
+];
+
+export const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] =
+  KEYBOARD_SHORTCUT_GROUPS.flatMap((group) => group.shortcuts);
+
+const SHORTCUT_BY_ID: ReadonlyMap<string, KeyboardShortcut> = new Map(
+  KEYBOARD_SHORTCUTS.map((shortcut) => [shortcut.id, shortcut])
+);
+
+export function getKeyboardShortcut(id: string): KeyboardShortcut | undefined {
+  return SHORTCUT_BY_ID.get(id);
+}
+
+export function detectShortcutPlatform(
+  userAgent = typeof navigator !== "undefined" ? navigator.userAgent : ""
+): ShortcutPlatform {
+  return /Mac|iPhone|iPad|iPod/i.test(userAgent) ? "mac" : "windows";
+}
+
+function tokenAccessibleLabel(
+  token: ShortcutKeyToken,
+  platform: ShortcutPlatform
+): string {
+  switch (token) {
+    case "mod":
+      return platform === "mac" ? "Command" : "Control";
+    case "shift":
+      return "Shift";
+    case "alt":
+      return platform === "mac" ? "Option" : "Alt";
+    case "enter":
+      return "Enter";
+    case "backspace":
+      return "Backspace";
+    case "escape":
+      return "Escape";
+    case "arrowup":
+      return "Arrow Up";
+    case "arrowdown":
+      return "Arrow Down";
+    case "f3":
+      return "F3";
+    default:
+      return token.length === 1 ? token.toUpperCase() : token;
+  }
+}
+
+function tokenVisualLabel(
+  token: ShortcutKeyToken,
+  platform: ShortcutPlatform
+): string {
+  switch (token) {
+    case "mod":
+      return platform === "mac" ? "⌘" : "Ctrl";
+    case "shift":
+      return platform === "mac" ? "⇧" : "Shift";
+    case "alt":
+      return platform === "mac" ? "⌥" : "Alt";
+    case "enter":
+      return "Enter";
+    case "backspace":
+      return "Backspace";
+    case "escape":
+      return "Esc";
+    case "arrowup":
+      return "↑";
+    case "arrowdown":
+      return "↓";
+    case "f3":
+      return "F3";
+    default:
+      return token.length === 1 ? token.toUpperCase() : token;
+  }
+}
+
+export function formatChordAccessible(
+  chord: ShortcutChord,
+  platform: ShortcutPlatform = detectShortcutPlatform()
+): string {
+  return chord.keys
+    .map((token) => tokenAccessibleLabel(token, platform))
+    .join("+");
+}
+
+export function formatChordVisual(
+  chord: ShortcutChord,
+  platform: ShortcutPlatform = detectShortcutPlatform()
+): string[] {
+  return chord.keys.map((token) => tokenVisualLabel(token, platform));
+}
+
+export function formatShortcutAccessible(
+  shortcut: KeyboardShortcut,
+  platform: ShortcutPlatform = detectShortcutPlatform()
+): string {
+  return shortcut.chords
+    .map((chord) => formatChordAccessible(chord, platform))
+    .join(" or ");
+}
+
+export function formatShortcutHint(
+  shortcut: KeyboardShortcut,
+  platform: ShortcutPlatform = detectShortcutPlatform()
+): string {
+  return formatShortcutAccessible(shortcut, platform);
+}
+
+export function getShortcutActionDescription(
+  shortcutId: string,
+  actionLabel: string,
+  platform: ShortcutPlatform = detectShortcutPlatform()
+): string {
+  const shortcut = getKeyboardShortcut(shortcutId);
+  if (!shortcut) {
+    return actionLabel;
+  }
+  return `${actionLabel}. ${formatShortcutAccessible(shortcut, platform)}.`;
+}
+
+export function getFocusModeActionLabel(isFocusMode: boolean): string {
+  return isFocusMode ? "Exit focus mode" : "Enter focus mode";
+}

--- a/apps/frontend/src/test/setup.ts
+++ b/apps/frontend/src/test/setup.ts
@@ -2,6 +2,95 @@ import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
+/**
+ * Node 26 exposes an experimental `localStorage` getter on the global object
+ * that returns `undefined` unless `--localstorage-file` is passed. Under
+ * vitest + jsdom that getter also shadows `window.localStorage`, while
+ * `window.sessionStorage` remains a usable jsdom Storage.
+ *
+ * Fix narrowly: if `localStorage` is missing/unusable, install a Map-backed
+ * Storage **only** on `globalThis.localStorage` and `window.localStorage`.
+ * Do **not** mutate `Storage.prototype` — that would also rewrite
+ * `sessionStorage` behavior and break per-storage isolation.
+ *
+ * Tests that need to simulate storage failures should spy the instance
+ * (`vi.spyOn(localStorage, "getItem")`), not `Storage.prototype`.
+ */
+function isUsableStorage(value: unknown): value is Storage {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    typeof (value as Storage).getItem === "function" &&
+    typeof (value as Storage).setItem === "function" &&
+    typeof (value as Storage).removeItem === "function" &&
+    typeof (value as Storage).clear === "function"
+  );
+}
+
+function createMemoryLocalStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.has(String(key)) ? (store.get(String(key)) ?? null) : null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(String(key));
+    },
+    setItem(key: string, value: string) {
+      store.set(String(key), String(value));
+    },
+  } as Storage;
+}
+
+function readStorageCandidate(read: () => unknown): unknown {
+  try {
+    return read();
+  } catch {
+    return undefined;
+  }
+}
+
+function ensureLocalStorage(): void {
+  const existing = readStorageCandidate(() => globalThis.localStorage);
+  if (isUsableStorage(existing)) {
+    return;
+  }
+
+  // Prefer a usable jsdom window.localStorage if one exists independently.
+  const fromWindow =
+    typeof window !== "undefined"
+      ? readStorageCandidate(() => window.localStorage)
+      : undefined;
+  const storage = isUsableStorage(fromWindow)
+    ? fromWindow
+    : createMemoryLocalStorage();
+
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    enumerable: true,
+    value: storage,
+  });
+
+  if (typeof window !== "undefined") {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      enumerable: true,
+      value: storage,
+    });
+  }
+}
+
+ensureLocalStorage();
+
 // Polyfill ResizeObserver for jsdom (used by auto-resize textareas, etc.)
 if (typeof globalThis.ResizeObserver === "undefined") {
   globalThis.ResizeObserver = class ResizeObserver {


### PR DESCRIPTION
## Description

Documents BranchForge keyboard shortcuts with a canonical frontend registry, an accessible in-app help dialog, contextual UI hints for Save/Undo/Redo/Focus Mode, and a VitePress user guide page.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Tests (adding or updating tests)

## Related Issue

Fixes #16

## Changes Made

- Added `apps/frontend/src/lib/keyboard-shortcuts.ts` as the canonical shortcut registry and platform-aware formatters
- Added `KeyboardShortcutsDialog` / list / keycap components and wired them into desktop + mobile sidebar navigation
- Migrated Save, Undo/Redo, and Focus Mode UI hints to the shared registry
- Added VitePress docs page `apps/docs/user/keyboard-shortcuts.md` plus nav/cross-links
- Added focused unit/UI/behavior tests and a Node 26 localStorage test-setup guard
- Added changeset for `@branchforge/frontend`

## Testing

- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [ ] Manually tested the following scenarios:
  - Open Keyboard shortcuts from desktop sidebar and mobile menu
  - Confirm Save / Undo / Redo / Focus Mode hints render platform-aware labels
- [x] Related frontend tests pass locally (`vitest` focused suite: 9 files / 91 tests)
- [x] `pnpm --filter @branchforge/frontend typecheck`
- [x] `pnpm --filter @branchforge/shared typecheck`
- [x] `pnpm --filter @branchforge/docs typecheck`
- [x] `pnpm --filter @branchforge/frontend lint` (0 errors; existing unrelated warnings only)
- [x] `pnpm --filter @branchforge/docs build`

## Checklist

- [x] My code follows the style guidelines of this project (run `pnpm lint` and `pnpm format`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings (run `pnpm typecheck`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm changeset` (if applicable)

## Additional Notes

Scope documents BranchForge-owned shortcuts plus Script Mode search commands already exposed by the editor. Browser/widget accessibility key handling remains out of the shortcut list by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app keyboard shortcuts dialog accessible from desktop and mobile menus.
  * Added contextual shortcut hints and tooltips for saving, undo/redo, and Focus Mode.
  * Added platform-aware shortcut formatting for Windows, macOS, and other systems.
* **Documentation**
  * Added a comprehensive Keyboard Shortcuts user guide covering Write Mode, Script Mode, focus mode, saving, editing, and accessibility navigation.
  * Added the guide to the documentation sidebar and linked related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->